### PR TITLE
[VW-216] use one-time-tokens for webhook responses instead of api keys

### DIFF
--- a/n8n_workflows/AI_Sync_Workflow.json
+++ b/n8n_workflows/AI_Sync_Workflow.json
@@ -12,10 +12,7 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2.1,
-      "position": [
-        0,
-        -416
-      ],
+      "position": [0, -416],
       "webhookId": "1741504f-8151-46a9-9ab9-52eea89e7087",
       "alwaysOutputData": false,
       "credentials": {
@@ -56,10 +53,7 @@
       "name": "Workflow Configuration",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [
-        224,
-        -416
-      ]
+      "position": [224, -416]
     },
     {
       "parameters": {
@@ -75,10 +69,7 @@
       "name": "OpenAI Chat Model",
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
-      "position": [
-        672,
-        -192
-      ],
+      "position": [672, -192],
       "credentials": {
         "openAiApi": {
           "id": "j0mv3A9ieKbr7MtD",
@@ -105,10 +96,7 @@
       "name": "HTTP Request Tool",
       "type": "n8n-nodes-base.httpRequestTool",
       "typeVersion": 4.3,
-      "position": [
-        800,
-        -192
-      ]
+      "position": [800, -192]
     },
     {
       "parameters": {
@@ -124,10 +112,7 @@
       "name": "OpenAI Model for Vulnerability Parser",
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
-      "position": [
-        1008,
-        16
-      ],
+      "position": [1008, 16],
       "credentials": {
         "openAiApi": {
           "id": "j0mv3A9ieKbr7MtD",
@@ -148,10 +133,7 @@
       "name": "API Crawler - AI Agent",
       "type": "@n8n/n8n-nodes-langchain.agent",
       "typeVersion": 3,
-      "position": [
-        736,
-        -416
-      ]
+      "position": [736, -416]
     },
     {
       "parameters": {
@@ -163,10 +145,7 @@
       "name": "JSON Schema Parser",
       "type": "@n8n/n8n-nodes-langchain.outputParserStructured",
       "typeVersion": 1.3,
-      "position": [
-        928,
-        -192
-      ]
+      "position": [928, -192]
     },
     {
       "parameters": {
@@ -187,10 +166,7 @@
       "name": "Prepare Instructions",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [
-        448,
-        -416
-      ]
+      "position": [448, -416]
     },
     {
       "parameters": {
@@ -214,10 +190,7 @@
       "name": "Send Data to VIPER API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.3,
-      "position": [
-        1296,
-        -416
-      ]
+      "position": [1296, -416]
     }
   ],
   "pinData": {},

--- a/n8n_workflows/AI_Sync_Workflow.json
+++ b/n8n_workflows/AI_Sync_Workflow.json
@@ -12,7 +12,10 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2.1,
-      "position": [0, -416],
+      "position": [
+        0,
+        -416
+      ],
       "webhookId": "1741504f-8151-46a9-9ab9-52eea89e7087",
       "alwaysOutputData": false,
       "credentials": {
@@ -53,7 +56,10 @@
       "name": "Workflow Configuration",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [224, -416]
+      "position": [
+        224,
+        -416
+      ]
     },
     {
       "parameters": {
@@ -69,7 +75,10 @@
       "name": "OpenAI Chat Model",
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
-      "position": [672, -192],
+      "position": [
+        672,
+        -192
+      ],
       "credentials": {
         "openAiApi": {
           "id": "j0mv3A9ieKbr7MtD",
@@ -85,8 +94,8 @@
         "headerParameters": {
           "parameters": [
             {
-              "name": "={{  $json.authType === \"Header\" ? $json.authentication.header : \"Authentication\" }}",
-              "value": "={{  $json.authType === \"Header\" ? $json.authentication.value : \"Bearer \" + $json.authentication.token  }}"
+              "name": "={{ $json.body.authType === \"Header\" ? $json.body.authentication.header : \"Authentication\" }}",
+              "value": "={{  $json.body.authType === \"Header\" ? $json.body.authentication.value : \"Bearer \" + $json.body.authentication.token  }}"
             }
           ]
         },
@@ -96,7 +105,10 @@
       "name": "HTTP Request Tool",
       "type": "n8n-nodes-base.httpRequestTool",
       "typeVersion": 4.3,
-      "position": [800, -192]
+      "position": [
+        800,
+        -192
+      ]
     },
     {
       "parameters": {
@@ -112,7 +124,10 @@
       "name": "OpenAI Model for Vulnerability Parser",
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
-      "position": [1008, 16],
+      "position": [
+        1008,
+        16
+      ],
       "credentials": {
         "openAiApi": {
           "id": "j0mv3A9ieKbr7MtD",
@@ -133,7 +148,10 @@
       "name": "API Crawler - AI Agent",
       "type": "@n8n/n8n-nodes-langchain.agent",
       "typeVersion": 3,
-      "position": [728, -416]
+      "position": [
+        736,
+        -416
+      ]
     },
     {
       "parameters": {
@@ -145,7 +163,10 @@
       "name": "JSON Schema Parser",
       "type": "@n8n/n8n-nodes-langchain.outputParserStructured",
       "typeVersion": 1.3,
-      "position": [928, -192]
+      "position": [
+        928,
+        -192
+      ]
     },
     {
       "parameters": {
@@ -166,14 +187,15 @@
       "name": "Prepare Instructions",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [448, -416]
+      "position": [
+        448,
+        -416
+      ]
     },
     {
       "parameters": {
         "method": "POST",
         "url": "={{ $('Workflow Configuration').first().json.apiBaseUrl + $('Workflow Configuration').first().json.responsePath }}",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpBearerAuth",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -192,15 +214,13 @@
       "name": "Send Data to VIPER API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.3,
-      "position": [1296, -416],
-      "credentials": {
-        "httpBearerAuth": {
-          "id": "1M7bJlVV6osJ3KV0",
-          "name": "production viper auth"
-        }
-      }
+      "position": [
+        1296,
+        -416
+      ]
     }
   ],
+  "pinData": {},
   "connections": {
     "Webhook Trigger": {
       "main": [
@@ -291,11 +311,11 @@
       ]
     }
   },
-  "active": false,
+  "active": true,
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "b1c40fa0-12d4-49b8-8878-fff285974aad",
+  "versionId": "6964a24b-ce7b-4d31-b193-dbc3fc5a5cb1",
   "meta": {
     "templateCredsSetupCompleted": true,
     "instanceId": "66207f7815720e24b39297468a019ba2a80d8e3ab7d395f296925a8d0e9081c5"

--- a/prisma/migrations/20260326153511_user_tokens/migration.sql
+++ b/prisma/migrations/20260326153511_user_tokens/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `apiKeyId` on the `integration` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."integration" DROP CONSTRAINT "integration_apiKeyId_fkey";
+
+-- DropIndex
+DROP INDEX "public"."integration_apiKeyId_key";
+
+-- AlterTable
+ALTER TABLE "integration" DROP COLUMN "apiKeyId";
+
+-- CreateTable
+CREATE TABLE "UserToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "permissions" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserToken_tokenHash_key" ON "UserToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "UserToken_userId_idx" ON "UserToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserToken_expiresAt_idx" ON "UserToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "UserToken" ADD CONSTRAINT "UserToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260327193952_user_tokens/migration.sql
+++ b/prisma/migrations/20260327193952_user_tokens/migration.sql
@@ -2,6 +2,7 @@
   Warnings:
 
   - You are about to drop the column `apiKeyId` on the `integration` table. All the data in the column will be lost.
+  - Made the column `integrationUserId` on table `integration` required. This step will fail if there are existing NULL values in that column.
 
 */
 -- DropForeignKey
@@ -11,7 +12,8 @@ ALTER TABLE "public"."integration" DROP CONSTRAINT "integration_apiKeyId_fkey";
 DROP INDEX "public"."integration_apiKeyId_key";
 
 -- AlterTable
-ALTER TABLE "integration" DROP COLUMN "apiKeyId";
+ALTER TABLE "integration" DROP COLUMN "apiKeyId",
+ALTER COLUMN "integrationUserId" SET NOT NULL;
 
 -- CreateTable
 CREATE TABLE "UserToken" (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -598,9 +598,8 @@ model Integration {
   user                   User              @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // the user that this integration creates
-  // TODO: should this be required? leaving it optional for migration
-  integrationUserId      String? @unique
-  integrationUser        User?             @relation(name: "integration_user", fields: [integrationUserId], references: [id], onDelete: Cascade)
+  integrationUserId      String @unique
+  integrationUser        User             @relation(name: "integration_user", fields: [integrationUserId], references: [id], onDelete: Cascade)
 
   assetMappings          ExternalAssetMapping[]
   deviceArtifactMappings ExternalDeviceArtifactMapping[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   integration               Integration[]
   integrationUser          Integration?     @relation("integration_user")
   webhooks                  Webhook[]
+  userTokens UserToken[]
 
   @@unique([email])
   @@map("user")
@@ -88,6 +89,19 @@ model Verification {
 
   @@index([identifier])
   @@map("verification")
+}
+
+model UserToken {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String   @unique
+  permissions String? // what can the token be used for?
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model Workflow {
@@ -556,7 +570,6 @@ model Apikey {
   metadata            String?
 
   connector           ApiKeyConnector?
-  integration         Integration?
 
   @@map("apikey")
 }
@@ -578,8 +591,6 @@ model Integration {
   syncStatus             SyncStatus[]
   lastSuccessfulSync DateTime?
 
-  apiKeyId               String?           @unique
-  apiKey                 Apikey?           @relation(fields: [apiKeyId], references: [id])
   apiKeyConnector        ApiKeyConnector?
 
   // The user who created the integration

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -9,6 +9,7 @@ import {
   syncAllIntegrations,
   syncIntegration,
 } from "@/inngest/functions/sync-integrations";
+import { purgeExpiredTokensFn } from "@/inngest/functions/purge-expired-user-tokens";
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -18,5 +19,6 @@ export const { GET, POST, PUT } = serve({
     enrichVulnerability,
     enrichAllVulnerabilities,
     chatAgent,
+    purgeExpiredTokensFn,
   ],
 });

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -5,11 +5,11 @@ import {
   enrichAllVulnerabilities,
   enrichVulnerability,
 } from "@/inngest/functions/enrich-vulnerabilities";
+import { purgeExpiredTokensFn } from "@/inngest/functions/purge-expired-user-tokens";
 import {
   syncAllIntegrations,
   syncIntegration,
 } from "@/inngest/functions/sync-integrations";
-import { purgeExpiredTokensFn } from "@/inngest/functions/purge-expired-user-tokens";
 
 export const { GET, POST, PUT } = serve({
   client: inngest,

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -7,6 +7,7 @@ import {
   AUTH_TOKEN,
   authHeader,
   BASE_URL,
+  createIntegrationToken,
   generateCPE,
   jsonHeader,
   setupMockIntegration,
@@ -346,13 +347,13 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("empty Assets uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     // this should succeed and nothing should be created
     const noAssets = { ...assetIntegrationPayload, items: [] };
+    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
     const createAssetResp = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${token}`)
       .set(jsonHeader)
       .send(noAssets);
 
@@ -364,7 +365,7 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("create Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
@@ -383,9 +384,9 @@ describe("Assets Endpoint (/assets)", () => {
       });
     });
 
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const integrationRes = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(assetIntegrationPayload);
 
@@ -480,7 +481,7 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("update Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
@@ -500,9 +501,9 @@ describe("Assets Endpoint (/assets)", () => {
     });
 
     // create the assets first
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const createAssetsReq = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(assetIntegrationPayload);
 
@@ -521,9 +522,9 @@ describe("Assets Endpoint (/assets)", () => {
     updateAssetsPayload.items[0].upstreamApi = newUpstreamApi;
     updateAssetsPayload.items[1].upstreamApi = newUpstreamApi;
 
+    const updateToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const integrationRes = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${updateToken}`)
       .set(jsonHeader)
       .send(updateAssetsPayload);
 
@@ -608,7 +609,7 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("mixed create+update Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
@@ -632,9 +633,9 @@ describe("Assets Endpoint (/assets)", () => {
       ...assetIntegrationPayload,
       items: assetIntegrationPayload.items.slice(1),
     };
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const createAssetResp = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(oneAsset);
 
@@ -649,9 +650,9 @@ describe("Assets Endpoint (/assets)", () => {
     const newUpstreamApi = "https://mock-upstream-api.com/v2";
     createWithUpdateAssets.items[0].upstreamApi = newUpstreamApi;
 
+    const updateToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const integrationResp = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${updateToken}`)
       .set(jsonHeader)
       .send(createWithUpdateAssets);
 
@@ -782,9 +783,9 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // then run the endpoint which should update the asset and create the mapping
+    const integrationToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
     const updateAssetResp = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${integrationToken}`)
       .set(jsonHeader)
       .send(updateAssetPayload);
 
@@ -838,7 +839,7 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("all null unique field should miss Asset uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
       // this won't throw errors if it misses, which messes up the onTestFinished stack
@@ -892,9 +893,9 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // this should create a new asset because all unique fields are missing
+    const allNullToken = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
     const integrationRes = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${allNullToken}`)
       .set(jsonHeader)
       .send({
         ...assetIntegrationPayload,
@@ -909,7 +910,7 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("partial null unique field shouldn't miss Asset uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
       // this won't throw errors if it misses, which messes up the onTestFinished stack
@@ -954,9 +955,9 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // this should produce an update based on serialNumber match
+    const partialNullToken = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
     const integrationRes = await request(BASE_URL)
-      .post("/assets/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/assets/integrationUpload/${partialNullToken}`)
       .set(jsonHeader)
       .send({
         ...assetIntegrationPayload,

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -351,7 +351,10 @@ describe("Assets Endpoint (/assets)", () => {
 
     // this should succeed and nothing should be created
     const noAssets = { ...assetIntegrationPayload, items: [] };
-    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
+    const token = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.Asset,
+    );
     const createAssetResp = await request(BASE_URL)
       .post(`/assets/integrationUpload/${token}`)
       .set(jsonHeader)
@@ -365,8 +368,9 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("create Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
     onTestFinished(async () => {
       // this won't throw errors if it misses, which messes up the onTestFinished stack
@@ -384,7 +388,10 @@ describe("Assets Endpoint (/assets)", () => {
       });
     });
 
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
@@ -481,8 +488,9 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("update Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
     onTestFinished(async () => {
       // this won't cause an error if it misses which messes up the onTestFinished stack
@@ -501,7 +509,10 @@ describe("Assets Endpoint (/assets)", () => {
     });
 
     // create the assets first
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const createAssetsReq = await request(BASE_URL)
       .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
@@ -522,7 +533,10 @@ describe("Assets Endpoint (/assets)", () => {
     updateAssetsPayload.items[0].upstreamApi = newUpstreamApi;
     updateAssetsPayload.items[1].upstreamApi = newUpstreamApi;
 
-    const updateToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const updateToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/assets/integrationUpload/${updateToken}`)
       .set(jsonHeader)
@@ -609,8 +623,9 @@ describe("Assets Endpoint (/assets)", () => {
   });
 
   it("mixed create+update Assets uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
     onTestFinished(async () => {
       // this won't throw errors if it misses, which messes up the onTestFinished stack
@@ -633,7 +648,10 @@ describe("Assets Endpoint (/assets)", () => {
       ...assetIntegrationPayload,
       items: assetIntegrationPayload.items.slice(1),
     };
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const createAssetResp = await request(BASE_URL)
       .post(`/assets/integrationUpload/${createToken}`)
       .set(jsonHeader)
@@ -650,7 +668,10 @@ describe("Assets Endpoint (/assets)", () => {
     const newUpstreamApi = "https://mock-upstream-api.com/v2";
     createWithUpdateAssets.items[0].upstreamApi = newUpstreamApi;
 
-    const updateToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const updateToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const integrationResp = await request(BASE_URL)
       .post(`/assets/integrationUpload/${updateToken}`)
       .set(jsonHeader)
@@ -783,7 +804,10 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // then run the endpoint which should update the asset and create the mapping
-    const integrationToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Asset);
+    const integrationToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Asset,
+    );
     const updateAssetResp = await request(BASE_URL)
       .post(`/assets/integrationUpload/${integrationToken}`)
       .set(jsonHeader)
@@ -893,7 +917,10 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // this should create a new asset because all unique fields are missing
-    const allNullToken = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
+    const allNullToken = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.Asset,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/assets/integrationUpload/${allNullToken}`)
       .set(jsonHeader)
@@ -955,7 +982,10 @@ describe("Assets Endpoint (/assets)", () => {
     };
 
     // this should produce an update based on serialNumber match
-    const partialNullToken = await createIntegrationToken(integration.integrationUserId, ResourceType.Asset);
+    const partialNullToken = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.Asset,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/assets/integrationUpload/${partialNullToken}`)
       .set(jsonHeader)

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -524,7 +524,10 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       ...deviceArtifactsIntegrationPayload,
       items: [],
     };
-    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.DeviceArtifact);
+    const token = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.DeviceArtifact,
+    );
     const createRes = await request(BASE_URL)
       .post(`/deviceArtifacts/integrationUpload/${token}`)
       .set(jsonHeader)
@@ -538,8 +541,9 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
   });
 
   it("create DeviceArtifact uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
     onTestFinished(async () => {
       await prisma.deviceArtifact.deleteMany({
@@ -552,7 +556,10 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       });
     });
 
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.DeviceArtifact);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.DeviceArtifact,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/deviceArtifacts/integrationUpload/${createToken}`)
       .set(jsonHeader)

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -14,6 +14,7 @@ import {
   AUTH_TOKEN,
   authHeader,
   BASE_URL,
+  createIntegrationToken,
   generateCPE,
   jsonHeader,
   setupMockIntegration,
@@ -516,16 +517,16 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
   });
 
   it("empty DeviceArtifact uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     // this should succeed and nothing should be created
     const noDeviceArtifacts = {
       ...deviceArtifactsIntegrationPayload,
       items: [],
     };
+    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.DeviceArtifact);
     const createRes = await request(BASE_URL)
-      .post("/deviceArtifacts/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/deviceArtifacts/integrationUpload/${token}`)
       .set(jsonHeader)
       .send(noDeviceArtifacts);
 
@@ -537,7 +538,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
   });
 
   it("create DeviceArtifact uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
@@ -551,9 +552,9 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       });
     });
 
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.DeviceArtifact);
     const integrationRes = await request(BASE_URL)
-      .post("/deviceArtifacts/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/deviceArtifacts/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(deviceArtifactsIntegrationPayload);
 

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -15,6 +15,7 @@ import {
   AUTH_TOKEN,
   authHeader,
   BASE_URL,
+  createIntegrationToken,
   generateCPE,
   jsonHeader,
   setupMockIntegration,
@@ -553,13 +554,13 @@ describe("Remediations Endpoint (/remediations)", () => {
   });
 
   it("empty Remediation uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     // this should succeed and nothing should be created
     const noRemediations = { ...remediationIntegrationPayload, items: [] };
+    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Remediation);
     const createRemResp = await request(BASE_URL)
-      .post("/remediations/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/remediations/integrationUpload/${token}`)
       .set(jsonHeader)
       .send(noRemediations);
 
@@ -571,7 +572,7 @@ describe("Remediations Endpoint (/remediations)", () => {
   });
 
   it("create Remediation uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
     onTestFinished(async () => {
@@ -586,9 +587,9 @@ describe("Remediations Endpoint (/remediations)", () => {
       });
     });
 
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Remediation);
     const integrationRes = await request(BASE_URL)
-      .post("/remediations/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/remediations/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(remediationIntegrationPayload);
 

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -558,7 +558,10 @@ describe("Remediations Endpoint (/remediations)", () => {
 
     // this should succeed and nothing should be created
     const noRemediations = { ...remediationIntegrationPayload, items: [] };
-    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Remediation);
+    const token = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.Remediation,
+    );
     const createRemResp = await request(BASE_URL)
       .post(`/remediations/integrationUpload/${token}`)
       .set(jsonHeader)
@@ -572,8 +575,9 @@ describe("Remediations Endpoint (/remediations)", () => {
   });
 
   it("create Remediation uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
     onTestFinished(async () => {
       // this won't throw errors if it misses, which messes up the onTestFinished stack
@@ -587,7 +591,10 @@ describe("Remediations Endpoint (/remediations)", () => {
       });
     });
 
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Remediation);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Remediation,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/remediations/integrationUpload/${createToken}`)
       .set(jsonHeader)

--- a/src/app/api/v1/__tests__/test-config.ts
+++ b/src/app/api/v1/__tests__/test-config.ts
@@ -1,9 +1,9 @@
 import request from "supertest";
 import { describe, expect, it, onTestFinished } from "vitest";
 import type { IntegrationFormValues } from "@/features/integrations/types";
+import { auth } from "@/lib/auth";
 import prisma from "@/lib/db";
 import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
-import { auth } from "@/lib/auth";
 
 export const BASE_URL = "http://localhost:3000/api/v1";
 export const ROOT_API_URL = "http://localhost:3000/api";
@@ -75,14 +75,14 @@ export const setupMockIntegration = async (
   // this will be used to simulate previous integrationUpload runs
   const apiKey = await auth.api.createApiKey({
     body: {
-        name: 'integration-user-key',
-        userId: createdIntegration.integrationUserId,
+      name: "integration-user-key",
+      userId: createdIntegration.integrationUserId,
     },
   });
 
   return {
     integration: createdIntegration,
-    apiKey
+    apiKey,
   };
 };
 
@@ -90,5 +90,9 @@ export const createIntegrationToken = (
   integrationUserId: string,
   resourceType: string,
 ): Promise<string> => {
-  return createUserToken(integrationUserId, DEFAULT_TOKEN_TTL_SECONDS, resourceType);
+  return createUserToken(
+    integrationUserId,
+    DEFAULT_TOKEN_TTL_SECONDS,
+    resourceType,
+  );
 };

--- a/src/app/api/v1/__tests__/test-config.ts
+++ b/src/app/api/v1/__tests__/test-config.ts
@@ -2,6 +2,8 @@ import request from "supertest";
 import { describe, expect, it, onTestFinished } from "vitest";
 import type { IntegrationFormValues } from "@/features/integrations/types";
 import prisma from "@/lib/db";
+import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
+import { auth } from "@/lib/auth";
 
 export const BASE_URL = "http://localhost:3000/api/v1";
 export const ROOT_API_URL = "http://localhost:3000/api";
@@ -38,11 +40,9 @@ export const setupMockIntegration = async (
     .set(jsonHeader)
     .send(trpcPayload);
 
-  const responseData = createIntegrationRes.body[0]?.result?.data.json;
-  expect(responseData).toHaveProperty("integration");
-  expect(responseData).toHaveProperty("apiKey");
+  const createdIntegration = createIntegrationRes.body[0]?.result?.data.json;
+  expect(createdIntegration).toHaveProperty("id");
 
-  const createdIntegration = responseData.integration;
   onTestFinished(async () => {
     await prisma.integration
       .delete({
@@ -71,5 +71,24 @@ export const setupMockIntegration = async (
   );
   expect(createdIntegration.syncEvery).toBe(mockIntegrationPayload.syncEvery);
 
-  return responseData;
+  // create an api key for the integration user
+  // this will be used to simulate previous integrationUpload runs
+  const apiKey = await auth.api.createApiKey({
+    body: {
+        name: 'integration-user-key',
+        userId: createdIntegration.integrationUserId,
+    },
+  });
+
+  return {
+    integration: createdIntegration,
+    apiKey
+  };
+};
+
+export const createIntegrationToken = (
+  integrationUserId: string,
+  resourceType: string,
+): Promise<string> => {
+  return createUserToken(integrationUserId, DEFAULT_TOKEN_TTL_SECONDS, resourceType);
 };

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -167,7 +167,10 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
 
     // this should succeed and nothing should be created
     const noVulnerabilities = { ...vulnerabilityIntegrationPayload, items: [] };
-    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Vulnerability);
+    const token = await createIntegrationToken(
+      integration.integrationUserId,
+      ResourceType.Vulnerability,
+    );
     const createVulnResp = await request(BASE_URL)
       .post(`/vulnerabilities/integrationUpload/${token}`)
       .set(jsonHeader)
@@ -181,10 +184,14 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
   });
 
   it("create Vulnerabilities uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration } =
-      await setupMockIntegration(mockIntegrationPayload);
+    const { integration: createdIntegration } = await setupMockIntegration(
+      mockIntegrationPayload,
+    );
 
-    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Vulnerability);
+    const createToken = await createIntegrationToken(
+      createdIntegration.integrationUserId,
+      ResourceType.Vulnerability,
+    );
     const integrationRes = await request(BASE_URL)
       .post(`/vulnerabilities/integrationUpload/${createToken}`)
       .set(jsonHeader)

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -6,6 +6,7 @@ import prisma from "@/lib/db";
 import {
   authHeader,
   BASE_URL,
+  createIntegrationToken,
   generateCPE,
   jsonHeader,
   setupMockIntegration,
@@ -162,13 +163,13 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
   });
 
   it("empty Vulnerabilities uploadIntegration endpoint int test", async () => {
-    const { apiKey } = await setupMockIntegration(mockIntegrationPayload);
+    const { integration } = await setupMockIntegration(mockIntegrationPayload);
 
     // this should succeed and nothing should be created
     const noVulnerabilities = { ...vulnerabilityIntegrationPayload, items: [] };
+    const token = await createIntegrationToken(integration.integrationUserId, ResourceType.Vulnerability);
     const createVulnResp = await request(BASE_URL)
-      .post("/vulnerabilities/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/vulnerabilities/integrationUpload/${token}`)
       .set(jsonHeader)
       .send(noVulnerabilities);
 
@@ -180,12 +181,12 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
   });
 
   it("create Vulnerabilities uploadIntegration endpoint int test", async () => {
-    const { integration: createdIntegration, apiKey } =
+    const { integration: createdIntegration } =
       await setupMockIntegration(mockIntegrationPayload);
 
+    const createToken = await createIntegrationToken(createdIntegration.integrationUserId, ResourceType.Vulnerability);
     const integrationRes = await request(BASE_URL)
-      .post("/vulnerabilities/integrationUpload")
-      .set({ Authorization: apiKey.key })
+      .post(`/vulnerabilities/integrationUpload/${createToken}`)
       .set(jsonHeader)
       .send(vulnerabilityIntegrationPayload);
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,3 +11,5 @@ export const headerClass = "text-lg md:text-xl font-semibold";
 export const UNKNOWN_CPE_STRING = "cpe:2.3:-:-:-";
 
 export const MIN_PASSWORD_LENGTH = 8;
+
+export const INTEGRATION_SYNC_EVERY_MIN = 5; //minutes

--- a/src/features/assets/server/routers.ts
+++ b/src/features/assets/server/routers.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { UNKNOWN_CPE_STRING } from "@/config/constants";
-import { IssueStatus, Severity } from "@/generated/prisma";
+import { IssueStatus, ResourceType, Severity } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
   buildPaginationMeta,
@@ -11,9 +11,10 @@ import {
   cpeToDeviceGroup,
   fetchPaginated,
   processIntegrationSync,
+  processIntegrationToken,
 } from "@/lib/router-utils";
 import { integrationResponseSchema } from "@/lib/schemas";
-import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   assetArrayInputSchema,
@@ -457,27 +458,21 @@ export const assetsRouter = createTRPCRouter({
       );
     }),
 
-  processIntegrationCreate: protectedProcedure
+  processIntegrationCreate: baseProcedure 
     .input(integrationAssetInputSchema)
     .meta({
       openapi: {
         method: "POST",
-        path: "/assets/integrationUpload",
+        path: "/assets/integrationUpload/{token}",
         tags: ["Assets"],
         summary: "Synchronize assets with integration",
         description: "Synchronize Assets on VIPER from a partnered platform",
       },
     })
     .output(integrationResponseSchema)
-    .mutation(async ({ ctx, input }) => {
-      const userId = ctx.auth.user.id;
-      const integration = await prisma.integration.findFirst({
-        // @ts-expect-error ctx.auth.key.id is defined if logging in with api key
-        where: { apiKey: { id: ctx.auth.key?.id } },
-        select: { id: true },
-      });
-
-      const integrationId = requireExistence(integration, "Integration").id;
+    .mutation(async ({ input }) => {
+      // Validate provided token or throw error
+      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Asset);
 
       return processIntegrationSync(
         prisma,

--- a/src/features/assets/server/routers.ts
+++ b/src/features/assets/server/routers.ts
@@ -14,7 +14,11 @@ import {
   processIntegrationToken,
 } from "@/lib/router-utils";
 import { integrationResponseSchema } from "@/lib/schemas";
-import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import {
+  baseProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+} from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   assetArrayInputSchema,
@@ -458,7 +462,7 @@ export const assetsRouter = createTRPCRouter({
       );
     }),
 
-  processIntegrationCreate: baseProcedure 
+  processIntegrationCreate: baseProcedure
     .input(integrationAssetInputSchema)
     .meta({
       openapi: {
@@ -472,7 +476,10 @@ export const assetsRouter = createTRPCRouter({
     .output(integrationResponseSchema)
     .mutation(async ({ input }) => {
       // Validate provided token or throw error
-      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Asset);
+      const { userId, integrationId } = await processIntegrationToken(
+        input.token,
+        ResourceType.Asset,
+      );
 
       return processIntegrationSync(
         prisma,

--- a/src/features/device-artifacts/server/routers.ts
+++ b/src/features/device-artifacts/server/routers.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { Prisma } from "@/generated/prisma";
+import { ResourceType, type Prisma } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import {
@@ -7,10 +7,11 @@ import {
   createArtifactWrappers,
   fetchPaginated,
   processIntegrationSync,
+  processIntegrationToken,
   transformArtifactWrapper,
 } from "@/lib/router-utils";
 import { integrationResponseSchema } from "@/lib/schemas";
-import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   deviceArtifactInclude,
@@ -20,6 +21,7 @@ import {
   integrationDeviceArtifactInputSchema,
   paginatedDeviceArtifactResponseSchema,
 } from "../types";
+import { consumeUserToken } from "@/lib/tokens";
 
 // TODO: do something DRY with `createSearchFilter` in other routers
 const createSearchFilter = (search: string) => {
@@ -204,12 +206,12 @@ export const deviceArtifactsRouter = createTRPCRouter({
       return transformArtifactWrapper(result);
     }),
 
-  processIntegrationCreate: protectedProcedure
+  processIntegrationCreate: baseProcedure
     .input(integrationDeviceArtifactInputSchema)
     .meta({
       openapi: {
         method: "POST",
-        path: "/deviceArtifacts/integrationUpload",
+        path: "/deviceArtifacts/integrationUpload/{token}",
         tags: ["DeviceArtifacts"],
         summary: "Synchronize Device Artifact with integration",
         description:
@@ -217,15 +219,9 @@ export const deviceArtifactsRouter = createTRPCRouter({
       },
     })
     .output(integrationResponseSchema)
-    .mutation(async ({ ctx, input }) => {
-      const userId = ctx.auth.user.id;
-      const integration = await prisma.integration.findFirst({
-        // @ts-expect-error ctx.auth.key.id is defined if logging in with api key
-        where: { apiKey: { id: ctx.auth.key?.id } },
-        select: { id: true },
-      });
-
-      const integrationId = requireExistence(integration, "Integration").id;
+    .mutation(async ({ input }) => {
+      // Validate provided token or throw error
+      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.DeviceArtifact); 
 
       return processIntegrationSync(
         prisma,

--- a/src/features/device-artifacts/server/routers.ts
+++ b/src/features/device-artifacts/server/routers.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ResourceType, type Prisma } from "@/generated/prisma";
+import { type Prisma, ResourceType } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import {
@@ -11,7 +11,11 @@ import {
   transformArtifactWrapper,
 } from "@/lib/router-utils";
 import { integrationResponseSchema } from "@/lib/schemas";
-import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import {
+  baseProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+} from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   deviceArtifactInclude,
@@ -21,7 +25,6 @@ import {
   integrationDeviceArtifactInputSchema,
   paginatedDeviceArtifactResponseSchema,
 } from "../types";
-import { consumeUserToken } from "@/lib/tokens";
 
 // TODO: do something DRY with `createSearchFilter` in other routers
 const createSearchFilter = (search: string) => {
@@ -221,7 +224,10 @@ export const deviceArtifactsRouter = createTRPCRouter({
     .output(integrationResponseSchema)
     .mutation(async ({ input }) => {
       // Validate provided token or throw error
-      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.DeviceArtifact); 
+      const { userId, integrationId } = await processIntegrationToken(
+        input.token,
+        ResourceType.DeviceArtifact,
+      );
 
       return processIntegrationSync(
         prisma,

--- a/src/features/integrations/components/columns.tsx
+++ b/src/features/integrations/components/columns.tsx
@@ -6,7 +6,6 @@ import { formatDistanceToNow } from "date-fns";
 import {
   MoreVertical,
   RefreshCw,
-  RotateCwIcon,
   Sparkles,
   SquarePen,
   TrashIcon,
@@ -28,16 +27,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ApiTokenSuccessModal } from "@/features/user/components/user";
-import {
-  type Apikey,
-  type ResourceType,
-  SyncStatusEnum,
-} from "@/generated/prisma";
+import { type ResourceType, SyncStatusEnum } from "@/generated/prisma";
 import type { AuthenticationInputType } from "@/lib/schemas";
 import {
   useRemoveIntegration,
-  useRotateIntegration,
   useTriggerSync,
   useUpdateIntegration,
 } from "../hooks/use-integrations";
@@ -46,11 +39,7 @@ import {
   type IntegrationWithRelations,
   integrationInputSchema,
 } from "../types";
-import {
-  IntegrationCreateModal,
-  RotateIntegrationConfirmModal,
-  SyncStatusIndicator,
-} from "./integrations";
+import { IntegrationCreateModal, SyncStatusIndicator } from "./integrations";
 
 export const getIntegrationColumns = (
   resourceType: ResourceType,
@@ -185,11 +174,7 @@ export const getIntegrationColumns = (
         };
 
         const updateIntegration = useUpdateIntegration();
-        const rotateIntegration = useRotateIntegration();
         const [open, setOpen] = useState(false);
-        const [rotateOpen, setRotateOpen] = useState(false);
-        const [successOpen, setSuccessOpen] = useState(false);
-        const [key, setKey] = useState<Apikey | undefined>(undefined);
 
         const form = useForm<IntegrationFormValues>({
           resolver: zodResolver(integrationInputSchema),
@@ -222,21 +207,6 @@ export const getIntegrationColumns = (
           );
         };
 
-        const handleRotate = () => {
-          rotateIntegration.mutate(
-            { id: data.id },
-            {
-              onSuccess: (data) => {
-                setKey(data.apiKey);
-                setSuccessOpen(true);
-              },
-              onError: () => {
-                setRotateOpen(true);
-              },
-            },
-          );
-        };
-
         return (
           <>
             <DropdownMenu>
@@ -253,9 +223,6 @@ export const getIntegrationColumns = (
                 >
                   <SquarePen />
                   {updateIntegration.isPending ? "Updating..." : "Update"}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setRotateOpen(true)}>
-                  <RotateCwIcon /> Rotate API Key
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -275,20 +242,6 @@ export const getIntegrationColumns = (
                 setOpen={setOpen}
                 handleCreate={handleUpdate}
                 isUpdate={true}
-              />
-            )}
-            {rotateOpen && (
-              <RotateIntegrationConfirmModal
-                open={rotateOpen}
-                setOpen={setRotateOpen}
-                handleRotate={handleRotate}
-              />
-            )}
-            {successOpen && (
-              <ApiTokenSuccessModal
-                open={successOpen}
-                setOpen={setSuccessOpen}
-                apiKey={key}
               />
             )}
           </>

--- a/src/features/integrations/components/integrations-layout.tsx
+++ b/src/features/integrations/components/integrations-layout.tsx
@@ -10,8 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { mainPadding } from "@/config/constants";
 import { SettingsSubheader } from "@/features/settings/components/settings-layout";
-import { ApiTokenSuccessModal } from "@/features/user/components/user";
-import { type Apikey, AuthType } from "@/generated/prisma";
+import { AuthType } from "@/generated/prisma";
 import { cn } from "@/lib/utils";
 import { useCreateIntegration } from "../hooks/use-integrations";
 import {
@@ -33,8 +32,6 @@ export const IntegrationsLayout = ({
 
   const createIntegration = useCreateIntegration();
   const [open, setOpen] = useState(false);
-  const [successOpen, setSuccessOpen] = useState(false);
-  const [key, setKey] = useState<Apikey | undefined>(undefined);
 
   const resourceType = integrationsMapping[activeTab].type;
   const form = useForm<IntegrationFormValues>({
@@ -56,11 +53,9 @@ export const IntegrationsLayout = ({
 
   const handleCreate = (item: IntegrationFormValues) => {
     createIntegration.mutate(item, {
-      onSuccess: (data) => {
+      onSuccess: () => {
         form.reset();
         setOpen(false);
-        setKey(data.apiKey);
-        setSuccessOpen(true);
       },
       onError: () => {
         setOpen(true);
@@ -106,11 +101,6 @@ export const IntegrationsLayout = ({
         open={open}
         setOpen={setOpen}
         handleCreate={handleCreate}
-      />
-      <ApiTokenSuccessModal
-        open={successOpen}
-        setOpen={setSuccessOpen}
-        apiKey={key}
       />
     </>
   );

--- a/src/features/integrations/components/integrations-layout.tsx
+++ b/src/features/integrations/components/integrations-layout.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { mainPadding } from "@/config/constants";
+import { INTEGRATION_SYNC_EVERY_MIN, mainPadding } from "@/config/constants";
 import { SettingsSubheader } from "@/features/settings/components/settings-layout";
 import { AuthType } from "@/generated/prisma";
 import { cn } from "@/lib/utils";
@@ -42,7 +42,7 @@ export const IntegrationsLayout = ({
       integrationUri: "",
       prompt: "",
       isGeneric: false,
-      syncEvery: 300,
+      syncEvery: INTEGRATION_SYNC_EVERY_MIN * 60,
       authType: AuthType.None,
     },
   });

--- a/src/features/integrations/components/integrations.tsx
+++ b/src/features/integrations/components/integrations.tsx
@@ -366,44 +366,6 @@ export const IntegrationCreateModal = ({
   );
 };
 
-interface RotateIntegrationConfirmModalProps {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  handleRotate: () => void;
-}
-
-export function RotateIntegrationConfirmModal({
-  open,
-  setOpen,
-  handleRotate,
-}: RotateIntegrationConfirmModalProps) {
-  const onConfirm = () => {
-    handleRotate();
-    setOpen(false);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Rotate API Key</DialogTitle>
-          <DialogDescription>
-            Are you sure you want to rotate this API key? This will invalidate
-            the current key and generate a new one. Any applications using the
-            old key will need to be updated.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)}>
-            Cancel
-          </Button>
-          <Button onClick={onConfirm}>Rotate Key</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 export const IntegrationsLoading = () => {
   return <LoadingView message="Loading integrations..." />;
 };

--- a/src/features/integrations/components/integrations.tsx
+++ b/src/features/integrations/components/integrations.tsx
@@ -41,6 +41,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Textarea } from "@/components/ui/textarea";
+import { INTEGRATION_SYNC_EVERY_MIN } from "@/config/constants";
 import { getIntegrationColumns } from "@/features/integrations/components/columns";
 import type { ResourceType, SyncStatusEnum } from "@/generated/prisma";
 import { useEntitySearch } from "@/hooks/use-entity-search";
@@ -320,7 +321,9 @@ export const IntegrationCreateModal = ({
                         }}
                       />
                     </FormControl>
-                    <FormDescription>Minimum: 60 seconds</FormDescription>
+                    <FormDescription>
+                      Minimum: {INTEGRATION_SYNC_EVERY_MIN * 60} seconds
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/features/integrations/hooks/use-integrations.ts
+++ b/src/features/integrations/hooks/use-integrations.ts
@@ -34,7 +34,7 @@ export const useCreateIntegration = () => {
         toast.success("Integration created");
         queryClient.invalidateQueries(
           trpc.integrations.getMany.queryOptions({
-            resourceType: data.integration.resourceType,
+            resourceType: data.resourceType,
           }),
         );
         // Need to recount # of active ApiKey Connectors
@@ -101,25 +101,6 @@ export const useRemoveIntegration = () => {
       },
       onError: (error) => {
         toast.error(`Failed to remove Integration: ${error.message}`);
-      },
-    }),
-  );
-};
-
-/**
- * Hook to rotate Integration API Key
- */
-export const useRotateIntegration = () => {
-  const trpc = useTRPC();
-
-  return useMutation(
-    trpc.integrations.rotateKey.mutationOptions({
-      onSuccess: (data) => {
-        toast.success("Integration API key updated");
-        return data;
-      },
-      onError: (error) => {
-        toast.error(`Failed to rotate Integration API key: ${error.message}`);
       },
     }),
   );

--- a/src/features/integrations/server/routers.ts
+++ b/src/features/integrations/server/routers.ts
@@ -3,7 +3,6 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { ResourceType } from "@/generated/prisma";
 import { inngest } from "@/inngest/client";
-import { auth } from "@/lib/auth";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import { fetchPaginated } from "@/lib/router-utils";

--- a/src/features/integrations/server/routers.ts
+++ b/src/features/integrations/server/routers.ts
@@ -37,35 +37,6 @@ const integrationsInclude = {
   },
 } as const;
 
-// Helper function to create an API key for an integration
-async function createIntegrationApiKey(
-  integrationName: string,
-  userId: string,
-) {
-  // better auth api keys fail to get created if name is too long
-  const BETTER_AUTH_MAX_KEY_NAME_LENGTH = 32;
-  const name = `${integrationName} Integration Key`;
-  const apiKey = await auth.api.createApiKey({
-    body: {
-      name:
-        name.length < BETTER_AUTH_MAX_KEY_NAME_LENGTH
-          ? name
-          : "Integration Key",
-      expiresIn: null,
-      userId,
-      // Better auth, for some reason, defaults to an API key that can only be
-      // used 10 times daily and never refills. Here are more sensible values.
-      remaining: 100,
-      refillAmount: 100,
-      refillInterval: 1000,
-      rateLimitTimeWindow: 1000,
-      rateLimitMax: 100,
-      rateLimitEnabled: true,
-    },
-  });
-  return apiKey;
-}
-
 export const integrationsRouter = createTRPCRouter({
   // intentionally fetches all integrations, not just user's
   getMany: protectedProcedure
@@ -91,118 +62,33 @@ export const integrationsRouter = createTRPCRouter({
     .input(integrationInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { name, resourceType } = input;
-      const integrationUser = await prisma.user.create({
-        data: {
-          id: crypto.randomUUID(),
-          name,
-        },
-      });
-
-      const integrationUserId = integrationUser.id;
-      const apiKey = await createIntegrationApiKey(name, integrationUserId);
-
-      const integration = await prisma.integration.create({
-        data: {
-          ...input,
-          userId: ctx.auth.user.id,
-          integrationUserId,
-          apiKeyId: apiKey.id,
-          apiKeyConnector: {
-            create: {
-              name,
-              resourceType,
-              apiKeyId: apiKey.id,
-              userId: ctx.auth.user.id,
-            },
-          },
-        },
-        include: integrationsInclude,
-      });
-
-      return {
-        integration,
-        apiKey,
-      };
-    }),
-
-  // Rotate key mutation. Returns an api key.
-  rotateKey: protectedProcedure
-    .input(z.object({ id: z.string() }))
-    .mutation(async ({ ctx, input }) => {
-      const result = await prisma.$transaction(async (tx) => {
-        // Require ownership of integration to rotate an API key
-        const integration = await tx.integration.findUniqueOrThrow({
-          where: { id: input.id, userId: ctx.auth.user.id },
-          select: {
-            apiKeyId: true,
-            name: true,
-            userId: true,
-            integrationUserId: true,
-            apiKeyConnector: true,
+      const integration = await prisma.$transaction(async (tx) => {
+        const integrationUser = await tx.user.create({
+          data: {
+            id: crypto.randomUUID(),
+            name,
           },
         });
 
-        // an integration should always have an integrationUserId
-        // but for right now it's technically an optional field
-        const integrationUserId = integration.integrationUserId;
-        if (!integrationUserId) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Integration user missing!",
-          });
-        }
+        const integrationUserId = integrationUser.id;
 
-        // Delete the existing API key if it exists
-        // use prisma to do this instead of better-auth since user doesn't own
-        //   the integration apikey, the integration user does
-        if (integration.apiKeyId) {
-          await tx.apikey.delete({
-            where: { id: integration.apiKeyId },
-          });
-        }
-
-        return {
-          integrationName: integration.name,
-          integrationUserId,
-          apiKeyConnectorId: integration.apiKeyConnector?.id,
-          lastRequest: integration.apiKeyConnector?.lastRequest,
-        };
-      });
-
-      const {
-        integrationName,
-        integrationUserId,
-        apiKeyConnectorId,
-        lastRequest,
-      } = result;
-
-      const newApiKey = await createIntegrationApiKey(
-        integrationName,
-        integrationUserId,
-      );
-
-      const newApiKeyId = newApiKey.id;
-
-      await prisma.$transaction(async (tx) => {
-        await tx.integration.update({
-          where: { id: input.id },
-          data: { apiKeyId: newApiKeyId },
-        });
-
-        // integrations should always come with a connector even
-        // if connectors sometimes don't come with integrations
-        if (apiKeyConnectorId) {
-          await tx.apiKeyConnector.update({
-            where: { id: apiKeyConnectorId },
-            data: {
-              apiKeyId: newApiKeyId,
-              lastRequest,
+        return tx.integration.create({
+          data: {
+            ...input,
+            userId: ctx.auth.user.id,
+            integrationUserId,
+            apiKeyConnector: {
+              create: {
+                name,
+                resourceType,
+                userId: ctx.auth.user.id,
+              },
             },
-          });
-        }
+          },
+          include: integrationsInclude,
+        });
       });
-
-      return { apiKey: newApiKey };
+      return integration;
     }),
 
   // any user can intentionally update any integration

--- a/src/features/integrations/types.ts
+++ b/src/features/integrations/types.ts
@@ -1,5 +1,6 @@
 import type { inferOutput } from "@trpc/tanstack-react-query";
 import { z } from "zod";
+import { INTEGRATION_SYNC_EVERY_MIN } from "@/config/constants";
 import { type Integration, ResourceType } from "@/generated/prisma";
 import { authSchema, safeUrlSchema } from "@/lib/schemas";
 import type { trpc } from "@/trpc/server";
@@ -18,7 +19,11 @@ export const integrationInputSchema = authSchema.safeExtend({
   isGeneric: z.boolean(),
   prompt: z.string().optional(),
   resourceType: resourceTypeSchema,
-  syncEvery: z.number().int().positive().min(60),
+  syncEvery: z
+    .number()
+    .int()
+    .positive()
+    .min(INTEGRATION_SYNC_EVERY_MIN * 60),
 });
 export type IntegrationFormValues = z.infer<typeof integrationInputSchema>;
 

--- a/src/features/remediations/server/routers.ts
+++ b/src/features/remediations/server/routers.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { ResourceType, type AlohaStatus, type Prisma } from "@/generated/prisma";
+import {
+  type AlohaStatus,
+  type Prisma,
+  ResourceType,
+} from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import {
@@ -12,7 +16,11 @@ import {
 } from "@/lib/router-utils";
 import { processArtifactHosting } from "@/lib/s3";
 import { alohaInputSchema, integrationResponseSchema } from "@/lib/schemas";
-import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import {
+  baseProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+} from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   integrationRemediationInputSchema,
@@ -194,7 +202,10 @@ export const remediationsRouter = createTRPCRouter({
     .output(integrationResponseSchema)
     .mutation(async ({ input }) => {
       // Validate provided token or throw error
-      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Remediation);
+      const { userId, integrationId } = await processIntegrationToken(
+        input.token,
+        ResourceType.Remediation,
+      );
 
       return processIntegrationSync(
         prisma,

--- a/src/features/remediations/server/routers.ts
+++ b/src/features/remediations/server/routers.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { AlohaStatus, Prisma } from "@/generated/prisma";
+import { ResourceType, type AlohaStatus, type Prisma } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import {
@@ -7,11 +7,12 @@ import {
   createArtifactWrappers,
   fetchPaginated,
   processIntegrationSync,
+  processIntegrationToken,
   transformArtifactWrapper,
 } from "@/lib/router-utils";
 import { processArtifactHosting } from "@/lib/s3";
 import { alohaInputSchema, integrationResponseSchema } from "@/lib/schemas";
-import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   integrationRemediationInputSchema,
@@ -119,7 +120,6 @@ export const remediationsRouter = createTRPCRouter({
         summary: "Create Remediation",
         description: `
           Create a new remediation. The authenticated user will be recorded as the creator. 
-          
           **Artifact hosting**
           See docs/upload_artifact.md
           `.trim(),
@@ -179,12 +179,12 @@ export const remediationsRouter = createTRPCRouter({
       };
     }),
 
-  processIntegrationCreate: protectedProcedure
+  processIntegrationCreate: baseProcedure
     .input(integrationRemediationInputSchema)
     .meta({
       openapi: {
         method: "POST",
-        path: "/remediations/integrationUpload",
+        path: "/remediations/integrationUpload/{token}",
         tags: ["Remediations"],
         summary: "Synchronize Remediations with integration",
         description:
@@ -192,15 +192,9 @@ export const remediationsRouter = createTRPCRouter({
       },
     })
     .output(integrationResponseSchema)
-    .mutation(async ({ ctx, input }) => {
-      const userId = ctx.auth.user.id;
-      const integration = await prisma.integration.findFirst({
-        // @ts-expect-error ctx.auth.key.id is defined if logging in with api key
-        where: { apiKey: { id: ctx.auth.key?.id } },
-        select: { id: true },
-      });
-
-      const integrationId = requireExistence(integration, "Integration").id;
+    .mutation(async ({ input }) => {
+      // Validate provided token or throw error
+      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Remediation);
 
       return processIntegrationSync(
         prisma,

--- a/src/features/vulnerabilities/server/routers.ts
+++ b/src/features/vulnerabilities/server/routers.ts
@@ -246,7 +246,7 @@ export const vulnerabilitiesRouter = createTRPCRouter({
     .meta({
       openapi: {
         method: "POST",
-        path: "/vulnerabilities/integrationUpload/{raw}",
+        path: "/vulnerabilities/integrationUpload/{token}",
         tags: ["Vulnerabilities"],
         summary: "Synchronize Vulnerabilities with integration",
         description:

--- a/src/features/vulnerabilities/server/routers.ts
+++ b/src/features/vulnerabilities/server/routers.ts
@@ -9,7 +9,11 @@ import {
   processIntegrationToken,
 } from "@/lib/router-utils";
 import { alohaInputSchema, integrationResponseSchema } from "@/lib/schemas";
-import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import {
+  baseProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+} from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   integrationVulnerabilityInputSchema,
@@ -241,7 +245,7 @@ export const vulnerabilitiesRouter = createTRPCRouter({
       );
     }),
 
-  processIntegrationCreate: baseProcedure 
+  processIntegrationCreate: baseProcedure
     .input(integrationVulnerabilityInputSchema)
     .meta({
       openapi: {
@@ -256,7 +260,10 @@ export const vulnerabilitiesRouter = createTRPCRouter({
     .output(integrationResponseSchema)
     .mutation(async ({ input }) => {
       // Validate provided token or throw error
-      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Vulnerability);
+      const { userId, integrationId } = await processIntegrationToken(
+        input.token,
+        ResourceType.Vulnerability,
+      );
 
       return processIntegrationSync(
         prisma,

--- a/src/features/vulnerabilities/server/routers.ts
+++ b/src/features/vulnerabilities/server/routers.ts
@@ -1,14 +1,15 @@
 import { z } from "zod";
-import { type AlohaStatus, Priority } from "@/generated/prisma";
+import { type AlohaStatus, Priority, ResourceType } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { paginationInputSchema } from "@/lib/pagination";
 import {
   cpesToDeviceGroups,
   fetchPaginated,
   processIntegrationSync,
+  processIntegrationToken,
 } from "@/lib/router-utils";
 import { alohaInputSchema, integrationResponseSchema } from "@/lib/schemas";
-import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { requireExistence, requireOwnership } from "@/trpc/middleware";
 import {
   integrationVulnerabilityInputSchema,
@@ -240,12 +241,12 @@ export const vulnerabilitiesRouter = createTRPCRouter({
       );
     }),
 
-  processIntegrationCreate: protectedProcedure
+  processIntegrationCreate: baseProcedure 
     .input(integrationVulnerabilityInputSchema)
     .meta({
       openapi: {
         method: "POST",
-        path: "/vulnerabilities/integrationUpload",
+        path: "/vulnerabilities/integrationUpload/{raw}",
         tags: ["Vulnerabilities"],
         summary: "Synchronize Vulnerabilities with integration",
         description:
@@ -253,15 +254,9 @@ export const vulnerabilitiesRouter = createTRPCRouter({
       },
     })
     .output(integrationResponseSchema)
-    .mutation(async ({ ctx, input }) => {
-      const userId = ctx.auth.user.id;
-      const integration = await prisma.integration.findFirst({
-        // @ts-expect-error ctx.auth.key.id is defined if logging in with api key
-        where: { apiKey: { id: ctx.auth.key?.id } },
-        select: { id: true },
-      });
-
-      const integrationId = requireExistence(integration, "Integration").id;
+    .mutation(async ({ input }) => {
+      // Validate provided token or throw error
+      const {userId, integrationId} = await processIntegrationToken(input.token, ResourceType.Vulnerability);
 
       return processIntegrationSync(
         prisma,

--- a/src/inngest/functions/purge-expired-user-tokens.ts
+++ b/src/inngest/functions/purge-expired-user-tokens.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { purgeExpiredTokens } from "@/lib/tokens";
+import { inngest } from "../client";
+
+export const purgeExpiredTokensFn = inngest.createFunction(
+  { id: "purge-expired-tokens" },
+  { cron: "0 */6 * * *" }, // every 6 hours
+  async ({ logger }) => {
+    const deleted = await purgeExpiredTokens();
+    logger.info(`Purged ${deleted} expired token(s)`);
+    return { deleted };
+  },
+);

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -12,6 +12,7 @@ import prisma from "@/lib/db";
 import { getBaseUrl } from "@/lib/url-utils";
 import { parseAuthenticationJson } from "@/lib/utils";
 import { inngest } from "../client";
+import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
 
 export const syncAllIntegrations = inngest.createFunction(
   { id: "sync-all-integrations" },
@@ -55,26 +56,31 @@ export const syncAllIntegrations = inngest.createFunction(
   },
 );
 
-const getResponseConfig = (resourceType: ResourceType) => {
+/* Create a new User Token for an integration webhook response. Return the
+ * unique reponse path and the schema */
+const getResponseConfig = (integrationUserId : string, resourceType: ResourceType) => {
+  // create a user token for the integration user that can only be used for
+  // this resource type
+  const raw = createUserToken(integrationUserId, DEFAULT_TOKEN_TTL_SECONDS, resourceType)
   switch (resourceType) {
     case "Asset":
       return {
-        path: "/assets/integrationUpload",
+        path: `/assets/integrationUpload/${raw}`,
         schema: z.toJSONSchema(integrationAssetInputSchema),
       };
     case "DeviceArtifact":
       return {
-        path: "/deviceArtifacts/integrationUpload",
+        path: `/deviceArtifacts/integrationUpload/${raw}`,
         schema: z.toJSONSchema(integrationDeviceArtifactInputSchema),
       };
     case "Remediation":
       return {
-        path: "/remediations/integrationUpload",
+        path: `/remediations/integrationUpload/${raw}`,
         schema: z.toJSONSchema(integrationRemediationInputSchema),
       };
     case "Vulnerability":
       return {
-        path: "/vulnerabilities/integrationUpload",
+        path: `/vulnerabilities/integrationUpload/${raw}`,
         schema: z.toJSONSchema(integrationVulnerabilityInputSchema),
       };
     default:
@@ -99,27 +105,9 @@ async function syncAiIntegration(
 
   // get where n8n should respond, and what schema it should respond with
   const { schema: responseSchema, path: responsePath } = getResponseConfig(
+    integration.integrationUserId!,
     integration.resourceType,
   );
-
-  // generate an api key for the response
-  // TODO: this probably isn't great auth, use HMAC and a webhook secret later on
-  // put the integration user id in the payload
-  const apiKey = await auth.api.createApiKey({
-    body: {
-      userId: integration.userId,
-      name: "n8n response api key",
-      // we cannot create api keys that are shorter than 24 hrs
-      expiresIn: 60 * 60 * 24,
-      rateLimitEnabled: false,
-    },
-  });
-
-  // update integration with new key
-  await prisma.integration.update({
-    where: { id: integration.id },
-    data: { apiKeyId: apiKey.id },
-  });
 
   const response = await fetch(n8nWebhookUrl, {
     method: "POST",
@@ -131,7 +119,6 @@ async function syncAiIntegration(
     body: JSON.stringify({
       // If you're testing this locally and need webhooks, use NEXT_PUBLIC_APP_URL
       baseApiUrl: `${getBaseUrl()}/api/v1`,
-      responseApiKey: apiKey.key, // TODO: eventually switch to tokens or webhook secrets
       responsePath,
       responseSchema,
       resourceType: integration.resourceType,
@@ -163,7 +150,7 @@ async function syncPartnerIntegration(
     headers[header] = value;
   }
 
-  const { path: responsePath } = getResponseConfig(integration.resourceType);
+  const { path: responsePath } = getResponseConfig(integration.integrationUserId!, integration.resourceType);
 
   const body = JSON.stringify({
     // TODO: blueflow should be able to handle "null". for now though, if there's no date just send one in the past

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -15,7 +15,7 @@ import { inngest } from "../client";
 
 export const syncAllIntegrations = inngest.createFunction(
   { id: "sync-all-integrations" },
-  { cron: "*/1 * * * *" }, // Run every 1 minute
+  { cron: "*/5 * * * *" }, // Run every 5 minutes
   async ({ step }) => {
     // Get all active integrations
     const integrations = await step.run("fetch-integrations", async () => {

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { z } from "zod";
+import { INTEGRATION_SYNC_EVERY_MIN } from "@/config/constants";
 import { integrationAssetInputSchema } from "@/features/assets/types";
 import { integrationDeviceArtifactInputSchema } from "@/features/device-artifacts/types";
 import type { IntegrationWithStringDates } from "@/features/integrations/types";
@@ -7,16 +8,15 @@ import { integrationRemediationInputSchema } from "@/features/remediations/types
 import { integrationVulnerabilityInputSchema } from "@/features/vulnerabilities/types";
 import type { ResourceType } from "@/generated/prisma";
 import { AuthType, SyncStatusEnum } from "@/generated/prisma";
-import { auth } from "@/lib/auth";
 import prisma from "@/lib/db";
+import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
 import { getBaseUrl } from "@/lib/url-utils";
 import { parseAuthenticationJson } from "@/lib/utils";
 import { inngest } from "../client";
-import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
 
 export const syncAllIntegrations = inngest.createFunction(
   { id: "sync-all-integrations" },
-  { cron: "*/5 * * * *" }, // Run every 5 minutes
+  { cron: `*/${INTEGRATION_SYNC_EVERY_MIN} * * * *` }, // Run every 5 minutes
   async ({ step }) => {
     // Get all active integrations
     const integrations = await step.run("fetch-integrations", async () => {
@@ -58,10 +58,17 @@ export const syncAllIntegrations = inngest.createFunction(
 
 /* Create a new User Token for an integration webhook response. Return the
  * unique reponse path and the schema */
-const getResponseConfig = (integrationUserId : string, resourceType: ResourceType) => {
+const getResponseConfig = async (
+  integrationUserId: string,
+  resourceType: ResourceType,
+) => {
   // create a user token for the integration user that can only be used for
   // this resource type
-  const raw = createUserToken(integrationUserId, DEFAULT_TOKEN_TTL_SECONDS, resourceType)
+  const raw = await createUserToken(
+    integrationUserId,
+    DEFAULT_TOKEN_TTL_SECONDS,
+    resourceType,
+  );
   switch (resourceType) {
     case "Asset":
       return {
@@ -104,10 +111,11 @@ async function syncAiIntegration(
   }
 
   // get where n8n should respond, and what schema it should respond with
-  const { schema: responseSchema, path: responsePath } = getResponseConfig(
-    integration.integrationUserId!,
-    integration.resourceType,
-  );
+  const { schema: responseSchema, path: responsePath } =
+    await getResponseConfig(
+      integration.integrationUserId!,
+      integration.resourceType,
+    );
 
   const response = await fetch(n8nWebhookUrl, {
     method: "POST",
@@ -150,7 +158,10 @@ async function syncPartnerIntegration(
     headers[header] = value;
   }
 
-  const { path: responsePath } = getResponseConfig(integration.integrationUserId!, integration.resourceType);
+  const { path: responsePath } = await getResponseConfig(
+    integration.integrationUserId!,
+    integration.resourceType,
+  );
 
   const body = JSON.stringify({
     // TODO: blueflow should be able to handle "null". for now though, if there's no date just send one in the past

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -113,7 +113,7 @@ async function syncAiIntegration(
   // get where n8n should respond, and what schema it should respond with
   const { schema: responseSchema, path: responsePath } =
     await getResponseConfig(
-      integration.integrationUserId!,
+      integration.integrationUserId,
       integration.resourceType,
     );
 
@@ -159,7 +159,7 @@ async function syncPartnerIntegration(
   }
 
   const { path: responsePath } = await getResponseConfig(
-    integration.integrationUserId!,
+    integration.integrationUserId,
     integration.resourceType,
   );
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -77,13 +77,7 @@ export const auth = betterAuth({
     sendOnSignIn: true, // Auto-resend the verification email if the user tries to sign in before verifying their account
     autoSignInAfterVerification: true,
   },
-  plugins: [
-    apiKey({
-      keyExpiration: {
-        minExpiresIn: 0.5,
-      },
-    }),
-  ],
+  plugins: [apiKey()],
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_OAUTH_CLIENT_ID as string,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -77,7 +77,13 @@ export const auth = betterAuth({
     sendOnSignIn: true, // Auto-resend the verification email if the user tries to sign in before verifying their account
     autoSignInAfterVerification: true,
   },
-  plugins: [apiKey()],
+  plugins: [
+    apiKey({
+      keyExpiration: {
+        minExpiresIn: 0.5,
+      },
+    }),
+  ],
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_OAUTH_CLIENT_ID as string,

--- a/src/lib/router-utils.ts
+++ b/src/lib/router-utils.ts
@@ -221,7 +221,7 @@ async function upsertSyncStatus(
     }
 
     // integrations do not have api keys. update when the request was made here
-    await tx.apiKeyConnector.update({
+    await tx.apiKeyConnector.updateMany({
       where: { integrationId },
       data: { lastRequest: lastSynced },
     });

--- a/src/lib/router-utils.ts
+++ b/src/lib/router-utils.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: "any" allows us to reuse prisma client/models accross multiple files
 import "server-only";
-import { type ArtifactType, SyncStatusEnum } from "@/generated/prisma";
+import { type ArtifactType, SyncStatusEnum, ResourceType } from "@/generated/prisma";
 import {
   PrismaClientKnownRequestError,
   PrismaClientValidationError,
@@ -12,6 +12,9 @@ import {
   type PaginationInput,
 } from "./pagination";
 import type { IntegrationResponse } from "./schemas";
+import { consumeUserToken } from "./tokens";
+import { TRPCError } from "@trpc/server";
+import { requireExistence } from "@/trpc/middleware";
 
 // ============================================================================
 // PRISMA TYPES
@@ -175,7 +178,7 @@ async function upsertSyncStatus(
   response: IntegrationResponse,
   lastSynced: Date,
 ): Promise<void> {
-  // sync-integrations.ts shoudl create PENDING sync status
+  // sync-integrations.ts should create PENDING sync status
   // update that if possible
   const latestPending = await prisma.syncStatus.findFirst({
     where: {
@@ -216,6 +219,12 @@ async function upsertSyncStatus(
         data: { lastSuccessfulSync: lastSynced },
       });
     }
+
+    // integrations do not have api keys. update when the request was made here
+    await tx.apiKeyConnector.update({
+      where: { integrationId },
+      data: { lastRequest: lastSynced },
+    });
   });
 }
 
@@ -260,6 +269,27 @@ interface SyncConfig<
 
   // Optional: Additional fields to include in create
   additionalCreateFields?: (userId: string) => Record<string, any>;
+}
+
+/**
+ * Helper: return a userId and the associated integration, or throw an error
+ * if invalid
+ */
+export const processIntegrationToken = async (token: string, expectedPermissions: string) => {
+    const userId = await consumeUserToken(token, expectedPermissions);
+    // TODO: probably need better error messages than this tbh
+    if (!userId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: `Invalid token (couldn't find it, expired, or invalid permissions)`,
+      });
+    }
+    const integration = await prisma.integration.findUnique({
+      where: { integrationUserId: userId },
+      select: { id: true },
+    });
+    const integrationId = requireExistence(integration, "Integration").id;
+    return { userId, integrationId };
 }
 
 /**

--- a/src/lib/router-utils.ts
+++ b/src/lib/router-utils.ts
@@ -1,11 +1,13 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: "any" allows us to reuse prisma client/models accross multiple files
 import "server-only";
-import { type ArtifactType, SyncStatusEnum, ResourceType } from "@/generated/prisma";
+import { TRPCError } from "@trpc/server";
+import { type ArtifactType, SyncStatusEnum } from "@/generated/prisma";
 import {
   PrismaClientKnownRequestError,
   PrismaClientValidationError,
 } from "@/generated/prisma/runtime/library";
 import prisma, { type TransactionClient } from "@/lib/db";
+import { requireExistence } from "@/trpc/middleware";
 import {
   buildPaginationMeta,
   createPaginatedResponse,
@@ -13,8 +15,6 @@ import {
 } from "./pagination";
 import type { IntegrationResponse } from "./schemas";
 import { consumeUserToken } from "./tokens";
-import { TRPCError } from "@trpc/server";
-import { requireExistence } from "@/trpc/middleware";
 
 // ============================================================================
 // PRISMA TYPES
@@ -275,22 +275,25 @@ interface SyncConfig<
  * Helper: return a userId and the associated integration, or throw an error
  * if invalid
  */
-export const processIntegrationToken = async (token: string, expectedPermissions: string) => {
-    const userId = await consumeUserToken(token, expectedPermissions);
-    // TODO: probably need better error messages than this tbh
-    if (!userId) {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: `Invalid token (couldn't find it, expired, or invalid permissions)`,
-      });
-    }
-    const integration = await prisma.integration.findUnique({
-      where: { integrationUserId: userId },
-      select: { id: true },
+export const processIntegrationToken = async (
+  token: string,
+  expectedPermissions: string,
+) => {
+  const userId = await consumeUserToken(token, expectedPermissions);
+  // TODO: probably need better error messages than this tbh
+  if (!userId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `Invalid token (couldn't find it, expired, or invalid permissions)`,
     });
-    const integrationId = requireExistence(integration, "Integration").id;
-    return { userId, integrationId };
-}
+  }
+  const integration = await prisma.integration.findUnique({
+    where: { integrationUserId: userId },
+    select: { id: true },
+  });
+  const integrationId = requireExistence(integration, "Integration").id;
+  return { userId, integrationId };
+};
 
 /**
  * Generic helper function for processing integration syncs

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -107,7 +107,9 @@ export const createIntegrationInputSchema = <T extends z.ZodRawShape>(
   const integrationInputSchema = inputSchema.extend({
     vendorId: z.string(),
   });
-  const pagesWithLinksSchema = createPaginatedResponseWithLinksSchema(integrationInputSchema);
+  const pagesWithLinksSchema = createPaginatedResponseWithLinksSchema(
+    integrationInputSchema,
+  );
   return pagesWithLinksSchema.extend({
     token: z.string(), // the user token calling this endpoint
   });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -107,7 +107,10 @@ export const createIntegrationInputSchema = <T extends z.ZodRawShape>(
   const integrationInputSchema = inputSchema.extend({
     vendorId: z.string(),
   });
-  return createPaginatedResponseWithLinksSchema(integrationInputSchema);
+  const pagesWithLinksSchema = createPaginatedResponseWithLinksSchema(integrationInputSchema);
+  return pagesWithLinksSchema.extend({
+    token: z.string(), // the user token calling this endpoint
+  });
 };
 
 export const alohaInputSchema = z.object({

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,6 +1,6 @@
 import prisma from "@/lib/db";
 
-const DEFAULT_TTL_SECONDS = 15 * 60; // 15 minutes
+export const DEFAULT_TOKEN_TTL_SECONDS = 15 * 60; // 15 minutes
 
 function generateRawToken(): string {
   const bytes = new Uint8Array(32); // 256 bits
@@ -22,7 +22,7 @@ async function hashToken(raw: string): Promise<string> {
  */
 export async function createUserToken(
   userId: string,
-  ttlSeconds = DEFAULT_TTL_SECONDS,
+  ttlSeconds = DEFAULT_TOKEN_TTL_SECONDS,
   permissions?: string,
 ): Promise<string> {
   const raw = generateRawToken();

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,80 @@
+import prisma from "@/lib/db";
+
+const DEFAULT_TTL_SECONDS = 15 * 60; // 15 minutes
+
+function generateRawToken(): string {
+  const bytes = new Uint8Array(32); // 256 bits
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("hex"); // 64-char hex string
+}
+
+async function hashToken(raw: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(raw),
+  );
+  return Buffer.from(buf).toString("hex");
+}
+
+/**
+ * Creates a new one-time token for a user.
+ * Returns the RAW token (shown once, never stored).
+ */
+export async function createUserToken(
+  userId: string,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+  permissions?: string,
+): Promise<string> {
+  const raw = generateRawToken();
+  const tokenHash = await hashToken(raw);
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+  await prisma.userToken.create({
+    data: { userId, tokenHash, permissions, expiresAt },
+  });
+
+  return raw;
+}
+
+/**
+ * Validates and consumes a one-time token.
+ * Returns the userId on success, null on failure/expiry.
+ */
+export async function consumeUserToken(
+  raw: string,
+  expectedPermissions?: string,
+): Promise<string | null> {
+  const tokenHash = await hashToken(raw);
+
+  // Atomic find-and-delete so concurrent requests can't double-consume
+  const record = await prisma.userToken.findUnique({
+    where: { tokenHash },
+  });
+
+  if (!record) return null;
+  if (record.expiresAt < new Date()) {
+    // Opportunistically clean up this expired record
+    await prisma.userToken.delete({ where: { tokenHash } }).catch(() => {});
+    return null;
+  }
+
+  // invalid permissions on token
+  if (expectedPermissions && record.permissions !== expectedPermissions) {
+    return null;
+  }
+
+  // Delete before returning — token is spent
+  await prisma.userToken.delete({ where: { tokenHash } });
+  return record.userId;
+}
+
+/**
+ * Deletes all expired tokens. Called by inngest event
+ * Returns the number of rows removed.
+ */
+export async function purgeExpiredTokens(): Promise<number> {
+  const { count } = await prisma.userToken.deleteMany({
+    where: { expiresAt: { lt: new Date() } },
+  });
+  return count;
+}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -46,7 +46,6 @@ export async function consumeUserToken(
 ): Promise<string | null> {
   const tokenHash = await hashToken(raw);
 
-  // Atomic find-and-delete so concurrent requests can't double-consume
   const record = await prisma.userToken.findUnique({
     where: { tokenHash },
   });

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -13,8 +13,12 @@ export function getBaseUrl(): string {
   // Client-side: use relative URLs
   if (typeof window !== "undefined") return "";
 
-  // Vercel deployment
-  if (process.env.VERCEL_PROJECT_PRODUCTION_URL)
+  // Vercel preview deployment
+  if (process.env.VERCEL_ENV === "preview")
+    return `https://${process.env.VERCEL_URL}`;
+
+  // Vercel production deployment
+  if (process.env.VERCEL_ENV === "production")
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
 
   // Local development or custom deployment


### PR DESCRIPTION
previously a user had to configure an api key for the integrated service on VIPER, and configure a VIPER api key on the integrated service. so for example, a user had to put a Blueflow API key in VIPER and a VIPER API key in Blueflow.

Now, we use one-time-tokens to create unique urls. We pass these to external services, who get authenticated via the unique url, instead of from an API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced token-based authentication for integration uploads, replacing API keys with secure, expiring tokens.
  * Added automatic cleanup of expired authentication tokens.
  * Made integration sync frequency configurable via new constant.

* **Removed Features**
  * Removed API key rotation UI and functionality from integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->