### PR TITLE
[VW-222] Advisories Demo

### DIFF
--- a/prisma/migrations/20260331000000_csaf_advisory/migration.sql
+++ b/prisma/migrations/20260331000000_csaf_advisory/migration.sql
@@ -1,0 +1,106 @@
+-- CreateEnum
+CREATE TYPE "IntegrationType" AS ENUM ('PARTNER', 'AI', 'CSAF');
+
+-- CreateEnum
+CREATE TYPE "Tlp" AS ENUM ('WHITE', 'GREEN', 'AMBER', 'RED', 'CLEAR', 'AMBER_STRICT');
+
+-- Step 1: Add integrationType as nullable to migrate existing data
+ALTER TABLE "integration" ADD COLUMN "integrationType" "IntegrationType";
+
+-- Step 2: Migrate existing rows: isGeneric=true → AI, isGeneric=false → PARTNER
+UPDATE "integration" SET "integrationType" = 'AI'::"IntegrationType" WHERE "isGeneric" = true;
+UPDATE "integration" SET "integrationType" = 'PARTNER'::"IntegrationType" WHERE "isGeneric" = false;
+
+-- Step 3: Make NOT NULL now that all rows are populated
+ALTER TABLE "integration" ALTER COLUMN "integrationType" SET NOT NULL;
+
+-- Step 4: Drop the old column
+ALTER TABLE "integration" DROP COLUMN "isGeneric";
+
+-- CreateTable
+CREATE TABLE "advisory" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "csaf" JSONB NOT NULL DEFAULT '{}',
+    "upstreamUrl" TEXT,
+    "severity" "Severity" NOT NULL,
+    "summary" TEXT,
+    "status" "IssueStatus" NOT NULL DEFAULT 'ACTIVE',
+    "tlp" "Tlp",
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "advisory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "external_advisory_mappings" (
+    "id" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "integrationId" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastSynced" TIMESTAMP(3),
+
+    CONSTRAINT "external_advisory_mappings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable (implicit M2M: advisory <-> vulnerability)
+CREATE TABLE "_AdvisoryVulnerabilities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_AdvisoryVulnerabilities_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateTable (implicit M2M: advisory <-> device_group)
+CREATE TABLE "_AdvisoryDeviceGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_AdvisoryDeviceGroups_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "advisory_upstreamUrl_key" ON "advisory"("upstreamUrl");
+
+-- CreateIndex
+CREATE INDEX "advisory_userId_idx" ON "advisory"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "external_advisory_mappings_itemId_integrationId_key" ON "external_advisory_mappings"("itemId", "integrationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "external_advisory_mappings_integrationId_externalId_key" ON "external_advisory_mappings"("integrationId", "externalId");
+
+-- CreateIndex
+CREATE INDEX "external_advisory_mappings_itemId_idx" ON "external_advisory_mappings"("itemId");
+
+-- CreateIndex
+CREATE INDEX "_AdvisoryVulnerabilities_B_index" ON "_AdvisoryVulnerabilities"("B");
+
+-- CreateIndex
+CREATE INDEX "_AdvisoryDeviceGroups_B_index" ON "_AdvisoryDeviceGroups"("B");
+
+-- AddForeignKey
+ALTER TABLE "advisory" ADD CONSTRAINT "advisory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "external_advisory_mappings" ADD CONSTRAINT "external_advisory_mappings_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "advisory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "external_advisory_mappings" ADD CONSTRAINT "external_advisory_mappings_integrationId_fkey" FOREIGN KEY ("integrationId") REFERENCES "integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AdvisoryVulnerabilities" ADD CONSTRAINT "_AdvisoryVulnerabilities_A_fkey" FOREIGN KEY ("A") REFERENCES "advisory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AdvisoryVulnerabilities" ADD CONSTRAINT "_AdvisoryVulnerabilities_B_fkey" FOREIGN KEY ("B") REFERENCES "vulnerability"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AdvisoryDeviceGroups" ADD CONSTRAINT "_AdvisoryDeviceGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "advisory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AdvisoryDeviceGroups" ADD CONSTRAINT "_AdvisoryDeviceGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "device_group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260331000000_csaf_advisory/migration.sql
+++ b/prisma/migrations/20260331000000_csaf_advisory/migration.sql
@@ -84,6 +84,9 @@ CREATE INDEX "_AdvisoryVulnerabilities_B_index" ON "_AdvisoryVulnerabilities"("B
 -- CreateIndex
 CREATE INDEX "_AdvisoryDeviceGroups_B_index" ON "_AdvisoryDeviceGroups"("B");
 
+-- AddColumn
+ALTER TABLE "advisory" ADD COLUMN "title" TEXT;
+
 -- AddForeignKey
 ALTER TABLE "advisory" ADD CONSTRAINT "advisory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   deviceArtifacts           DeviceArtifact[]
   artifacts                 Artifact[]
   artifactWrappers          ArtifactWrapper[]
+  advisories                Advisory[]
 
   apikeys                   Apikey[]
   apiKeyConnectors          ApiKeyConnector[]
@@ -191,6 +192,7 @@ model DeviceGroup {
   vulnerabilities      Vulnerability[]      @relation("VulnerabilityDeviceGroups")
   remediations         Remediation[]        @relation("RemediationDeviceGroups")
   deviceArtifacts      DeviceArtifact[]
+  advisories           Advisory[]           @relation("AdvisoryDeviceGroups")
 
   @@index([cpe])
   @@map("device_group")
@@ -439,6 +441,7 @@ model Vulnerability {
   sarif                Json
   affectedComponents   String[]        @default([])
   affectedDeviceGroups DeviceGroup[]   @relation("VulnerabilityDeviceGroups")
+  advisories           Advisory[]      @relation("AdvisoryVulnerabilities")
   exploitUri           String?         @map("exploit-uri")
   upstreamApi          String?         @map("upstream-api")
 
@@ -579,10 +582,10 @@ model Integration {
   name                   String
   platform               String?           // The name of the integration platform, e.g "BlueFlow"
   integrationUri         String            @map("integration-uri")
-  isGeneric              Boolean
-  // ^a generic integration uses AI to pull data
-  // if generic is false, the integration will respond to one of our endpoints
-  //  with structured data
+  integrationType        IntegrationType
+  // ^PARTNER: Helm, Blueflow. Follows VIPER standard 
+  // AI: uses AI to pull data from any platform
+  // CSAF: parses CSAF security advisories (Vulnerability resource type only)
   prompt                 String?           @db.Text // optional, additional instructions for AI
   authType               AuthType
   resourceType           ResourceType
@@ -605,6 +608,7 @@ model Integration {
   deviceArtifactMappings ExternalDeviceArtifactMapping[]
   remediationMappings    ExternalRemediationMapping[]
   vulnerabilityMappings  ExternalVulnerabilityMapping[]
+  advisoryMappings       ExternalAdvisoryMapping[]
 
   createdAt              DateTime          @default(now())
   updatedAt              DateTime          @updatedAt
@@ -695,4 +699,59 @@ enum ResourceType {
   Vulnerability
   DeviceArtifact
   Remediation
+}
+
+enum IntegrationType {
+  PARTNER
+  AI
+  CSAF
+}
+
+enum Tlp {
+  // TLP v1
+  WHITE
+  GREEN
+  AMBER
+  RED
+  // TLP v2
+  CLEAR
+  AMBER_STRICT
+}
+
+model Advisory {
+  id                        String          @id @default(cuid())
+  userId                    String
+  user                      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  referencedVulnerabilities Vulnerability[] @relation("AdvisoryVulnerabilities")
+  affectedDeviceGroups      DeviceGroup[]   @relation("AdvisoryDeviceGroups")
+  csaf                      Json            @default("{}")
+  upstreamUrl               String?         @unique
+  severity                  Severity
+  summary                   String?         @db.Text
+  status                    IssueStatus     @default(ACTIVE)
+  tlp                       Tlp?
+  publishedAt               DateTime?
+  createdAt                 DateTime        @default(now())
+  updatedAt                 DateTime        @updatedAt
+  externalMappings          ExternalAdvisoryMapping[]
+
+  @@index([userId])
+  @@map("advisory")
+}
+
+model ExternalAdvisoryMapping {
+  id            String      @id @default(cuid())
+  itemId        String
+  integrationId String
+  externalId    String
+  item          Advisory    @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  lastSynced    DateTime?
+
+  @@unique([itemId, integrationId], name: "external_advisory_mappings_itemId_integrationId_key")
+  @@unique([integrationId, externalId], name: "external_advisory_mappings_integrationId_externalId_key")
+  @@index([itemId])
+  @@map("external_advisory_mappings")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -721,6 +721,7 @@ enum Tlp {
 model Advisory {
   id                        String          @id @default(cuid())
   userId                    String
+  title                     String?
   user                      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   referencedVulnerabilities Vulnerability[] @relation("AdvisoryVulnerabilities")
   affectedDeviceGroups      DeviceGroup[]   @relation("AdvisoryDeviceGroups")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -724,6 +724,9 @@ model Advisory {
   title                     String?
   user                      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   referencedVulnerabilities Vulnerability[] @relation("AdvisoryVulnerabilities")
+  // TODO: In the future, don't reference vulnerabilities directly, but consider using "match objects" that
+  // can reference ranges of vulnerabilities. `affectedDeviceGroups` is also currently unused, but left
+  // here in case we want to use it to cache searches to increase performance later.
   affectedDeviceGroups      DeviceGroup[]   @relation("AdvisoryDeviceGroups")
   csaf                      Json            @default("{}")
   upstreamUrl               String?         @unique

--- a/prisma/seed-icsma-24-319-01.ts
+++ b/prisma/seed-icsma-24-319-01.ts
@@ -1,5 +1,5 @@
-import { hashPassword } from "better-auth/crypto";
 import {
+  type AssetStatus,
   AuthType,
   IntegrationType,
   IssueStatus,
@@ -7,7 +7,6 @@ import {
   ResourceType,
   Severity,
   Tlp,
-  type AssetStatus,
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
 
@@ -37,7 +36,11 @@ async function createOrGetCisaIntegration(seedUserId: string) {
   });
 
   await prisma.integration.create({
-    data: { ...CISA_INTEGRATION, userId: seedUserId, integrationUserId: integrationUser.id },
+    data: {
+      ...CISA_INTEGRATION,
+      userId: seedUserId,
+      integrationUserId: integrationUser.id,
+    },
   });
 
   console.log("✅ Created CISA CSAF integration and integration user");

--- a/prisma/seed-icsma-24-319-01.ts
+++ b/prisma/seed-icsma-24-319-01.ts
@@ -1,0 +1,716 @@
+import { hashPassword } from "better-auth/crypto";
+import {
+  AuthType,
+  IntegrationType,
+  IssueStatus,
+  Priority,
+  ResourceType,
+  Severity,
+  Tlp,
+  type AssetStatus,
+} from "@/generated/prisma";
+import prisma from "@/lib/db";
+
+const CISA_INTEGRATION = {
+  name: "CISA CSAF",
+  platform: "CISA",
+  integrationUri:
+    "https://www.cisa.gov/sites/default/files/csaf/provider-metadata.json",
+  integrationType: IntegrationType.CSAF,
+  authType: AuthType.None,
+  resourceType: ResourceType.Vulnerability,
+  syncEvery: 6 * 60 * 60, // 21600 seconds = 6 hours
+};
+
+async function createOrGetCisaIntegration(seedUserId: string) {
+  const existing = await prisma.integration.findFirst({
+    where: { integrationUri: CISA_INTEGRATION.integrationUri },
+    include: { integrationUser: true },
+  });
+  if (existing?.integrationUser) {
+    console.log("✅ Found existing CISA integration user");
+    return existing.integrationUser;
+  }
+
+  const integrationUser = await prisma.user.create({
+    data: { id: crypto.randomUUID(), name: CISA_INTEGRATION.name },
+  });
+
+  await prisma.integration.create({
+    data: { ...CISA_INTEGRATION, userId: seedUserId, integrationUserId: integrationUser.id },
+  });
+
+  console.log("✅ Created CISA CSAF integration and integration user");
+  return integrationUser;
+}
+
+const SEED_USER = {
+  email: "user@example.com",
+};
+
+const DEVICE_GROUP = {
+  cpe: "cpe:2.3:h:baxter:life2000_ventilation_system:06.08.00.00:*:*:*:*:*:*:*",
+  manufacturer: "Baxter",
+  modelName: "Life2000 Ventilation System",
+  version: "06.08.00.00",
+};
+
+const ASSETS = [
+  {
+    ip: "192.168.30.11",
+    networkSegment: "ICU-VENT",
+    role: "Ventilator",
+    upstreamApi: "https://www.baxter.com/product-security",
+    hostname: "icu-vent-01",
+    macAddress: "00:1A:2B:3C:4D:01",
+    serialNumber: "L2K-2024-00001",
+    location: {
+      facility: "Main Hospital",
+      building: "Tower A",
+      floor: "3",
+      room: "ICU-301",
+    },
+    status: "Active" as AssetStatus,
+  },
+  {
+    ip: "192.168.30.12",
+    networkSegment: "ICU-VENT",
+    role: "Ventilator",
+    upstreamApi: "https://www.baxter.com/product-security",
+    hostname: "icu-vent-02",
+    macAddress: "00:1A:2B:3C:4D:02",
+    serialNumber: "L2K-2024-00002",
+    location: {
+      facility: "Main Hospital",
+      building: "Tower A",
+      floor: "3",
+      room: "ICU-302",
+    },
+    status: "Active" as AssetStatus,
+  },
+  {
+    ip: "192.168.30.13",
+    networkSegment: "ICU-VENT",
+    role: "Ventilator",
+    upstreamApi: "https://www.baxter.com/product-security",
+    hostname: "icu-vent-03",
+    macAddress: "00:1A:2B:3C:4D:03",
+    serialNumber: "L2K-2024-00003",
+    location: {
+      facility: "Main Hospital",
+      building: "Tower A",
+      floor: "3",
+      room: "ICU-303",
+    },
+    status: "Active" as AssetStatus,
+  },
+  {
+    ip: "192.168.30.14",
+    networkSegment: "ICU-VENT",
+    role: "Ventilator",
+    upstreamApi: "https://www.baxter.com/product-security",
+    hostname: "icu-vent-04",
+    macAddress: "00:1A:2B:3C:4D:04",
+    serialNumber: "L2K-2024-00004",
+    location: {
+      facility: "Main Hospital",
+      building: "Tower B",
+      floor: "2",
+      room: "PICU-201",
+    },
+    status: "Active" as AssetStatus,
+  },
+  {
+    ip: "192.168.30.15",
+    networkSegment: "ICU-VENT",
+    role: "Ventilator",
+    upstreamApi: "https://www.baxter.com/product-security",
+    hostname: "icu-vent-05",
+    macAddress: "00:1A:2B:3C:4D:05",
+    serialNumber: "L2K-2024-00005",
+    location: {
+      facility: "Main Hospital",
+      building: "Tower B",
+      floor: "2",
+      room: "PICU-202",
+    },
+    status: "Maintenance" as AssetStatus,
+  },
+];
+
+const VULNERABILITIES = [
+  {
+    cveId: "CVE-2024-9834",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "Improper data protection on the ventilator's serial interface could allow an attacker to send and receive messages that result in unauthorized disclosure of information and/or have unintended impacts on device settings and performance.",
+    narrative:
+      "An attacker with physical access to the serial interface can intercept and inject unencrypted messages, potentially altering ventilator settings or extracting patient data without detection. This is particularly dangerous in ICU environments where ventilators are life-critical devices.",
+    impact:
+      "Unauthorized disclosure of patient respiratory data and potential disruption of ventilator function in life-critical ICU settings.",
+    affectedComponents: ["Serial Interface"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-9834",
+              level: "error",
+              message: {
+                text: "Cleartext transmission of sensitive information via serial interface on Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-9832",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "There is no limit on the number of failed login attempts permitted with the Clinician Password or the Serial Number Clinician Password. An attacker could execute a brute-force attack to gain unauthorized access to the ventilator, and then make changes to device settings that could disrupt the function of the device and/or result in unauthorized information disclosure.",
+    narrative:
+      "Without any lockout mechanism, an attacker can systematically try all possible clinician passwords via the serial interface. Once authenticated, they gain full clinician-level control over the device, able to modify ventilation parameters such as tidal volume, respiratory rate, and PEEP without triggering any alerts.",
+    impact:
+      "Full unauthorized clinician-level access to ventilator controls, enabling arbitrary modification of life-critical ventilation parameters.",
+    affectedComponents: ["Authentication", "Serial Interface"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-9832",
+              level: "error",
+              message: {
+                text: "No brute-force protection on clinician authentication in Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48971",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The Clinician Password and Serial Number Clinician Password are hard-coded into the ventilator in plaintext form. This could allow an attacker to obtain the password off the ventilator and use it to gain unauthorized access to the device, with clinician privileges.",
+    narrative:
+      "Hard-coded credentials in firmware are extractable via JTAG or serial debug access (see related CVEs). Once extracted, the same password applies across all Life2000 units of this firmware version deployed hospital-wide — a single extraction compromises the entire fleet.",
+    impact:
+      "Fleet-wide credential compromise; any attacker who extracts the hard-coded password gains clinician access to all deployed Life2000 units running this firmware version.",
+    affectedComponents: ["Firmware", "Authentication"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48971",
+              level: "error",
+              message: {
+                text: "Hard-coded credentials stored in plaintext firmware on Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48973",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The debug port on the ventilator's serial interface is enabled by default. This could allow an attacker to send and receive messages over the debug port (which are unencrypted) that result in unauthorized disclosure of information and/or have unintended impacts on device settings and performance.",
+    narrative:
+      "The always-on debug port provides an unauthenticated, unencrypted channel into the device. Combined with the cleartext serial interface (CVE-2024-9834), this creates a high-bandwidth attack surface for any person with brief physical access to the device.",
+    impact:
+      "Unauthenticated access to device internals via debug port, enabling information disclosure and device manipulation without leaving audit traces.",
+    affectedComponents: ["Debug Interface", "Serial Interface"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48973",
+              level: "error",
+              message: {
+                text: "Debug port enabled by default on serial interface of Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48974",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The ventilator does not perform proper file integrity checks when adopting firmware updates. This makes it possible for an attacker to force unauthorized changes to the device's configuration settings and/or compromise device functionality by pushing a compromised/illegitimate firmware file.",
+    narrative:
+      "With no cryptographic verification on firmware images, an attacker who gains serial access can push malicious firmware that silently alters ventilation behavior — for example, capping oxygen delivery or disabling alarms — while appearing functional to clinical staff.",
+    impact:
+      "Persistent device compromise via malicious firmware; attacker-controlled ventilation behavior with no detection mechanism for clinical staff.",
+    affectedComponents: ["Firmware Update", "Integrity Check"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48974",
+              level: "error",
+              message: {
+                text: "No firmware integrity check on updates for Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48970",
+    severity: Severity.Critical,
+    cvssScore: 9.3,
+    cvssVector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The ventilator's microcontroller lacks memory protection. An attacker could connect to the internal JTAG interface and read or write to flash memory using an off-the-shelf debugging tool, which could disrupt the function of the device and/or cause unauthorized information disclosure.",
+    narrative:
+      "JTAG access with no memory protection means an attacker with a ~$20 hardware debugger can dump the entire firmware image, extract hard-coded credentials, and modify memory at runtime. This is the root-cause enabler for multiple other CVEs in this advisory.",
+    impact:
+      "Complete firmware extraction and runtime memory manipulation via JTAG; root-cause vulnerability enabling exploitation of CVE-2024-48971 (hard-coded credentials) and CVE-2024-48974 (unsigned firmware).",
+    affectedComponents: [
+      "Microcontroller",
+      "JTAG Interface",
+      "Memory Protection",
+    ],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48970",
+              level: "error",
+              message: {
+                text: "Microcontroller lacks memory protection — JTAG flash read/write on Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2020-8004",
+    severity: Severity.High,
+    cvssScore: 7.5,
+    cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+    description:
+      "The flash memory read-out protection feature on the microcontroller does not block memory access via the ICode bus. Attackers can exploit this in conjunction with certain CPU exception handling behaviors to gain knowledge of how the onboard flash memory is organized and ultimately bypass read-out protection to expose memory contents.",
+    narrative:
+      "This microcontroller-level flaw predates the device's deployment and has been known since 2020. The ICode bus bypass allows reading protected flash regions by triggering specific CPU exception states — no specialized hardware required beyond basic JTAG access already enabled by CVE-2024-48970.",
+    impact:
+      "Bypass of flash read-out protection, exposing full firmware contents including hard-coded credentials and proprietary clinical algorithms.",
+    affectedComponents: [
+      "Microcontroller",
+      "Flash Memory",
+      "Read-out Protection",
+    ],
+    priority: Priority.High,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2020-8004",
+              level: "warning",
+              message: {
+                text: "Flash read-out protection bypass via ICode bus on microcontroller in Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48966",
+    severity: Severity.Critical,
+    cvssScore: 10.0,
+    cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The software tools used by service personnel to test & calibrate the ventilator do not support user authentication. An attacker with access to the Service PC where the tools are installed could obtain diagnostic information through the test tool or manipulate the ventilator's settings and embedded software via the calibration tool, without having to authenticate to either tool.",
+    narrative:
+      "Service PCs in hospital biomedical engineering departments are often shared, lightly secured workstations. An attacker with brief access to such a workstation can use the unauthenticated service tools to fully reconfigure any Life2000 unit the PC has been connected to, with no credential barrier whatsoever.",
+    impact:
+      "Full unauthenticated control over ventilator settings and embedded software via service tooling; anyone with service PC access can silently alter device calibration or compromise device software.",
+    affectedComponents: [
+      "Service Tools",
+      "Calibration Software",
+      "Authentication",
+    ],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48966",
+              level: "error",
+              message: {
+                text: "No authentication on service/calibration tools for Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    cveId: "CVE-2024-48967",
+    severity: Severity.Critical,
+    cvssScore: 10.0,
+    cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    description:
+      "The ventilator and the Service PC lack sufficient audit logging capabilities to allow for detection of malicious activity and subsequent forensic examination. An attacker with access to the ventilator and/or the Service PC could, without detection, make unauthorized changes to ventilator settings that result in unauthorized disclosure of information and/or have unintended impacts on device performance.",
+    narrative:
+      "The absence of audit logging means that any exploitation of the other vulnerabilities in this advisory leaves no forensic trace. Security teams cannot determine if a device has been tampered with, making incident response and post-event investigation impossible without physical device inspection.",
+    impact:
+      "No detection or forensic capability for malicious activity; exploitation of any other CVE in this advisory is completely invisible to security monitoring and incident response teams.",
+    affectedComponents: ["Audit Logging", "Forensics"],
+    priority: Priority.Critical,
+    inKEV: false,
+    sarif: {
+      version: "2.1.0",
+      runs: [
+        {
+          tool: { driver: { name: "CISA ICS-CERT" } },
+          results: [
+            {
+              ruleId: "CVE-2024-48967",
+              level: "error",
+              message: {
+                text: "Insufficient audit logging on ventilator and Service PC for Baxter Life2000 Ventilation System",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+const CSAF_REMEDIATIONS = [
+  {
+    category: "mitigation",
+    details:
+      "Baxter plans to issue a follow-up announcement in Q2 2025 regarding the Life2000 vulnerabilities described in this disclosure.",
+    product_ids: ["CSAFPID-0001"],
+  },
+  {
+    category: "mitigation",
+    details:
+      "Baxter is unaware of any exploitation of these vulnerabilities and/or the compromise of personal or health data.",
+    product_ids: ["CSAFPID-0001"],
+  },
+  {
+    category: "vendor_fix",
+    details:
+      "Baxter recommends that users of the Life2000 Ventilation System not leave their ventilators unattended in public or unsecured areas. Maintaining physical possession and control of the ventilator reduces the likelihood of a malicious actor gaining access to the device.",
+    product_ids: ["CSAFPID-0001"],
+  },
+  {
+    category: "mitigation",
+    details:
+      "For more information, refer to Baxter's Product Security and Responsible Disclosures web page.",
+    product_ids: ["CSAFPID-0001"],
+    url: "https://www.baxter.com/product-security",
+  },
+];
+
+const CSAF_JSON = {
+  document: {
+    acknowledgments: [
+      { names: ["Baxter"], summary: "reporting these vulnerabilities to CISA" },
+    ],
+    category: "csaf_security_advisory",
+    csaf_version: "2.0",
+    distribution: {
+      text: "Disclosure is not limited",
+      tlp: { label: "WHITE", url: "https://us-cert.cisa.gov/tlp/" },
+    },
+    lang: "en-US",
+    notes: [
+      {
+        category: "legal_disclaimer",
+        text: 'All information products included in https://us-cert.cisa.gov/ics are provided "as is" for informational purposes only.',
+        title: "Legal Notice",
+      },
+      {
+        category: "summary",
+        text: "Successful exploitation of these vulnerabilities could lead to information disclosure and/or disruption of the device's function without detection.",
+        title: "Risk evaluation",
+      },
+      {
+        category: "other",
+        text: "Healthcare and Public Health",
+        title: "Critical infrastructure sectors",
+      },
+      {
+        category: "other",
+        text: "United States",
+        title: "Countries/areas deployed",
+      },
+      {
+        category: "other",
+        text: "United States",
+        title: "Company headquarters location",
+      },
+    ],
+    publisher: {
+      category: "coordinator",
+      contact_details: "central@cisa.dhs.gov",
+      name: "CISA",
+      namespace: "https://www.cisa.gov/",
+    },
+    references: [
+      {
+        category: "self",
+        summary: "ICS Advisory ICSMA-24-319-01 JSON",
+        url: "https://raw.githubusercontent.com/cisagov/CSAF/develop/csaf_files/OT/white/2024/icsma-24-319-01.json",
+      },
+      {
+        category: "self",
+        summary: "ICSA Advisory ICSMA-24-319-01 - Web Version",
+        url: "https://www.cisa.gov/news-events/ics-medical-advisories/icsma-24-319-01",
+      },
+    ],
+    title: "Baxter Life2000 Ventilation System",
+    tracking: {
+      current_release_date: "2024-11-14T07:00:00.000000Z",
+      generator: { engine: { name: "CISA CSAF Generator", version: "1.0.0" } },
+      id: "ICSMA-24-319-01",
+      initial_release_date: "2024-11-14T07:00:00.000000Z",
+      revision_history: [
+        {
+          date: "2024-11-14T07:00:00.000000Z",
+          legacy_version: "Initial",
+          number: "1",
+          summary: "Initial Publication",
+        },
+      ],
+      status: "final",
+      version: "1",
+    },
+  },
+  product_tree: {
+    branches: [
+      {
+        branches: [
+          {
+            branches: [
+              {
+                category: "product_version_range",
+                name: "<=06.08.00.00",
+                product: {
+                  name: "Baxter Life2000 Ventilation System: <=06.08.00.00",
+                  product_id: "CSAFPID-0001",
+                },
+              },
+            ],
+            category: "product_name",
+            name: "Life2000 Ventilation System",
+          },
+        ],
+        category: "vendor",
+        name: "Baxter",
+      },
+    ],
+  },
+  vulnerabilities: VULNERABILITIES.map((v) => ({
+    cve: v.cveId,
+    notes: [
+      {
+        category: "summary",
+        text: v.description,
+        title: "Vulnerability Summary",
+      },
+    ],
+    product_status: { known_affected: ["CSAFPID-0001"] },
+    remediations: CSAF_REMEDIATIONS,
+    scores: [
+      {
+        cvss_v3: {
+          baseScore: v.cvssScore,
+          baseSeverity: v.severity === Severity.Critical ? "CRITICAL" : "HIGH",
+          vectorString: v.cvssVector,
+          version: "3.1",
+        },
+        products: ["CSAFPID-0001"],
+      },
+    ],
+  })),
+};
+
+async function createOrGetSeedUser() {
+  console.log("\n👤 Finding/creating seed user...");
+
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { email: SEED_USER.email },
+  });
+  console.log(`✅ Found existing seed user: ${SEED_USER.email}`);
+  return user;
+}
+
+async function seedDeviceGroup() {
+  console.log("\n🌱 Upserting Baxter Life2000 device group...");
+
+  const deviceGroup = await prisma.deviceGroup.upsert({
+    where: { cpe: DEVICE_GROUP.cpe },
+    update: DEVICE_GROUP,
+    create: DEVICE_GROUP,
+  });
+
+  console.log(`✅ Device group: ${deviceGroup.modelName} (${deviceGroup.id})`);
+  return deviceGroup;
+}
+
+async function seedAssets(userId: string, deviceGroupId: string) {
+  console.log("\n🌱 Seeding assets...");
+
+  const assets = await Promise.all(
+    ASSETS.map((asset) =>
+      prisma.asset.create({
+        data: {
+          ...asset,
+          deviceGroupId,
+          userId,
+        },
+      }),
+    ),
+  );
+
+  console.log(`✅ Seeded ${assets.length} assets`);
+  return assets;
+}
+
+async function seedVulnerabilities(userId: string, deviceGroupId: string) {
+  console.log("\n🌱 Seeding vulnerabilities...");
+
+  const vulns = await Promise.all(
+    VULNERABILITIES.map(({ ...data }) =>
+      prisma.vulnerability.create({
+        data: {
+          ...data,
+          userId,
+          affectedDeviceGroups: {
+            connect: { id: deviceGroupId },
+          },
+        },
+      }),
+    ),
+  );
+
+  console.log(`✅ Seeded ${vulns.length} vulnerabilities`);
+  return vulns;
+}
+
+async function seedAdvisory(
+  userId: string,
+  deviceGroupId: string,
+  vulnIds: string[],
+) {
+  console.log("\n🌱 Seeding advisory...");
+
+  const advisory = await prisma.advisory.create({
+    data: {
+      userId,
+      title: "Baxter Life2000 Ventilation System",
+      severity: Severity.Critical,
+      tlp: Tlp.WHITE,
+      upstreamUrl:
+        "https://raw.githubusercontent.com/cisagov/CSAF/develop/csaf_files/OT/white/2024/icsma-24-319-01.json",
+      summary:
+        "Successful exploitation of these vulnerabilities could lead to information disclosure and/or disruption of the device's function without detection.",
+      publishedAt: new Date("2024-11-14T07:00:00.000Z"),
+      status: IssueStatus.ACTIVE,
+      csaf: CSAF_JSON,
+      referencedVulnerabilities: {
+        connect: vulnIds.map((id) => ({ id })),
+      },
+      affectedDeviceGroups: {
+        connect: [{ id: deviceGroupId }],
+      },
+    },
+  });
+
+  console.log(`✅ Advisory created: ${advisory.title} (${advisory.id})`);
+  return advisory;
+}
+
+async function main() {
+  console.log(
+    "🚀 Seeding ICSMA-24-319-01: Baxter Life2000 Ventilation System\n",
+  );
+
+  const user = await createOrGetSeedUser();
+  const integrationUser = await createOrGetCisaIntegration(user.id);
+  const deviceGroup = await seedDeviceGroup();
+  await seedAssets(user.id, deviceGroup.id);
+  const vulns = await seedVulnerabilities(integrationUser.id, deviceGroup.id);
+  await seedAdvisory(
+    integrationUser.id,
+    deviceGroup.id,
+    vulns.map((v) => v.id),
+  );
+
+  console.log("\n✨ Done.");
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/seed-icsma-24-319-01.ts
+++ b/scripts/seed-icsma-24-319-01.ts
@@ -8,7 +8,7 @@ import {
   Severity,
   Tlp,
 } from "@/generated/prisma";
-import prisma from "@/lib/db";
+import prisma from "../src/lib/db";
 
 const CISA_INTEGRATION = {
   name: "CISA CSAF",
@@ -623,15 +623,13 @@ async function seedAssets(userId: string, deviceGroupId: string) {
   console.log("\n🌱 Seeding assets...");
 
   const assets = await Promise.all(
-    ASSETS.map((asset) =>
-      prisma.asset.create({
-        data: {
-          ...asset,
-          deviceGroupId,
-          userId,
-        },
-      }),
-    ),
+    ASSETS.map(async (asset) => {
+      const existing = await prisma.asset.findFirst({
+        where: { serialNumber: asset.serialNumber },
+      });
+      if (existing) return existing;
+      return prisma.asset.create({ data: { ...asset, deviceGroupId, userId } });
+    }),
   );
 
   console.log(`✅ Seeded ${assets.length} assets`);
@@ -642,17 +640,19 @@ async function seedVulnerabilities(userId: string, deviceGroupId: string) {
   console.log("\n🌱 Seeding vulnerabilities...");
 
   const vulns = await Promise.all(
-    VULNERABILITIES.map(({ ...data }) =>
-      prisma.vulnerability.create({
+    VULNERABILITIES.map(async ({ ...data }) => {
+      const existing = await prisma.vulnerability.findFirst({
+        where: { cveId: data.cveId },
+      });
+      if (existing) return existing;
+      return prisma.vulnerability.create({
         data: {
           ...data,
           userId,
-          affectedDeviceGroups: {
-            connect: { id: deviceGroupId },
-          },
+          affectedDeviceGroups: { connect: { id: deviceGroupId } },
         },
-      }),
-    ),
+      });
+    }),
   );
 
   console.log(`✅ Seeded ${vulns.length} vulnerabilities`);
@@ -664,19 +664,30 @@ async function seedAdvisory(
   deviceGroupId: string,
   vulnIds: string[],
 ) {
-  console.log("\n🌱 Seeding advisory...");
+  console.log("\n🌱 Upserting advisory...");
 
   const UPSTREAM_URL =
     "https://raw.githubusercontent.com/cisagov/CSAF/develop/csaf_files/OT/white/2024/icsma-24-319-01.json";
 
-  const existing = await prisma.advisory.findFirst({
+  const advisory = await prisma.advisory.upsert({
     where: { upstreamUrl: UPSTREAM_URL },
-  });
-
-  if (existing) return existing;
-
-  const advisory = await prisma.advisory.create({
-    data: {
+    update: {
+      title: "Baxter Life2000 Ventilation System",
+      severity: Severity.Critical,
+      tlp: Tlp.WHITE,
+      summary:
+        "Successful exploitation of these vulnerabilities could lead to information disclosure and/or disruption of the device's function without detection.",
+      publishedAt: new Date("2024-11-14T07:00:00.000Z"),
+      status: IssueStatus.ACTIVE,
+      csaf: CSAF_JSON,
+      referencedVulnerabilities: {
+        set: vulnIds.map((id) => ({ id })),
+      },
+      affectedDeviceGroups: {
+        set: [{ id: deviceGroupId }],
+      },
+    },
+    create: {
       userId,
       title: "Baxter Life2000 Ventilation System",
       severity: Severity.Critical,
@@ -696,7 +707,7 @@ async function seedAdvisory(
     },
   });
 
-  console.log(`✅ Advisory created: ${advisory.title} (${advisory.id})`);
+  console.log(`✅ Advisory upserted: ${advisory.title} (${advisory.id})`);
   return advisory;
 }
 

--- a/scripts/seed-icsma-24-319-01.ts
+++ b/scripts/seed-icsma-24-319-01.ts
@@ -666,14 +666,22 @@ async function seedAdvisory(
 ) {
   console.log("\n🌱 Seeding advisory...");
 
+  const UPSTREAM_URL =
+    "https://raw.githubusercontent.com/cisagov/CSAF/develop/csaf_files/OT/white/2024/icsma-24-319-01.json";
+
+  const existing = await prisma.advisory.findFirst({
+    where: { upstreamUrl: UPSTREAM_URL },
+  });
+
+  if (existing) return existing;
+
   const advisory = await prisma.advisory.create({
     data: {
       userId,
       title: "Baxter Life2000 Ventilation System",
       severity: Severity.Critical,
       tlp: Tlp.WHITE,
-      upstreamUrl:
-        "https://raw.githubusercontent.com/cisagov/CSAF/develop/csaf_files/OT/white/2024/icsma-24-319-01.json",
+      upstreamUrl: UPSTREAM_URL,
       summary:
         "Successful exploitation of these vulnerabilities could lead to information disclosure and/or disruption of the device's function without detection.",
       publishedAt: new Date("2024-11-14T07:00:00.000Z"),

--- a/src/app/(dashboard)/(rest)/advisories/[advisoryId]/page.tsx
+++ b/src/app/(dashboard)/(rest)/advisories/[advisoryId]/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import {
+  AdvisoryDetailError,
+  AdvisoryDetailLoading,
+  AdvisoryDetailPage,
+} from "@/features/advisories/components/advisories";
+import { prefetchAdvisory } from "@/features/advisories/server/prefetch";
+import { requireAuth } from "@/lib/auth-utils";
+import { HydrateClient } from "@/trpc/server";
+
+interface PageProps {
+  params: Promise<{
+    advisoryId: string;
+  }>;
+}
+
+const Page = async ({ params }: PageProps) => {
+  await requireAuth();
+
+  const { advisoryId } = await params;
+
+  prefetchAdvisory(advisoryId);
+
+  return (
+    <HydrateClient>
+      <ErrorBoundary fallback={<AdvisoryDetailError />}>
+        <Suspense fallback={<AdvisoryDetailLoading />}>
+          <AdvisoryDetailPage id={advisoryId} />
+        </Suspense>
+      </ErrorBoundary>
+    </HydrateClient>
+  );
+};
+
+export default Page;

--- a/src/app/(dashboard)/(rest)/advisories/[advisoryId]/page.tsx
+++ b/src/app/(dashboard)/(rest)/advisories/[advisoryId]/page.tsx
@@ -20,7 +20,7 @@ const Page = async ({ params }: PageProps) => {
 
   const { advisoryId } = await params;
 
-  prefetchAdvisory(advisoryId);
+  await prefetchAdvisory(advisoryId);
 
   return (
     <HydrateClient>

--- a/src/app/(dashboard)/(rest)/advisories/page.tsx
+++ b/src/app/(dashboard)/(rest)/advisories/page.tsx
@@ -1,0 +1,18 @@
+import {
+  AdvisoriesContainer,
+  AdvisoriesError,
+  AdvisoriesList,
+  AdvisoriesLoading,
+} from "@/features/advisories/components/advisories";
+import { advisoriesParamsLoader } from "@/features/advisories/server/params-loader";
+import { prefetchAdvisories } from "@/features/advisories/server/prefetch";
+import { createListPage } from "@/lib/page-factory";
+
+export default createListPage({
+  paramsLoader: advisoriesParamsLoader,
+  prefetch: prefetchAdvisories,
+  Container: AdvisoriesContainer,
+  List: AdvisoriesList,
+  Loading: AdvisoriesLoading,
+  Error: AdvisoriesError,
+});

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -32,7 +32,7 @@ describe("Assets Endpoint (/assets)", () => {
     name: "mockIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-upstream-api.com/",
-    isGeneric: false,
+    integrationType: "PARTNER",
     authType: AuthType.Bearer,
     resourceType: ResourceType.Asset,
     authentication: {

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -32,7 +32,7 @@ describe("Assets Endpoint (/assets)", () => {
     name: "mockIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-upstream-api.com/",
-    integrationType: "PARTNER",
+    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
     resourceType: ResourceType.Asset,
     authentication: {

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -40,7 +40,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     name: "mockDeviceArtifactIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-deviceArtifact-upstream-api.com/",
-    isGeneric: false,
+    integrationType: "PARTNER",
     authType: AuthType.Bearer,
     resourceType: ResourceType.DeviceArtifact,
     authentication: {

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -40,7 +40,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     name: "mockDeviceArtifactIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-deviceArtifact-upstream-api.com/",
-    integrationType: "PARTNER",
+    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
     resourceType: ResourceType.DeviceArtifact,
     authentication: {

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -51,7 +51,7 @@ describe("Remediations Endpoint (/remediations)", () => {
     name: "mockVulnIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    integrationType: "PARTNER",
+    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
     resourceType: ResourceType.Remediation,
     authentication: {

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -51,7 +51,7 @@ describe("Remediations Endpoint (/remediations)", () => {
     name: "mockVulnIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    isGeneric: false,
+    integrationType: "PARTNER",
     authType: AuthType.Bearer,
     resourceType: ResourceType.Remediation,
     authentication: {

--- a/src/app/api/v1/__tests__/test-config.ts
+++ b/src/app/api/v1/__tests__/test-config.ts
@@ -65,7 +65,9 @@ export const setupMockIntegration = async (
   expect(createdIntegration.integrationUri).toBe(
     mockIntegrationPayload.integrationUri,
   );
-  expect(createdIntegration.isGeneric).toBe(mockIntegrationPayload.isGeneric);
+  expect(createdIntegration.integrationType).toBe(
+    mockIntegrationPayload.integrationType,
+  );
   expect(createdIntegration.resourceType).toBe(
     mockIntegrationPayload.resourceType,
   );

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -34,7 +34,7 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
     name: "mockVulnIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    integrationType: "PARTNER",
+    integrationType: "PARTNER" as const,
     resourceType: ResourceType.Vulnerability,
     syncEvery: 300,
     authType: AuthType.None,

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -34,7 +34,7 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
     name: "mockVulnIntegration",
     platform: "mockIntegrationPlatform",
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    isGeneric: false,
+    integrationType: "PARTNER",
     resourceType: ResourceType.Vulnerability,
     syncEvery: 300,
     authType: AuthType.None,

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
   PlugIcon,
   SettingsIcon,
+  ShieldAlertIcon,
   ShieldCheckIcon,
   WorkflowIcon,
 } from "lucide-react";
@@ -66,6 +67,11 @@ const mainItems = [
     title: "Vulnerability Dashboard",
     icon: BugIcon,
     url: "/vulnerabilities",
+  },
+  {
+    title: "Advisories",
+    icon: ShieldAlertIcon,
+    url: "/advisories",
   },
   {
     title: "Recommendations",

--- a/src/components/dashboard-drawers.tsx
+++ b/src/components/dashboard-drawers.tsx
@@ -43,8 +43,6 @@ export interface InfoColumnSection {
   header: string;
   items: Array<{
     header: string;
-    /** Optional ReactNode (e.g. QuestionTooltip) shown inline after the item label */
-    tooltip?: ReactNode;
     content: ReactNode;
   }>;
 }
@@ -172,11 +170,10 @@ export function InfoColumn({
                 {section.header}
               </h3>
               <div className="grid grid-cols-1 gap-3">
-                {section.items.map(({ header, tooltip, content }) => (
+                {section.items.map(({ header, content }) => (
                   <div key={header}>
-                    <div className="flex items-center gap-1 text-xs font-medium text-muted-foreground mb-1">
+                    <div className="text-xs font-medium text-muted-foreground mb-1">
                       {header}
-                      {tooltip}
                     </div>
                     {content}
                   </div>

--- a/src/components/dashboard-drawers.tsx
+++ b/src/components/dashboard-drawers.tsx
@@ -23,6 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // Types
@@ -40,7 +41,12 @@ export interface DrawerTab {
 
 export interface InfoColumnSection {
   header: string;
-  items: Array<{ header: string; content: ReactNode }>;
+  items: Array<{
+    header: string;
+    /** Optional ReactNode (e.g. QuestionTooltip) shown inline after the item label */
+    tooltip?: ReactNode;
+    content: ReactNode;
+  }>;
 }
 
 interface DashboardDrawerShellProps {
@@ -148,9 +154,15 @@ export function DashboardDrawerShell({
 // InfoColumn
 // ============================================================================
 
-export function InfoColumn({ sections }: { sections: InfoColumnSection[] }) {
+export function InfoColumn({
+  sections,
+  className,
+}: {
+  sections: InfoColumnSection[];
+  className?: string;
+}) {
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea className={cn("h-full", className)}>
       <div className="flex flex-col gap-6 p-4 text-sm">
         {sections.map((section, i) => (
           <Fragment key={`${i}-${section.header}`}>
@@ -160,10 +172,11 @@ export function InfoColumn({ sections }: { sections: InfoColumnSection[] }) {
                 {section.header}
               </h3>
               <div className="grid grid-cols-1 gap-3">
-                {section.items.map(({ header, content }) => (
+                {section.items.map(({ header, tooltip, content }) => (
                   <div key={header}>
-                    <div className="text-xs font-medium text-muted-foreground mb-1">
+                    <div className="flex items-center gap-1 text-xs font-medium text-muted-foreground mb-1">
                       {header}
+                      {tooltip}
                     </div>
                     {content}
                   </div>

--- a/src/components/entity-components.tsx
+++ b/src/components/entity-components.tsx
@@ -3,7 +3,6 @@
 import {
   AlertTriangleIcon,
   Loader2Icon,
-  MoreVerticalIcon,
   PackageOpenIcon,
   PlusIcon,
   SearchIcon,
@@ -23,12 +22,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardDescription, CardTitle } from "./ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "./ui/dropdown-menu";
 import {
   Empty,
   EmptyContent,
@@ -324,27 +318,17 @@ export const EntityItem = ({
           <div className="flex gap-x-4 items-center">
             {actions}
             {onRemove && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="sr-only">Open menu</span>
-                    <MoreVerticalIcon className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={handleRemove}
-                    disabled={isRemoving}
-                  >
-                    <TrashIcon className="mr-2 size-4" />
-                    {isRemoving ? "Removing..." : "Remove"}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <MoreVerticalDropdownMenu
+                items={[
+                  {
+                    label: isRemoving ? "Removing..." : "Remove",
+                    icon: <TrashIcon className="mr-2 size-4" />,
+                    onClick: handleRemove,
+                    disabled: isRemoving,
+                    variant: "destructive",
+                  },
+                ]}
+              />
             )}
           </div>
         )}

--- a/src/components/severity-badge.tsx
+++ b/src/components/severity-badge.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { Severity } from "@/generated/prisma";
+
+export const severityConfig: Record<
+  Severity,
+  { label: string; short: string; badgeClassName: string }
+> = {
+  Critical: {
+    label: "Critical",
+    short: "C",
+    badgeClassName: "bg-red-600 hover:bg-red-600 text-white",
+  },
+  High: {
+    label: "High",
+    short: "H",
+    badgeClassName: "bg-orange-500 hover:bg-orange-500 text-white",
+  },
+  Medium: {
+    label: "Medium",
+    short: "M",
+    badgeClassName: "bg-yellow-500 hover:bg-yellow-500 text-black",
+  },
+  Low: {
+    label: "Low",
+    short: "L",
+    badgeClassName: "bg-blue-500 hover:bg-blue-500 text-white",
+  },
+};
+
+export const SeverityBadge = ({ severity }: { severity: Severity }) => {
+  const config = severityConfig[severity];
+  return <Badge className={config.badgeClassName}>{config.label}</Badge>;
+};

--- a/src/components/status-form.tsx
+++ b/src/components/status-form.tsx
@@ -86,9 +86,9 @@ export const StatusFormBase = ({
           .filter((s) => s !== status)
           .map((s) => (
             <DropdownMenuItem
+              onSelect={() => setStatus(s)}
               onClick={(e) => {
                 e.stopPropagation();
-                setStatus(s);
               }}
               key={s}
             >

--- a/src/components/status-form.tsx
+++ b/src/components/status-form.tsx
@@ -38,6 +38,12 @@ export const StatusFormBase = ({
 }) => {
   const [status, setStatus] = useState<IssueStatus>(initialStatus);
   const lastSubmittedStatusRef = useRef<IssueStatus>(initialStatus);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    setStatus(initialStatus);
+    lastSubmittedStatusRef.current = initialStatus;
+  }, [initialStatus]);
 
   useEffect(() => {
     // Don't submit if status hasn't changed or if we already submitted this status
@@ -45,11 +51,15 @@ export const StatusFormBase = ({
       return;
     }
 
+    const requestId = ++requestIdRef.current;
     const updateStatus = async () => {
       lastSubmittedStatusRef.current = status;
       try {
         await onUpdate({ id, status });
       } catch {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
         setStatus(initialStatus);
         lastSubmittedStatusRef.current = initialStatus;
       }

--- a/src/components/status-form.tsx
+++ b/src/components/status-form.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { IssueStatus } from "@/generated/prisma";
+
+export const statusDetails = {
+  [IssueStatus.FALSE_POSITIVE]: {
+    name: "False Positive",
+    color: "bg-yellow-500",
+  },
+  [IssueStatus.ACTIVE]: { name: "Active", color: "bg-red-500" },
+  [IssueStatus.REMEDIATED]: { name: "Remediated", color: "bg-green-500" },
+};
+
+export const IssueStatusBadge = ({ status }: { status: IssueStatus }) => {
+  const statusDetail = statusDetails[status];
+  return <Badge className={statusDetail.color}>{statusDetail.name}</Badge>;
+};
+
+export const StatusFormBase = ({
+  id,
+  initialStatus,
+  onUpdate,
+  className,
+}: {
+  id: string;
+  initialStatus: IssueStatus;
+  onUpdate: (input: { id: string; status: IssueStatus }) => Promise<unknown>;
+  className?: string;
+}) => {
+  const [status, setStatus] = useState<IssueStatus>(initialStatus);
+  const lastSubmittedStatusRef = useRef<IssueStatus>(initialStatus);
+
+  useEffect(() => {
+    // Don't submit if status hasn't changed or if we already submitted this status
+    if (status === initialStatus || status === lastSubmittedStatusRef.current) {
+      return;
+    }
+
+    const updateStatus = async () => {
+      lastSubmittedStatusRef.current = status;
+      try {
+        await onUpdate({ id, status });
+      } catch {
+        setStatus(initialStatus);
+        lastSubmittedStatusRef.current = initialStatus;
+      }
+    };
+
+    updateStatus();
+  }, [status, id, initialStatus, onUpdate]);
+
+  const statusDetail = statusDetails[status];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        asChild
+        onClick={(e) => e.stopPropagation()}
+        className={className}
+      >
+        <Badge className={statusDetail.color}>
+          {statusDetail.name} <ChevronDown className="ml-2" />
+        </Badge>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {Object.values(IssueStatus)
+          .filter((s) => s !== status)
+          .map((s) => (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                setStatus(s);
+              }}
+              key={s}
+            >
+              <IssueStatusBadge status={s} />
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -10,7 +10,7 @@ import {
 import Link from "next/link";
 import * as React from "react";
 
-import { buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({
@@ -269,6 +269,7 @@ type MoreVerticalDropdownMenuProps = {
   contentClassName?: string;
   triggerClassName?: string;
   stopPropagation?: boolean;
+  asSpan?: boolean;
 };
 
 function isMenuGroup(
@@ -283,6 +284,7 @@ function MoreVerticalDropdownMenu({
   contentClassName,
   triggerClassName,
   stopPropagation = true,
+  asSpan = false,
 }: MoreVerticalDropdownMenuProps) {
   const firstTruthy = items.find(Boolean);
   const groups: MoreVerticalMenuGroup[] = isMenuGroup(firstTruthy)
@@ -295,17 +297,19 @@ function MoreVerticalDropdownMenu({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger
-        type="button"
-        className={cn(
-          buttonVariants({ variant: "ghost" }),
-          "h-8 w-8 p-0 cursor-pointer",
-          triggerClassName,
-        )}
-        onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
-      >
-        <span className="sr-only">Open menu</span>
-        <MoreVertical className="h-4 w-4" />
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className={cn("h-8 w-8 p-0 cursor-pointer", triggerClassName)}
+          onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+          asChild={asSpan}
+        >
+          <span>
+            <span className="sr-only">Open menu</span>
+            <MoreVertical className="h-4 w-4" />
+          </span>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align} className={contentClassName}>
         {groups.map((group, groupIndex) => {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import type * as React from "react";
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  CircleIcon,
+  MoreVertical,
+} from "lucide-react";
+import Link from "next/link";
+import * as React from "react";
 
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({
@@ -238,6 +245,133 @@ function DropdownMenuSubContent({
   );
 }
 
+export type MoreVerticalMenuItem = {
+  label: string;
+  href?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  variant?: "default" | "destructive";
+  stopPropagation?: boolean;
+  className?: string;
+};
+
+export type MoreVerticalMenuGroup = {
+  label?: string;
+  items: (MoreVerticalMenuItem | false | null | undefined)[];
+};
+
+type MoreVerticalDropdownMenuProps = {
+  items:
+    | (MoreVerticalMenuItem | false | null | undefined)[]
+    | MoreVerticalMenuGroup[];
+  align?: "start" | "center" | "end";
+  contentClassName?: string;
+  triggerClassName?: string;
+  stopPropagation?: boolean;
+};
+
+function isMenuGroup(
+  item: MoreVerticalMenuItem | MoreVerticalMenuGroup | false | null | undefined,
+): item is MoreVerticalMenuGroup {
+  return !!item && typeof item === "object" && "items" in item;
+}
+
+function MoreVerticalDropdownMenu({
+  items,
+  align = "end",
+  contentClassName,
+  triggerClassName,
+  stopPropagation = true,
+}: MoreVerticalDropdownMenuProps) {
+  const firstTruthy = items.find(Boolean);
+  const groups: MoreVerticalMenuGroup[] = isMenuGroup(firstTruthy)
+    ? (items as MoreVerticalMenuGroup[])
+    : [
+        {
+          items: items as (MoreVerticalMenuItem | false | null | undefined)[],
+        },
+      ];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className={cn("h-8 w-8 p-0 cursor-pointer", triggerClassName)}
+          onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+          asChild
+        >
+          <span>
+            <span className="sr-only">Open menu</span>
+            <MoreVertical className="h-4 w-4" />
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className={contentClassName}>
+        {groups.map((group, groupIndex) => {
+          const filteredItems = group.items.filter(
+            Boolean,
+          ) as MoreVerticalMenuItem[];
+          if (filteredItems.length === 0) return null;
+          return (
+            <React.Fragment key={groupIndex}>
+              {groupIndex > 0 && <DropdownMenuSeparator />}
+              {group.label && (
+                <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+              )}
+              {filteredItems.map((item, itemIndex) => {
+                const handleClick = item.stopPropagation
+                  ? (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      item.onClick?.(e);
+                    }
+                  : item.onClick;
+
+                if (item.href) {
+                  return (
+                    <DropdownMenuItem
+                      key={itemIndex}
+                      asChild
+                      disabled={item.disabled}
+                      className={item.className}
+                    >
+                      <Link
+                        href={item.href}
+                        onClick={
+                          item.stopPropagation
+                            ? (e) => e.stopPropagation()
+                            : undefined
+                        }
+                      >
+                        {item.icon}
+                        {item.label}
+                      </Link>
+                    </DropdownMenuItem>
+                  );
+                }
+
+                return (
+                  <DropdownMenuItem
+                    key={itemIndex}
+                    onClick={handleClick}
+                    disabled={item.disabled}
+                    variant={item.variant}
+                    className={item.className}
+                  >
+                    {item.icon}
+                    {item.label}
+                  </DropdownMenuItem>
+                );
+              })}
+            </React.Fragment>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export {
   DropdownMenu,
   DropdownMenuPortal,
@@ -254,4 +388,5 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  MoreVerticalDropdownMenu,
 };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -10,7 +10,7 @@ import {
 import Link from "next/link";
 import * as React from "react";
 
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({
@@ -295,18 +295,17 @@ function MoreVerticalDropdownMenu({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          className={cn("h-8 w-8 p-0 cursor-pointer", triggerClassName)}
-          onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
-          asChild
-        >
-          <span>
-            <span className="sr-only">Open menu</span>
-            <MoreVertical className="h-4 w-4" />
-          </span>
-        </Button>
+      <DropdownMenuTrigger
+        type="button"
+        className={cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-8 w-8 p-0 cursor-pointer",
+          triggerClassName,
+        )}
+        onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+      >
+        <span className="sr-only">Open menu</span>
+        <MoreVertical className="h-4 w-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align} className={contentClassName}>
         {groups.map((group, groupIndex) => {
@@ -321,7 +320,10 @@ function MoreVerticalDropdownMenu({
                 <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
               )}
               {filteredItems.map((item, itemIndex) => {
-                const handleClick = item.stopPropagation
+                const shouldStopPropagation =
+                  item.stopPropagation ?? stopPropagation;
+
+                const handleClick = shouldStopPropagation
                   ? (e: React.MouseEvent) => {
                       e.stopPropagation();
                       item.onClick?.(e);
@@ -339,7 +341,7 @@ function MoreVerticalDropdownMenu({
                       <Link
                         href={item.href}
                         onClick={
-                          item.stopPropagation
+                          shouldStopPropagation
                             ? (e) => e.stopPropagation()
                             : undefined
                         }

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -223,9 +223,7 @@ function AdvisoryIssueProgressBar({
             style={{ width: `${falsePosPct}%` }}
           />
         </div>
-        <span className="text-sm font-medium">
-          {percentage}%&nbsp;remediated
-        </span>
+        <span className="text-sm font-medium">{percentage}%&nbsp;resolved</span>
       </div>
       {/* Legend */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
@@ -333,7 +331,7 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
           header: "Progress",
           content: (
             <span className="text-sm font-medium">
-              {advisory.progressPercent}% remediated
+              {advisory.progressPercent}% resolved
             </span>
           ),
         },
@@ -414,13 +412,7 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
             <p className="text-sm text-muted-foreground">No affected assets</p>
           ) : (
             <>
-              <DataTable
-                paginatedData={assetsPaginated}
-                columns={dashboardColumns}
-                nestedColumns={assetIssueColumns}
-                nestedDataKey="issues"
-              />
-              <div className="mt-4">
+              <div className="mb-4 mt-2">
                 <AdvisoryIssueProgressBar
                   issues={advisory.affectedAssetsWithIssues.flatMap(
                     (a) => a.issues,
@@ -428,6 +420,12 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                   percentage={advisory.progressPercent}
                 />
               </div>
+              <DataTable
+                paginatedData={assetsPaginated}
+                columns={dashboardColumns}
+                nestedColumns={assetIssueColumns}
+                nestedDataKey="issues"
+              />
             </>
           )}
         </DetailSection>

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -14,6 +14,7 @@ import {
   ErrorView,
   LoadingView,
 } from "@/components/entity-components";
+import { SeverityBadge } from "@/components/severity-badge";
 import { StatusFormBase } from "@/components/status-form";
 import {
   Accordion,
@@ -59,22 +60,6 @@ import {
 } from "../hooks/use-advisories";
 import { useAdvisoriesParams } from "../hooks/use-advisories-params";
 import { columns } from "./columns";
-
-// ---------------------------------------------------------------------------
-// Severity badge
-// ---------------------------------------------------------------------------
-
-const severityConfig: Record<Severity, { label: string; className: string }> = {
-  Critical: { label: "Critical", className: "bg-red-600 text-white" },
-  High: { label: "High", className: "bg-orange-500 text-white" },
-  Medium: { label: "Medium", className: "bg-yellow-500 text-black" },
-  Low: { label: "Low", className: "bg-blue-500 text-white" },
-};
-
-export const SeverityBadge = ({ severity }: { severity: Severity }) => {
-  const config = severityConfig[severity];
-  return <Badge className={config.className}>{config.label}</Badge>;
-};
 
 // ---------------------------------------------------------------------------
 // TLP badge — colors per https://www.first.org/tlp/
@@ -199,7 +184,7 @@ export const AdvisoryDetailError = () => {
 };
 
 // ---------------------------------------------------------------------------
-// Issue progress bar (JIRA epic style)
+// Issue progress bar
 // ---------------------------------------------------------------------------
 
 interface AdvisoryIssueProgressBarProps {
@@ -222,41 +207,55 @@ function AdvisoryIssueProgressBar({ issues, percentage }: AdvisoryIssueProgressB
   const remediatedPct = (remediated / total) * 100;
   const falsePosPct = (falsePos / total) * 100;
 
+  const legendItems = [
+    { count: remediated, label: "Remediated", colorClass: "bg-green-500" },
+    { count: falsePos, label: "False Positive", colorClass: "bg-yellow-500" },
+    { count: active, label: "Active", colorClass: "bg-muted-foreground" },
+  ];
+
   return (
     <div className="flex flex-col gap-1.5">
-      {/* Stacked bar */}
-      <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted flex">
-        <div
-          className="h-full bg-green-500 transition-all"
-          style={{ width: `${remediatedPct}%` }}
-        />
-        <div
-          className="h-full bg-yellow-500 transition-all"
-          style={{ width: `${falsePosPct}%` }}
-        />
+      <div className="flex items-center gap-4">
+        {/* Stacked bar */}
+        <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted-foreground flex">
+          <div
+            className="h-full bg-green-500 transition-all"
+            style={{ width: `${remediatedPct}%` }}
+          />
+          <div
+            className="h-full bg-yellow-500 transition-all"
+            style={{ width: `${falsePosPct}%` }}
+          />
+        </div>
+        <span className="text-sm font-medium">
+          {percentage}%&nbsp;remediated
+        </span>
       </div>
-      <span className="text-sm font-medium">
-        {percentage}% remediated
-      </span>
       {/* Legend */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block size-2 rounded-full bg-green-500" />
-          {remediated} Remediated
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block size-2 rounded-full bg-yellow-500" />
-          {falsePos} False Positive
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="bg-muted-foreground/40 inline-block size-2 rounded-full" />
-          {active} Active
-        </span>
+        {legendItems.map(({ count, label, colorClass }) => (
+          <span key={label} className="flex items-center gap-1.5">
+            <span className={`inline-block size-2 rounded-full ${colorClass}`} />
+            {count} {label}
+          </span>
+        ))}
         <span className="ml-auto font-medium text-foreground">
           {total} total
         </span>
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail section card
+// ---------------------------------------------------------------------------
+
+function DetailSection({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+      {children}
+    </section>
   );
 }
 
@@ -320,15 +319,15 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
         },
         {
           header: "TLP",
-          tooltip: (
+          content: (
+            <>{advisory.tlp ? <TlpBadge tlp={advisory.tlp} /> : null}
             <QuestionTooltip>
               TLP (Traffic Light Protocol) is a set of designations used to
               ensure that sensitive information is shared with the appropriate
               audience. RED = recipients only, AMBER = limited sharing, GREEN =
               community-wide, WHITE/CLEAR = unlimited.
-            </QuestionTooltip>
+            </QuestionTooltip></>
           ),
-          content: advisory.tlp ? <TlpBadge tlp={advisory.tlp} /> : null,
         },
         {
           header: "Progress",
@@ -400,14 +399,14 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
 
         {/* Summary */}
         {advisory.summary && (
-          <section className="flex flex-col gap-2 rounded-md border bg-background p-6">
+          <DetailSection>
             <h2 className="text-xl font-semibold">Summary</h2>
             <p className="text-sm text-muted-foreground">{advisory.summary}</p>
-          </section>
+          </DetailSection>
         )}
 
         {/* Affected Assets */}
-        <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+        <DetailSection>
           <h2 className="text-xl font-semibold">
             Affected Assets ({advisory.affectedAssetsWithIssues.length})
           </h2>
@@ -431,11 +430,11 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
               </div>
             </>
           )}
-        </section>
+        </DetailSection>
 
         {/* Notes */}
         {parsedCsaf.notes.length > 0 && (
-          <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+          <DetailSection>
             <h2 className="text-xl font-semibold">Notes</h2>
             <table className="w-full text-sm">
               <tbody>
@@ -451,12 +450,12 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                 ))}
               </tbody>
             </table>
-          </section>
+          </DetailSection>
         )}
 
         {/* Vulnerabilities */}
         {vulnItems.length > 0 && (
-          <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+          <DetailSection>
             <h2 className="text-xl font-semibold">Vulnerabilities</h2>
             <Accordion type="multiple">
               {vulnItems.map((item) => (
@@ -520,7 +519,19 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                                     </Badge>
                                   </td>
                                   <td className="py-2 text-muted-foreground align-top">
-                                    {r.details}
+                                    {r.url ? (
+                                      <a
+                                        href={r.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-primary hover:underline flex items-center gap-1"
+                                      >
+                                        {r.details}
+                                        <ExternalLinkIcon className="size-3 shrink-0" />
+                                      </a>
+                                    ) : (
+                                      r.details
+                                    )}
                                   </td>
                                 </tr>
                               ))}
@@ -533,7 +544,7 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                 </AccordionItem>
               ))}
             </Accordion>
-          </section>
+          </DetailSection>
         )}
       </main>
     </div>

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { ComputerIcon } from "lucide-react";
+import { ExternalLinkIcon, MoreVertical, SlashIcon } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import {
+  InfoColumn,
+  type InfoColumnSection,
+} from "@/components/dashboard-drawers";
 import {
   EntityContainer,
   EntityHeader,
@@ -10,10 +15,43 @@ import {
   LoadingView,
 } from "@/components/entity-components";
 import { StatusFormBase } from "@/components/status-form";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
-import type { Advisory, Severity, Tlp } from "@/generated/prisma";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { QuestionTooltip } from "@/components/ui/question-tooltip";
+import {
+  assetIssueColumns,
+  dashboardColumns,
+} from "@/features/assets/components/dashboard-columns";
+import type { AssetWithIssueRelations } from "@/features/assets/types";
+import {
+  type Advisory,
+  IssueStatus,
+  type Severity,
+  type Tlp,
+} from "@/generated/prisma";
 import { useEntitySearch } from "@/hooks/use-entity-search";
+import { parseCsaf } from "@/lib/csaf";
 import {
   useSuspenseAdvisories,
   useSuspenseAdvisory,
@@ -160,78 +198,344 @@ export const AdvisoryDetailError = () => {
   return <ErrorView message="Error loading advisory" />;
 };
 
+// ---------------------------------------------------------------------------
+// Issue progress bar (JIRA epic style)
+// ---------------------------------------------------------------------------
+
+interface AdvisoryIssueProgressBarProps {
+  issues: Array<{ status: IssueStatus }>;
+  percentage: number;
+}
+
+function AdvisoryIssueProgressBar({ issues, percentage }: AdvisoryIssueProgressBarProps) {
+  const total = issues.length;
+  if (total === 0) return null;
+
+  const remediated = issues.filter(
+    (i) => i.status === IssueStatus.REMEDIATED,
+  ).length;
+  const falsePos = issues.filter(
+    (i) => i.status === IssueStatus.FALSE_POSITIVE,
+  ).length;
+  const active = total - remediated - falsePos;
+
+  const remediatedPct = (remediated / total) * 100;
+  const falsePosPct = (falsePos / total) * 100;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {/* Stacked bar */}
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted flex">
+        <div
+          className="h-full bg-green-500 transition-all"
+          style={{ width: `${remediatedPct}%` }}
+        />
+        <div
+          className="h-full bg-yellow-500 transition-all"
+          style={{ width: `${falsePosPct}%` }}
+        />
+      </div>
+      <span className="text-sm font-medium">
+        {percentage}% remediated
+      </span>
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block size-2 rounded-full bg-green-500" />
+          {remediated} Remediated
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block size-2 rounded-full bg-yellow-500" />
+          {falsePos} False Positive
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="bg-muted-foreground/40 inline-block size-2 rounded-full" />
+          {active} Active
+        </span>
+        <span className="ml-auto font-medium text-foreground">
+          {total} total
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Normalize CSAF baseSeverity (e.g. "CRITICAL") to Prisma Severity enum (e.g. "Critical")
+function normalizeCsafSeverity(s: string | null): Severity | null {
+  if (!s) return null;
+  const map: Record<string, Severity> = {
+    CRITICAL: "Critical",
+    HIGH: "High",
+    MEDIUM: "Medium",
+    LOW: "Low",
+  };
+  return map[s.toUpperCase()] ?? null;
+}
+
 export const AdvisoryDetailPage = ({ id }: { id: string }) => {
   const { data: advisory } = useSuspenseAdvisory(id);
 
   const displayTitle = advisory.title ?? advisory.id;
+  const parsedCsaf = parseCsaf(advisory.csaf);
+
+  const assetsPaginated = {
+    items: advisory.affectedAssetsWithIssues as AssetWithIssueRelations[],
+    page: 1,
+    pageSize: Math.max(advisory.affectedAssetsWithIssues.length, 1),
+    totalCount: advisory.affectedAssetsWithIssues.length,
+    totalPages: 1,
+    hasNextPage: false,
+    hasPreviousPage: false,
+  };
+
+  const vulnItems = parsedCsaf.vulnerabilities.map((v) => ({
+    value: v.cve,
+    cve: v.cve,
+    severity: normalizeCsafSeverity(v.severity),
+    summary: v.summary,
+    remediations: v.remediations,
+    viperObject:
+      advisory.referencedVulnerabilities.find((rv) => rv.cveId === v.cve) ??
+      null,
+  }));
+
+  // Build grouped references: one item per category, links as a <ul>
+  const groupedRefs = new Map<string, typeof parsedCsaf.references>();
+  for (const ref of parsedCsaf.references) {
+    if (!groupedRefs.has(ref.category)) groupedRefs.set(ref.category, []);
+    groupedRefs.get(ref.category)!.push(ref);
+  }
+
+  const sidebarSections: InfoColumnSection[] = [
+    {
+      header: "Advisory Information",
+      items: [
+        {
+          header: "Status",
+          content: <AdvisoryStatusForm advisory={advisory} />,
+        },
+        {
+          header: "Severity",
+          content: <SeverityBadge severity={advisory.severity} />,
+        },
+        {
+          header: "TLP",
+          tooltip: (
+            <QuestionTooltip>
+              TLP (Traffic Light Protocol) is a set of designations used to
+              ensure that sensitive information is shared with the appropriate
+              audience. RED = recipients only, AMBER = limited sharing, GREEN =
+              community-wide, WHITE/CLEAR = unlimited.
+            </QuestionTooltip>
+          ),
+          content: advisory.tlp ? <TlpBadge tlp={advisory.tlp} /> : null,
+        },
+        {
+          header: "Progress",
+          content: (
+            <span className="text-sm font-medium">
+              {advisory.progressPercent}% remediated
+            </span>
+          ),
+        },
+      ],
+    },
+    ...(parsedCsaf.references.length > 0
+      ? [
+          {
+            header: "References",
+            items: [...groupedRefs.entries()].map(([category, refs]) => ({
+              header: category,
+              content: (
+                <ul className="flex flex-col gap-1 pl-4 list-disc">
+                  {refs.map((ref, i) => (
+                    <li key={i}>
+                      <a
+                        href={ref.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-primary hover:underline flex items-start gap-1"
+                      >
+                        {ref.summary || ref.url}
+                        <ExternalLinkIcon className="size-3 mt-0.5 shrink-0" />
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              ),
+            })),
+          },
+        ]
+      : []),
+  ];
 
   return (
-    <div className="mx-auto max-w-screen-lg w-full flex flex-col gap-y-8 p-8">
-      {/* Header */}
-      <div className="flex flex-col gap-y-1">
-        <h1 className="text-2xl font-semibold">{displayTitle}</h1>
-        <p className="text-xs text-muted-foreground font-mono">{advisory.id}</p>
-      </div>
+    <div className="flex flex-col lg:flex-row gap-8 p-8 w-full items-start">
+      {/* ── Right sidebar (top on mobile, right on lg) ── */}
+      <aside className="order-first lg:order-last lg:w-80 shrink-0 sticky top-4 bg-background border-1 rounded-md">
+        <InfoColumn sections={sidebarSections} className="h-auto" />
+      </aside>
 
-      {/* Status + Severity + TLP */}
-      <div className="flex flex-wrap items-center gap-3">
-        <AdvisoryStatusForm advisory={advisory} />
-        <SeverityBadge severity={advisory.severity} />
-        {advisory.tlp && <TlpBadge tlp={advisory.tlp} />}
-      </div>
+      {/* ── Main content ── */}
+      <main className="flex-1 flex flex-col gap-8 min-w-0">
+        {/* Breadcrumb */}
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/advisories">All Advisories</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>
+              <SlashIcon />
+            </BreadcrumbSeparator>
+            <BreadcrumbItem>
+              <BreadcrumbPage>{displayTitle}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
 
-      {/* Summary */}
-      {advisory.summary && (
-        <div className="flex flex-col gap-y-1">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-            Summary
+        {/* Title */}
+        <h1 className="text-3xl font-semibold tracking-tight">
+          {displayTitle}
+        </h1>
+
+        {/* Summary */}
+        {advisory.summary && (
+          <section className="flex flex-col gap-2 rounded-md border bg-background p-6">
+            <h2 className="text-xl font-semibold">Summary</h2>
+            <p className="text-sm text-muted-foreground">{advisory.summary}</p>
+          </section>
+        )}
+
+        {/* Affected Assets */}
+        <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+          <h2 className="text-xl font-semibold">
+            Affected Assets ({advisory.affectedAssetsWithIssues.length})
           </h2>
-          <p className="text-sm">{advisory.summary}</p>
-        </div>
-      )}
-
-      {/* Affected Assets */}
-      <div className="flex flex-col gap-y-3">
-        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-          Affected Assets ({advisory.affectedAssets.length})
-        </h2>
-        {advisory.affectedAssets.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No affected assets</p>
-        ) : (
-          <div className="flex flex-col gap-y-2">
-            {advisory.affectedAssets.map((asset) => (
-              <div
-                key={asset.id}
-                className="flex items-center gap-3 p-3 border rounded-lg"
-              >
-                <ComputerIcon className="size-4 text-muted-foreground shrink-0" />
-                <div className="flex flex-col gap-0.5 min-w-0">
-                  <span className="text-sm font-medium">
-                    {asset.hostname ?? asset.ip}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {asset.ip}
-                    {asset.role ? ` · ${asset.role}` : ""}
-                  </span>
-                </div>
+          {advisory.affectedAssetsWithIssues.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No affected assets</p>
+          ) : (
+            <>
+              <DataTable
+                paginatedData={assetsPaginated}
+                columns={dashboardColumns}
+                nestedColumns={assetIssueColumns}
+                nestedDataKey="issues"
+              />
+              <div className="mt-4">
+                <AdvisoryIssueProgressBar
+                  issues={advisory.affectedAssetsWithIssues.flatMap(
+                    (a) => a.issues,
+                  )}
+                  percentage={advisory.progressPercent}
+                />
               </div>
-            ))}
-          </div>
-        )}
-      </div>
+            </>
+          )}
+        </section>
 
-      {/* CSAF */}
-      {advisory.csaf &&
-        JSON.stringify(advisory.csaf) !== JSON.stringify({}) && (
-          <div className="flex flex-col gap-y-3">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-              CSAF
-            </h2>
-            <pre className="overflow-auto text-xs bg-muted p-4 rounded max-h-[600px]">
-              {JSON.stringify(advisory.csaf, null, 2)}
-            </pre>
-          </div>
+        {/* Notes */}
+        {parsedCsaf.notes.length > 0 && (
+          <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+            <h2 className="text-xl font-semibold">Notes</h2>
+            <table className="w-full text-sm">
+              <tbody>
+                {parsedCsaf.notes.map((note, i) => (
+                  <tr key={i} className="border-b last:border-0">
+                    <td className="py-2 pr-3 w-48 align-top">
+                      <Badge variant="secondary">{note.title}</Badge>
+                    </td>
+                    <td className="py-2 text-muted-foreground align-top">
+                      {note.text}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
         )}
+
+        {/* Vulnerabilities */}
+        {vulnItems.length > 0 && (
+          <section className="flex flex-col gap-3 rounded-md border bg-background p-6">
+            <h2 className="text-xl font-semibold">Vulnerabilities</h2>
+            <Accordion type="multiple">
+              {vulnItems.map((item) => (
+                <AccordionItem key={item.value} value={item.value}>
+                  <AccordionTrigger className="hover:no-underline">
+                    <span className="flex w-full items-center gap-3">
+                      <span className="font-mono text-sm">{item.cve}</span>
+                      {item.severity && (
+                        <SeverityBadge severity={item.severity} />
+                      )}
+                      {item.viperObject && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="ml-auto h-7 w-7 p-0"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <span className="sr-only">Open menu</span>
+                              <MoreVertical className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem asChild>
+                              <Link
+                                href={`/vulnerabilities/${item.viperObject.id}`}
+                              >
+                                Vulnerability Detail Page
+                              </Link>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="flex flex-col gap-4 pt-2">
+                      {item.summary && (
+                        <div>
+                          <h4 className="text-sm font-semibold mb-1">
+                            Summary
+                          </h4>
+                          <p className="text-sm text-muted-foreground">
+                            {item.summary}
+                          </p>
+                        </div>
+                      )}
+                      {item.remediations.length > 0 && (
+                        <div>
+                          <h4 className="text-sm font-semibold mb-2">
+                            Remediations
+                          </h4>
+                          <table className="w-full text-sm">
+                            <tbody>
+                              {item.remediations.map((r, i) => (
+                                <tr key={i} className="border-b last:border-0">
+                                  <td className="py-2 pr-3 w-32 align-top">
+                                    <Badge variant="secondary">
+                                      {r.category}
+                                    </Badge>
+                                  </td>
+                                  <td className="py-2 text-muted-foreground align-top">
+                                    {r.details}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </section>
+        )}
+      </main>
     </div>
   );
 };

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -473,6 +473,7 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                               href: `/vulnerabilities/${item.viperObject.id}`,
                             },
                           ]}
+                          asSpan={true}
                         />
                       )}
                     </span>

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { ComputerIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  EntityContainer,
+  EntityHeader,
+  EntitySearch,
+  ErrorView,
+  LoadingView,
+} from "@/components/entity-components";
+import { StatusFormBase } from "@/components/status-form";
+import { Badge } from "@/components/ui/badge";
+import { DataTable } from "@/components/ui/data-table";
+import type { Advisory, Severity, Tlp } from "@/generated/prisma";
+import { useEntitySearch } from "@/hooks/use-entity-search";
+import {
+  useSuspenseAdvisories,
+  useSuspenseAdvisory,
+  useUpdateAdvisoryStatus,
+} from "../hooks/use-advisories";
+import { useAdvisoriesParams } from "../hooks/use-advisories-params";
+import { columns } from "./columns";
+
+// ---------------------------------------------------------------------------
+// Severity badge
+// ---------------------------------------------------------------------------
+
+const severityConfig: Record<Severity, { label: string; className: string }> = {
+  Critical: { label: "Critical", className: "bg-red-600 text-white" },
+  High: { label: "High", className: "bg-orange-500 text-white" },
+  Medium: { label: "Medium", className: "bg-yellow-500 text-black" },
+  Low: { label: "Low", className: "bg-blue-500 text-white" },
+};
+
+export const SeverityBadge = ({ severity }: { severity: Severity }) => {
+  const config = severityConfig[severity];
+  return <Badge className={config.className}>{config.label}</Badge>;
+};
+
+// ---------------------------------------------------------------------------
+// TLP badge — colors per https://www.first.org/tlp/
+// ---------------------------------------------------------------------------
+
+const tlpConfig: Record<Tlp, { label: string; bg: string }> = {
+  RED: { label: "TLP:RED", bg: "#FF2B2B" },
+  AMBER: { label: "TLP:AMBER", bg: "#FFC000" },
+  AMBER_STRICT: { label: "TLP:AMBER+STRICT", bg: "#FFC000" },
+  GREEN: { label: "TLP:GREEN", bg: "#33FF00" },
+  CLEAR: { label: "TLP:CLEAR", bg: "#FFFFFF" },
+  WHITE: { label: "TLP:WHITE", bg: "#FFFFFF" },
+};
+
+export const TlpBadge = ({ tlp }: { tlp: Tlp }) => {
+  const config = tlpConfig[tlp];
+  const isClear = tlp === "CLEAR" || tlp === "WHITE";
+  return (
+    <Badge
+      style={{ backgroundColor: config.bg, color: "#000000" }}
+      className={isClear ? "border border-gray-300" : ""}
+    >
+      {config.label}
+    </Badge>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Advisory status form
+// ---------------------------------------------------------------------------
+
+export const AdvisoryStatusForm = ({
+  advisory,
+  className,
+}: {
+  advisory: Pick<Advisory, "id" | "status">;
+  className?: string;
+}) => {
+  const updateAdvisoryStatus = useUpdateAdvisoryStatus();
+  return (
+    <StatusFormBase
+      id={advisory.id}
+      initialStatus={advisory.status}
+      onUpdate={(input) => updateAdvisoryStatus.mutateAsync(input)}
+      className={className}
+    />
+  );
+};
+
+// ---------------------------------------------------------------------------
+// List components
+// ---------------------------------------------------------------------------
+
+export const AdvisoriesSearch = () => {
+  const [params, setParams] = useAdvisoriesParams();
+  const { searchValue, onSearchChange } = useEntitySearch({
+    params,
+    setParams,
+  });
+
+  return (
+    <EntitySearch
+      value={searchValue}
+      onChange={onSearchChange}
+      placeholder="Search advisories"
+    />
+  );
+};
+
+export const AdvisoriesList = () => {
+  const { data, isFetching } = useSuspenseAdvisories();
+  const router = useRouter();
+
+  return (
+    <DataTable
+      paginatedData={data}
+      columns={columns}
+      isLoading={isFetching}
+      search={<AdvisoriesSearch />}
+      rowOnclick={(row) => router.push(`/advisories/${row.original.id}`)}
+    />
+  );
+};
+
+export const AdvisoriesHeader = () => {
+  return (
+    <EntityHeader
+      title="Advisories"
+      description="Security advisories affecting your assets"
+    />
+  );
+};
+
+export const AdvisoriesContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return (
+    <EntityContainer header={<AdvisoriesHeader />}>{children}</EntityContainer>
+  );
+};
+
+export const AdvisoriesLoading = () => {
+  return <LoadingView message="Loading advisories..." />;
+};
+
+export const AdvisoriesError = () => {
+  return <ErrorView message="Error loading advisories" />;
+};
+
+// ---------------------------------------------------------------------------
+// Detail page
+// ---------------------------------------------------------------------------
+
+export const AdvisoryDetailLoading = () => {
+  return <LoadingView message="Loading advisory..." />;
+};
+
+export const AdvisoryDetailError = () => {
+  return <ErrorView message="Error loading advisory" />;
+};
+
+export const AdvisoryDetailPage = ({ id }: { id: string }) => {
+  const { data: advisory } = useSuspenseAdvisory(id);
+
+  const displayTitle = advisory.title ?? advisory.id;
+
+  return (
+    <div className="mx-auto max-w-screen-lg w-full flex flex-col gap-y-8 p-8">
+      {/* Header */}
+      <div className="flex flex-col gap-y-1">
+        <h1 className="text-2xl font-semibold">{displayTitle}</h1>
+        <p className="text-xs text-muted-foreground font-mono">{advisory.id}</p>
+      </div>
+
+      {/* Status + Severity + TLP */}
+      <div className="flex flex-wrap items-center gap-3">
+        <AdvisoryStatusForm advisory={advisory} />
+        <SeverityBadge severity={advisory.severity} />
+        {advisory.tlp && <TlpBadge tlp={advisory.tlp} />}
+      </div>
+
+      {/* Summary */}
+      {advisory.summary && (
+        <div className="flex flex-col gap-y-1">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Summary
+          </h2>
+          <p className="text-sm">{advisory.summary}</p>
+        </div>
+      )}
+
+      {/* Affected Assets */}
+      <div className="flex flex-col gap-y-3">
+        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Affected Assets ({advisory.affectedAssets.length})
+        </h2>
+        {advisory.affectedAssets.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No affected assets</p>
+        ) : (
+          <div className="flex flex-col gap-y-2">
+            {advisory.affectedAssets.map((asset) => (
+              <div
+                key={asset.id}
+                className="flex items-center gap-3 p-3 border rounded-lg"
+              >
+                <ComputerIcon className="size-4 text-muted-foreground shrink-0" />
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="text-sm font-medium">
+                    {asset.hostname ?? asset.ip}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {asset.ip}
+                    {asset.role ? ` · ${asset.role}` : ""}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* CSAF */}
+      {advisory.csaf &&
+        JSON.stringify(advisory.csaf) !== JSON.stringify({}) && (
+          <div className="flex flex-col gap-y-3">
+            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+              CSAF
+            </h2>
+            <pre className="overflow-auto text-xs bg-muted p-4 rounded max-h-[600px]">
+              {JSON.stringify(advisory.csaf, null, 2)}
+            </pre>
+          </div>
+        )}
+    </div>
+  );
+};

--- a/src/features/advisories/components/advisories.tsx
+++ b/src/features/advisories/components/advisories.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { ExternalLinkIcon, MoreVertical, SlashIcon } from "lucide-react";
-import Link from "next/link";
+import { ExternalLinkIcon, SlashIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
   InfoColumn,
@@ -31,14 +30,8 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import { QuestionTooltip } from "@/components/ui/question-tooltip";
 import {
   assetIssueColumns,
@@ -192,7 +185,10 @@ interface AdvisoryIssueProgressBarProps {
   percentage: number;
 }
 
-function AdvisoryIssueProgressBar({ issues, percentage }: AdvisoryIssueProgressBarProps) {
+function AdvisoryIssueProgressBar({
+  issues,
+  percentage,
+}: AdvisoryIssueProgressBarProps) {
   const total = issues.length;
   if (total === 0) return null;
 
@@ -235,7 +231,9 @@ function AdvisoryIssueProgressBar({ issues, percentage }: AdvisoryIssueProgressB
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
         {legendItems.map(({ count, label, colorClass }) => (
           <span key={label} className="flex items-center gap-1.5">
-            <span className={`inline-block size-2 rounded-full ${colorClass}`} />
+            <span
+              className={`inline-block size-2 rounded-full ${colorClass}`}
+            />
             {count} {label}
           </span>
         ))}
@@ -320,13 +318,15 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
         {
           header: "TLP",
           content: (
-            <>{advisory.tlp ? <TlpBadge tlp={advisory.tlp} /> : null}
-            <QuestionTooltip>
-              TLP (Traffic Light Protocol) is a set of designations used to
-              ensure that sensitive information is shared with the appropriate
-              audience. RED = recipients only, AMBER = limited sharing, GREEN =
-              community-wide, WHITE/CLEAR = unlimited.
-            </QuestionTooltip></>
+            <>
+              {advisory.tlp ? <TlpBadge tlp={advisory.tlp} /> : null}
+              <QuestionTooltip>
+                TLP (Traffic Light Protocol) is a set of designations used to
+                ensure that sensitive information is shared with the appropriate
+                audience. RED = recipients only, AMBER = limited sharing, GREEN
+                = community-wide, WHITE/CLEAR = unlimited.
+              </QuestionTooltip>
+            </>
           ),
         },
         {
@@ -467,28 +467,15 @@ export const AdvisoryDetailPage = ({ id }: { id: string }) => {
                         <SeverityBadge severity={item.severity} />
                       )}
                       {item.viperObject && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="ml-auto h-7 w-7 p-0"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <span className="sr-only">Open menu</span>
-                              <MoreVertical className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem asChild>
-                              <Link
-                                href={`/vulnerabilities/${item.viperObject.id}`}
-                              >
-                                Vulnerability Detail Page
-                              </Link>
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                        <MoreVerticalDropdownMenu
+                          triggerClassName="ml-auto"
+                          items={[
+                            {
+                              label: "Vulnerability Detail Page",
+                              href: `/vulnerabilities/${item.viperObject.id}`,
+                            },
+                          ]}
+                        />
                       )}
                     </span>
                   </AccordionTrigger>

--- a/src/features/advisories/components/columns.tsx
+++ b/src/features/advisories/components/columns.tsx
@@ -2,10 +2,11 @@
 
 import type { ColumnDef } from "@tanstack/table-core";
 import { formatDistanceToNow } from "date-fns";
+import { SeverityBadge } from "@/components/severity-badge";
 import { SortableHeader } from "@/components/ui/data-table";
 import { IssueStatusBadge } from "@/features/issues/components/issue";
 import type { AdvisoryWithRelations } from "../types";
-import { SeverityBadge, TlpBadge } from "./advisories";
+import { TlpBadge } from "./advisories";
 
 type AdvisoryRow = AdvisoryWithRelations & { affectedAssetCount: number };
 

--- a/src/features/advisories/components/columns.tsx
+++ b/src/features/advisories/components/columns.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/table-core";
+import { formatDistanceToNow } from "date-fns";
+import { SortableHeader } from "@/components/ui/data-table";
+import { IssueStatusBadge } from "@/features/issues/components/issue";
+import type { AdvisoryWithRelations } from "../types";
+import { SeverityBadge, TlpBadge } from "./advisories";
+
+type AdvisoryRow = AdvisoryWithRelations & { affectedAssetCount: number };
+
+export const columns: ColumnDef<AdvisoryRow>[] = [
+  {
+    id: "title",
+    accessorKey: "title",
+    header: ({ column }) => <SortableHeader header="Title" column={column} />,
+    cell: ({ row }) =>
+      row.original.title ?? (
+        <span className="text-muted-foreground font-mono text-xs">
+          {row.original.id.slice(0, 12)}…
+        </span>
+      ),
+  },
+  {
+    id: "severity",
+    accessorKey: "severity",
+    meta: { title: "Severity" },
+    header: "Severity",
+    cell: ({ row }) => <SeverityBadge severity={row.original.severity} />,
+  },
+  {
+    id: "tlp",
+    accessorKey: "tlp",
+    meta: { title: "TLP" },
+    header: "TLP",
+    cell: ({ row }) =>
+      row.original.tlp ? <TlpBadge tlp={row.original.tlp} /> : null,
+  },
+  {
+    id: "status",
+    accessorKey: "status",
+    meta: { title: "Status" },
+    header: "Status",
+    cell: ({ row }) => <IssueStatusBadge status={row.original.status} />,
+  },
+  {
+    id: "affectedAssets",
+    accessorKey: "affectedAssetCount",
+    meta: { title: "Affected Assets" },
+    header: "Affected Assets",
+    cell: ({ row }) => row.original.affectedAssetCount,
+  },
+  {
+    id: "publishedAt",
+    accessorKey: "publishedAt",
+    meta: { title: "Published" },
+    header: "Published",
+    cell: ({ row }) =>
+      row.original.publishedAt
+        ? formatDistanceToNow(row.original.publishedAt, { addSuffix: true })
+        : "—",
+  },
+  {
+    id: "updatedAt",
+    accessorKey: "updatedAt",
+    header: ({ column }) => (
+      <SortableHeader header="Last Updated" column={column} />
+    ),
+    cell: ({ row }) =>
+      formatDistanceToNow(row.original.updatedAt, { addSuffix: true }),
+  },
+];

--- a/src/features/advisories/hooks/use-advisories-params.ts
+++ b/src/features/advisories/hooks/use-advisories-params.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { useQueryStates } from "nuqs";
+import { advisoriesParams } from "../params";
+
+export const useAdvisoriesParams = () => {
+  return useQueryStates(advisoriesParams);
+};

--- a/src/features/advisories/hooks/use-advisories.ts
+++ b/src/features/advisories/hooks/use-advisories.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useTRPC } from "@/trpc/client";
+import { useAdvisoriesParams } from "./use-advisories-params";
+
+/**
+ * Hook to fetch all advisories using suspense
+ */
+export const useSuspenseAdvisories = () => {
+  const trpc = useTRPC();
+  const [params] = useAdvisoriesParams();
+  return useSuspenseQuery(trpc.advisories.getMany.queryOptions(params));
+};
+
+/**
+ * Hook to fetch a single advisory using suspense
+ */
+export const useSuspenseAdvisory = (id: string) => {
+  const trpc = useTRPC();
+  return useSuspenseQuery(trpc.advisories.getOne.queryOptions({ id }));
+};
+
+/**
+ * Hook to update an advisory's status
+ */
+export const useUpdateAdvisoryStatus = () => {
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+
+  return useMutation(
+    trpc.advisories.updateStatus.mutationOptions({
+      onSuccess: (data) => {
+        toast.success("Advisory status updated");
+        queryClient.invalidateQueries(
+          trpc.advisories.getOne.queryFilter({ id: data.id }),
+        );
+        queryClient.invalidateQueries(trpc.advisories.getMany.queryFilter());
+      },
+      onError: (error) => {
+        toast.error(`Failed to update advisory status: ${error.message}`);
+      },
+    }),
+  );
+};

--- a/src/features/advisories/params.ts
+++ b/src/features/advisories/params.ts
@@ -1,0 +1,3 @@
+import { createPaginationParams } from "@/lib/url-state";
+
+export const advisoriesParams = createPaginationParams();

--- a/src/features/advisories/server/params-loader.ts
+++ b/src/features/advisories/server/params-loader.ts
@@ -1,0 +1,4 @@
+import { createLoader } from "nuqs/server";
+import { advisoriesParams } from "../params";
+
+export const advisoriesParamsLoader = createLoader(advisoriesParams);

--- a/src/features/advisories/server/prefetch.ts
+++ b/src/features/advisories/server/prefetch.ts
@@ -1,0 +1,18 @@
+import type { inferInput } from "@trpc/tanstack-react-query";
+import { prefetch, trpc } from "@/trpc/server";
+
+type Input = inferInput<typeof trpc.advisories.getMany>;
+
+/**
+ * Prefetch all advisories
+ */
+export const prefetchAdvisories = (params: Input) => {
+  return prefetch(trpc.advisories.getMany.queryOptions(params));
+};
+
+/**
+ * Prefetch a single advisory
+ */
+export const prefetchAdvisory = (id: string) => {
+  return prefetch(trpc.advisories.getOne.queryOptions({ id }));
+};

--- a/src/features/advisories/server/routers.ts
+++ b/src/features/advisories/server/routers.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { z } from "zod";
+import { assetDashboardInclude } from "@/features/assets/types";
 import { IssueStatus } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
@@ -61,9 +62,35 @@ export const advisoriesRouter = createTRPCRouter({
         include: advisoryInclude,
       });
       const found = requireExistence(advisory, "Advisory");
+
+      const vulnIds = found.referencedVulnerabilities.map((v) => v.id);
+      const affectedAssetIds = getAffectedAssets(found).map((a) => a.id);
+
+      const affectedAssetsWithIssues = await prisma.asset.findMany({
+        where: { id: { in: affectedAssetIds } },
+        include: {
+          ...assetDashboardInclude,
+          issues: {
+            where: { vulnerabilityId: { in: vulnIds } },
+            include: assetDashboardInclude.issues.include,
+          },
+        },
+      });
+
+      const allIssues = affectedAssetsWithIssues.flatMap((a) => a.issues);
+      const nonActiveCount = allIssues.filter(
+        (i) => i.status !== IssueStatus.ACTIVE,
+      ).length;
+      const progressPercent =
+        allIssues.length > 0
+          ? Math.round((nonActiveCount / allIssues.length) * 100)
+          : 0;
+
       return {
         ...found,
         affectedAssets: getAffectedAssets(found),
+        affectedAssetsWithIssues,
+        progressPercent,
       };
     }),
 

--- a/src/features/advisories/server/routers.ts
+++ b/src/features/advisories/server/routers.ts
@@ -1,0 +1,78 @@
+import "server-only";
+import { z } from "zod";
+import { IssueStatus } from "@/generated/prisma";
+import prisma from "@/lib/db";
+import {
+  buildPaginationMeta,
+  createPaginatedResponse,
+  paginationInputSchema,
+} from "@/lib/pagination";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { requireExistence } from "@/trpc/middleware";
+import {
+  type AdvisoryWithRelations,
+  advisoryInclude,
+  getAffectedAssets,
+} from "../types";
+
+const createSearchFilter = (search: string) => {
+  return search
+    ? {
+        OR: [
+          { title: { contains: search, mode: "insensitive" as const } },
+          { summary: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
+};
+
+export const advisoriesRouter = createTRPCRouter({
+  getMany: protectedProcedure
+    .input(paginationInputSchema)
+    .query(async ({ ctx, input }) => {
+      const { search } = input;
+      const searchFilter = createSearchFilter(search);
+      const where = { userId: ctx.auth.user.id, ...searchFilter };
+
+      const totalCount = await prisma.advisory.count({ where });
+      const meta = buildPaginationMeta(input, totalCount);
+
+      const advisories = await prisma.advisory.findMany({
+        skip: meta.skip,
+        take: meta.take,
+        where,
+        include: advisoryInclude,
+        orderBy: { updatedAt: "desc" },
+      });
+
+      const items = advisories.map((advisory: AdvisoryWithRelations) => ({
+        ...advisory,
+        affectedAssetCount: getAffectedAssets(advisory).length,
+      }));
+
+      return createPaginatedResponse(items, meta);
+    }),
+
+  getOne: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      const advisory = await prisma.advisory.findUnique({
+        where: { id: input.id },
+        include: advisoryInclude,
+      });
+      const found = requireExistence(advisory, "Advisory");
+      return {
+        ...found,
+        affectedAssets: getAffectedAssets(found),
+      };
+    }),
+
+  updateStatus: protectedProcedure
+    .input(z.object({ id: z.string(), status: z.enum(IssueStatus) }))
+    .mutation(({ input }) => {
+      return prisma.advisory.update({
+        where: { id: input.id },
+        data: { status: input.status },
+      });
+    }),
+});

--- a/src/features/advisories/server/routers.ts
+++ b/src/features/advisories/server/routers.ts
@@ -30,10 +30,9 @@ const createSearchFilter = (search: string) => {
 export const advisoriesRouter = createTRPCRouter({
   getMany: protectedProcedure
     .input(paginationInputSchema)
-    .query(async ({ ctx, input }) => {
+    .query(async ({ input }) => {
       const { search } = input;
-      const searchFilter = createSearchFilter(search);
-      const where = { userId: ctx.auth.user.id, ...searchFilter };
+      const where = createSearchFilter(search);
 
       const totalCount = await prisma.advisory.count({ where });
       const meta = buildPaginationMeta(input, totalCount);

--- a/src/features/advisories/types.ts
+++ b/src/features/advisories/types.ts
@@ -1,0 +1,30 @@
+import type { Asset, Prisma } from "@/generated/prisma";
+
+export const advisoryInclude = {
+  referencedVulnerabilities: {
+    include: {
+      affectedDeviceGroups: {
+        include: { assets: true },
+      },
+    },
+  },
+} satisfies Prisma.AdvisoryInclude;
+
+export type AdvisoryWithRelations = Prisma.AdvisoryGetPayload<{
+  include: typeof advisoryInclude;
+}>;
+
+/**
+ * Deduplicate assets traversing advisory → referencedVulnerabilities → affectedDeviceGroups → assets
+ */
+export function getAffectedAssets(advisory: AdvisoryWithRelations): Asset[] {
+  const assetMap = new Map<string, Asset>();
+  for (const vuln of advisory.referencedVulnerabilities) {
+    for (const dg of vuln.affectedDeviceGroups) {
+      for (const asset of dg.assets) {
+        assetMap.set(asset.id, asset);
+      }
+    }
+  }
+  return [...assetMap.values()];
+}

--- a/src/features/assets/components/asset.tsx
+++ b/src/features/assets/components/asset.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { formatDistanceToNow } from "date-fns";
-import {
-  BugIcon,
-  ExternalLinkIcon,
-  MoreVertical,
-  ServerIcon,
-  SlashIcon,
-} from "lucide-react";
-import Link from "next/link";
+import { BugIcon, ExternalLinkIcon, ServerIcon, SlashIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import {
@@ -25,15 +18,9 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CopyCode } from "@/components/ui/code";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import {
   Pagination,
   PaginationContent,
@@ -115,37 +102,23 @@ const VulnList = ({
               <IssueStatusForm issue={issue} />
             </div>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                asChild
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <Button variant="ghost" className="h-8 w-8 p-0">
-                  <span className="sr-only">Open menu</span>
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-[200px]">
-                <DropdownMenuItem
-                  onClick={(e) => e.stopPropagation()}
-                  className="cursor-pointer"
-                  asChild
-                >
-                  <Link href={`/issues/${issue.id}`}>Go to Issue Details</Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={(e) => e.stopPropagation()}
-                  className="cursor-pointer"
-                  asChild
-                >
-                  <Link href={`/vulnerabilities/${issue.vulnerabilityId}`}>
-                    Go to Vulnerability Details
-                  </Link>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <MoreVerticalDropdownMenu
+              contentClassName="w-[200px]"
+              items={[
+                {
+                  label: "Go to Issue Details",
+                  href: `/issues/${issue.id}`,
+                  stopPropagation: true,
+                  className: "cursor-pointer",
+                },
+                {
+                  label: "Go to Vulnerability Details",
+                  href: `/vulnerabilities/${issue.vulnerabilityId}`,
+                  stopPropagation: true,
+                  className: "cursor-pointer",
+                },
+              ]}
+            />
           </li>
         ))}
       </ul>

--- a/src/features/assets/components/asset.tsx
+++ b/src/features/assets/components/asset.tsx
@@ -108,13 +108,11 @@ const VulnList = ({
                 {
                   label: "Go to Issue Details",
                   href: `/issues/${issue.id}`,
-                  stopPropagation: true,
                   className: "cursor-pointer",
                 },
                 {
                   label: "Go to Vulnerability Details",
                   href: `/vulnerabilities/${issue.vulnerabilityId}`,
-                  stopPropagation: true,
                   className: "cursor-pointer",
                 },
               ]}

--- a/src/features/assets/components/columns.tsx
+++ b/src/features/assets/components/columns.tsx
@@ -2,20 +2,11 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { CopyIcon, MoreVertical, TrashIcon } from "lucide-react";
-import Link from "next/link";
+import { CopyIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { CopyCode } from "@/components/ui/code";
 import { SortableHeader } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import { handleCopy } from "@/lib/copy";
 import type { AssetResponse } from "../types";
 
@@ -62,41 +53,45 @@ const actionsColumn: ColumnDef<AssetResponse> = {
     const asset = row.original;
 
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" className="h-8 w-8 p-0">
-            <span className="sr-only">Open menu</span>
-            <MoreVertical className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-[200px]">
-          <DropdownMenuItem asChild>
-            <Link href={`/assets/${asset.id}`}>Go to Asset Details</Link>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel>Quick Actions</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() =>
-              handleCopy(asset.deviceGroup.cpe, () => toast.success("Copied!"))
-            }
-          >
-            <CopyIcon strokeWidth={3} /> Copy Group ID
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => handleCopy(asset.id, () => toast.success("Copied!"))}
-          >
-            <CopyIcon strokeWidth={3} /> Copy Asset ID
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => console.log("TODO")}
-            variant="destructive"
-          >
-            <TrashIcon strokeWidth={3} /> Delete Asset
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <MoreVerticalDropdownMenu
+        contentClassName="w-[200px]"
+        items={[
+          {
+            items: [
+              { label: "Go to Asset Details", href: `/assets/${asset.id}` },
+            ],
+          },
+          {
+            label: "Quick Actions",
+            items: [
+              {
+                label: "Copy Group ID",
+                icon: <CopyIcon strokeWidth={3} />,
+                onClick: () =>
+                  handleCopy(asset.deviceGroup.cpe, () =>
+                    toast.success("Copied!"),
+                  ),
+              },
+              {
+                label: "Copy Asset ID",
+                icon: <CopyIcon strokeWidth={3} />,
+                onClick: () =>
+                  handleCopy(asset.id, () => toast.success("Copied!")),
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                label: "Delete Asset",
+                icon: <TrashIcon strokeWidth={3} />,
+                onClick: () => console.log("TODO"),
+                variant: "destructive",
+              },
+            ],
+          },
+        ]}
+      />
     );
   },
 };

--- a/src/features/assets/components/dashboard-columns.tsx
+++ b/src/features/assets/components/dashboard-columns.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
 import { MoreVertical } from "lucide-react";
 import Link from "next/link";
+import { severityConfig } from "@/components/severity-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SortableHeader } from "@/components/ui/data-table";
@@ -38,29 +39,6 @@ function countActiveBySeverity(
 function totalActiveIssues(issues: AssetIssue[]): number {
   return issues.filter((i) => i.status === IssueStatus.ACTIVE).length;
 }
-
-const severityConfig = {
-  [Severity.Critical]: {
-    label: "Critical",
-    short: "C",
-    badgeClass: "bg-red-600 hover:bg-red-600 text-white",
-  },
-  [Severity.High]: {
-    label: "High",
-    short: "H",
-    badgeClass: "bg-orange-500 hover:bg-orange-500 text-white",
-  },
-  [Severity.Medium]: {
-    label: "Medium",
-    short: "M",
-    badgeClass: "bg-yellow-500 hover:bg-yellow-500 text-white",
-  },
-  [Severity.Low]: {
-    label: "Low",
-    short: "L",
-    badgeClass: "bg-blue-500 hover:bg-blue-500 text-white",
-  },
-} as const;
 
 const SEVERITY_COL_COUNT = 4;
 
@@ -105,7 +83,7 @@ function createSeverityColumn(
 
       const count = countActiveBySeverity(issues, severity);
       if (count === 0) return <span className="text-muted-foreground">—</span>;
-      return <Badge className={config.badgeClass}>{count}</Badge>;
+      return <Badge className={config.badgeClassName}>{count}</Badge>;
     },
   };
 }
@@ -223,7 +201,7 @@ export const assetIssueColumns: ColumnDef<AssetIssue>[] = [
     cell: ({ row }) => {
       const severity = row.original.vulnerability.severity;
       const config = severityConfig[severity];
-      return <Badge className={config.badgeClass}>{config.label}</Badge>;
+      return <Badge className={config.badgeClassName}>{config.label}</Badge>;
     },
   },
   {

--- a/src/features/assets/components/dashboard-columns.tsx
+++ b/src/features/assets/components/dashboard-columns.tsx
@@ -2,18 +2,11 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { severityConfig } from "@/components/severity-badge";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { SortableHeader } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
@@ -160,19 +153,11 @@ export const dashboardColumns: ColumnDef<AssetWithIssueRelations>[] = [
     enableHiding: false,
     header: "",
     cell: ({ row }) => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-            <span className="sr-only">Open menu</span>
-            <MoreVertical className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <Link href={`/assets/${row.original.id}`}>Go to Asset Details</Link>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <MoreVerticalDropdownMenu
+        items={[
+          { label: "Go to Asset Details", href: `/assets/${row.original.id}` },
+        ]}
+      />
     ),
   },
 ];
@@ -221,24 +206,15 @@ export const assetIssueColumns: ColumnDef<AssetIssue>[] = [
     id: "actions",
     header: "",
     cell: ({ row }) => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-            <span className="sr-only">Open menu</span>
-            <MoreVertical className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <Link href={`/vulnerabilities/${row.original.vulnerabilityId}`}>
-              Go to Vulnerability
-            </Link>
-          </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href={`/issues/${row.original.id}`}>Go to Issue Details</Link>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <MoreVerticalDropdownMenu
+        items={[
+          {
+            label: "Go to Vulnerability",
+            href: `/vulnerabilities/${row.original.vulnerabilityId}`,
+          },
+          { label: "Go to Issue Details", href: `/issues/${row.original.id}` },
+        ]}
+      />
     ),
   },
 ];

--- a/src/features/integrations/components/columns.tsx
+++ b/src/features/integrations/components/columns.tsx
@@ -27,7 +27,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { type ResourceType, SyncStatusEnum } from "@/generated/prisma";
+import {
+  IntegrationType,
+  type ResourceType,
+  SyncStatusEnum,
+} from "@/generated/prisma";
 import type { AuthenticationInputType } from "@/lib/schemas";
 import {
   useRemoveIntegration,
@@ -74,7 +78,9 @@ export const getIntegrationColumns = (
       cell: ({ row }) => {
         return (
           <div className="flex gap-1 items-center">
-            {row.original.isGeneric && <Sparkles size={15} />}
+            {row.original.integrationType === IntegrationType.AI && (
+              <Sparkles size={15} />
+            )}
             <div className="font-semibold max-w-60 overflow-ellipsis overflow-hidden">
               {row.original.name}
             </div>
@@ -182,7 +188,7 @@ export const getIntegrationColumns = (
             name: data.name,
             platform: data.platform || "",
             integrationUri: data.integrationUri,
-            isGeneric: data.isGeneric,
+            integrationType: data.integrationType,
             prompt: data.prompt || "",
             authType: data.authType,
             resourceType: data.resourceType,

--- a/src/features/integrations/components/columns.tsx
+++ b/src/features/integrations/components/columns.tsx
@@ -3,34 +3,19 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import {
-  MoreVertical,
-  RefreshCw,
-  Sparkles,
-  SquarePen,
-  TrashIcon,
-} from "lucide-react";
+import { RefreshCw, Sparkles, SquarePen, TrashIcon } from "lucide-react";
 import ms from "ms";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { SortableHeader } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  type ResourceType,
-  SyncStatusEnum,
-} from "@/generated/prisma";
+import { type ResourceType, SyncStatusEnum } from "@/generated/prisma";
 import type { AuthenticationInputType } from "@/lib/schemas";
 import {
   useRemoveIntegration,
@@ -77,9 +62,7 @@ export const getIntegrationColumns = (
       cell: ({ row }) => {
         return (
           <div className="flex gap-1 items-center">
-            {row.original.integrationType === "AI" && (
-              <Sparkles size={15} />
-            )}
+            {row.original.integrationType === "AI" && <Sparkles size={15} />}
             <div className="font-semibold max-w-60 overflow-ellipsis overflow-hidden">
               {row.original.name}
             </div>
@@ -214,31 +197,34 @@ export const getIntegrationColumns = (
 
         return (
           <>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="h-8 w-8 p-0">
-                  <span className="sr-only">Open menu</span>
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-[200px]">
-                <DropdownMenuItem
-                  onClick={() => setOpen(true)}
-                  disabled={updateIntegration.isPending}
-                >
-                  <SquarePen />
-                  {updateIntegration.isPending ? "Updating..." : "Update"}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={handleRemove}
-                  disabled={removeItem.isPending}
-                  variant="destructive"
-                >
-                  <TrashIcon strokeWidth={3} /> Delete Integration
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <MoreVerticalDropdownMenu
+              contentClassName="w-[200px]"
+              items={[
+                {
+                  items: [
+                    {
+                      label: updateIntegration.isPending
+                        ? "Updating..."
+                        : "Update",
+                      icon: <SquarePen />,
+                      onClick: () => setOpen(true),
+                      disabled: updateIntegration.isPending,
+                    },
+                  ],
+                },
+                {
+                  items: [
+                    {
+                      label: "Delete Integration",
+                      icon: <TrashIcon strokeWidth={3} />,
+                      onClick: handleRemove,
+                      disabled: removeItem.isPending,
+                      variant: "destructive",
+                    },
+                  ],
+                },
+              ]}
+            />
 
             {open && (
               <IntegrationCreateModal

--- a/src/features/integrations/components/columns.tsx
+++ b/src/features/integrations/components/columns.tsx
@@ -28,7 +28,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  IntegrationType,
   type ResourceType,
   SyncStatusEnum,
 } from "@/generated/prisma";
@@ -78,7 +77,7 @@ export const getIntegrationColumns = (
       cell: ({ row }) => {
         return (
           <div className="flex gap-1 items-center">
-            {row.original.integrationType === IntegrationType.AI && (
+            {row.original.integrationType === "AI" && (
               <Sparkles size={15} />
             )}
             <div className="font-semibold max-w-60 overflow-ellipsis overflow-hidden">

--- a/src/features/integrations/components/integrations-layout.tsx
+++ b/src/features/integrations/components/integrations-layout.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { INTEGRATION_SYNC_EVERY_MIN, mainPadding } from "@/config/constants";
 import { SettingsSubheader } from "@/features/settings/components/settings-layout";
-import { AuthType } from "@/generated/prisma";
+import { AuthType, IntegrationType } from "@/generated/prisma";
 import { cn } from "@/lib/utils";
 import { useCreateIntegration } from "../hooks/use-integrations";
 import {
@@ -41,7 +41,7 @@ export const IntegrationsLayout = ({
       resourceType,
       integrationUri: "",
       prompt: "",
-      isGeneric: false,
+      integrationType: IntegrationType.PARTNER,
       syncEvery: INTEGRATION_SYNC_EVERY_MIN * 60,
       authType: AuthType.None,
     },

--- a/src/features/integrations/components/integrations.tsx
+++ b/src/features/integrations/components/integrations.tsx
@@ -43,7 +43,11 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Textarea } from "@/components/ui/textarea";
 import { INTEGRATION_SYNC_EVERY_MIN } from "@/config/constants";
 import { getIntegrationColumns } from "@/features/integrations/components/columns";
-import type { ResourceType, SyncStatusEnum } from "@/generated/prisma";
+import {
+  IntegrationType,
+  type ResourceType,
+  type SyncStatusEnum,
+} from "@/generated/prisma";
 import { useEntitySearch } from "@/hooks/use-entity-search";
 import { usePaginationParams } from "@/lib/pagination";
 import { cn } from "@/lib/utils";
@@ -136,28 +140,40 @@ export const IntegrationCreateModal = ({
   };
 
   const isPending = form.formState.isSubmitting;
-  const isGeneric = form.watch("isGeneric");
+  const integrationType = form.watch("integrationType");
   const verbLabel = isUpdate ? "Update" : "Create";
   const label = `${verbLabel} ${!isUpdate ? "New" : ""} ${resourceType || ""} Integration`;
 
   const integrationTypes = [
     {
-      value: false,
-      id: "standard",
+      value: IntegrationType.PARTNER,
+      id: "partner",
       title: "Standard Integration",
       description: "Pre-configured platforms with built-in support",
       badge: "e.g., BlueFlow, Helm",
       icon: null,
     },
     {
-      value: true,
+      value: IntegrationType.AI,
       id: "ai",
       title: "AI Integration",
       description: "Flexible setup for any custom platform",
       badge: "Universal & Adaptive",
       icon: <Sparkles size={15} />,
     },
-  ] as const;
+    ...(resourceType === "Vulnerability"
+      ? [
+          {
+            value: IntegrationType.CSAF,
+            id: "csaf",
+            title: "CSAF Integration",
+            description: "Parse machine-readable CSAF security advisories",
+            badge: "CSAF 2.0",
+            icon: null,
+          },
+        ]
+      : []),
+  ];
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -177,16 +193,14 @@ export const IntegrationCreateModal = ({
             <div className="no-scrollbar -mx-6 px-6 py-4 max-h-[60vh] overflow-y-auto grid gap-6">
               <FormField
                 control={form.control}
-                name="isGeneric"
+                name="integrationType"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Integration Type *</FormLabel>
                     <FormControl>
                       <RadioGroup
-                        onValueChange={(value) =>
-                          field.onChange(value === "true")
-                        }
-                        value={field.value ? "true" : "false"}
+                        onValueChange={field.onChange}
+                        value={field.value}
                         className="grid grid-cols-2 gap-4"
                       >
                         {integrationTypes.map((type) => {
@@ -245,7 +259,7 @@ export const IntegrationCreateModal = ({
                   </FormItem>
                 )}
               />
-              {isGeneric && (
+              {integrationType === IntegrationType.AI && (
                 <Alert className="border-blue-200 bg-blue-50">
                   <AlertCircleIcon className="stroke-blue-900" />
                   <AlertDescription className="text-blue-900">
@@ -329,7 +343,7 @@ export const IntegrationCreateModal = ({
                 )}
               />
 
-              {isGeneric && (
+              {integrationType === IntegrationType.AI && (
                 <FormField
                   control={form.control}
                   name="prompt"

--- a/src/features/integrations/types.ts
+++ b/src/features/integrations/types.ts
@@ -12,19 +12,30 @@ export const resourceTypeSchema = z.enum([
   "Remediation",
 ]);
 
-export const integrationInputSchema = authSchema.safeExtend({
-  name: z.string().min(1, "Name is required"),
-  platform: z.string().optional(),
-  integrationUri: safeUrlSchema,
-  isGeneric: z.boolean(),
-  prompt: z.string().optional(),
-  resourceType: resourceTypeSchema,
-  syncEvery: z
-    .number()
-    .int()
-    .positive()
-    .min(INTEGRATION_SYNC_EVERY_MIN * 60),
-});
+export const integrationInputSchema = authSchema
+  .safeExtend({
+    name: z.string().min(1, "Name is required"),
+    platform: z.string().optional(),
+    integrationUri: safeUrlSchema,
+    integrationType: z.enum(["PARTNER", "AI", "CSAF"]),
+    prompt: z.string().optional(),
+    resourceType: resourceTypeSchema,
+    syncEvery: z
+      .number()
+      .int()
+      .positive()
+      .min(INTEGRATION_SYNC_EVERY_MIN * 60),
+  })
+  .refine(
+    (data) =>
+      data.integrationType !== "CSAF" ||
+      data.resourceType === ResourceType.Vulnerability,
+    {
+      message:
+        "CSAF integrations are only available for Vulnerability resource type",
+      path: ["integrationType"],
+    },
+  );
 export type IntegrationFormValues = z.infer<typeof integrationInputSchema>;
 
 export function isValidResourceTypeKey(

--- a/src/features/issues/components/issue.tsx
+++ b/src/features/issues/components/issue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BugIcon, ComputerIcon, MoreVertical } from "lucide-react";
+import { BugIcon, ComputerIcon } from "lucide-react";
 import Link from "next/link";
 import {
   EntityContainer,
@@ -8,13 +8,7 @@ import {
   LoadingView,
 } from "@/components/entity-components";
 import { StatusFormBase, statusDetails } from "@/components/status-form";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import { AssetItem } from "@/features/assets/components/assets";
 import { locationSchema } from "@/features/assets/types";
 import { getAssetRoleLabel } from "@/features/assets/utils";
@@ -176,52 +170,29 @@ export const IssuesSidebarList = ({
                   </>
                 )}
 
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    asChild
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                      <span className="sr-only">Open menu</span>
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-[200px]">
-                    <DropdownMenuItem
-                      onClick={(e) => e.stopPropagation()}
-                      className="cursor-pointer"
-                      asChild
-                    >
-                      <Link href={`/issues/${issue.id}`}>
-                        Go to Issue Details
-                      </Link>
-                    </DropdownMenuItem>
-                    {type === "vulnerabilities" && (
-                      <DropdownMenuItem
-                        onClick={(e) => e.stopPropagation()}
-                        className="cursor-pointer"
-                        asChild
-                      >
-                        <Link
-                          href={`/vulnerabilities/${issue.vulnerabilityId}`}
-                        >
-                          Go to Vulnerability Details
-                        </Link>
-                      </DropdownMenuItem>
-                    )}
-                    {type === "assets" && (
-                      <DropdownMenuItem
-                        onClick={(e) => e.stopPropagation()}
-                        className="cursor-pointer"
-                        asChild
-                      >
-                        <Link href={`/assets/${issue.assetId}`}>
-                          Go to Asset Details
-                        </Link>
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <MoreVerticalDropdownMenu
+                  contentClassName="w-[200px]"
+                  items={[
+                    {
+                      label: "Go to Issue Details",
+                      href: `/issues/${issue.id}`,
+                      stopPropagation: true,
+                      className: "cursor-pointer",
+                    },
+                    type === "vulnerabilities" && {
+                      label: "Go to Vulnerability Details",
+                      href: `/vulnerabilities/${issue.vulnerabilityId}`,
+                      stopPropagation: true,
+                      className: "cursor-pointer",
+                    },
+                    type === "assets" && {
+                      label: "Go to Asset Details",
+                      href: `/assets/${issue.assetId}`,
+                      stopPropagation: true,
+                      className: "cursor-pointer",
+                    },
+                  ]}
+                />
               </Link>
             </li>
           );

--- a/src/features/issues/components/issue.tsx
+++ b/src/features/issues/components/issue.tsx
@@ -176,19 +176,16 @@ export const IssuesSidebarList = ({
                     {
                       label: "Go to Issue Details",
                       href: `/issues/${issue.id}`,
-                      stopPropagation: true,
                       className: "cursor-pointer",
                     },
                     type === "vulnerabilities" && {
                       label: "Go to Vulnerability Details",
                       href: `/vulnerabilities/${issue.vulnerabilityId}`,
-                      stopPropagation: true,
                       className: "cursor-pointer",
                     },
                     type === "assets" && {
                       label: "Go to Asset Details",
                       href: `/assets/${issue.assetId}`,
-                      stopPropagation: true,
                       className: "cursor-pointer",
                     },
                   ]}

--- a/src/features/issues/components/issue.tsx
+++ b/src/features/issues/components/issue.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { BugIcon, ChevronDown, ComputerIcon, MoreVertical } from "lucide-react";
+import { BugIcon, ComputerIcon, MoreVertical } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
 import {
   EntityContainer,
   ErrorView,
   LoadingView,
 } from "@/components/entity-components";
-import { Badge } from "@/components/ui/badge";
+import { StatusFormBase, statusDetails } from "@/components/status-form";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -29,19 +28,7 @@ import {
 } from "../hooks/use-issues";
 import type { IssueWithRelations } from "../types";
 
-const statusDetails = {
-  [IssueStatus.FALSE_POSITIVE]: {
-    name: "False Positive",
-    color: "bg-yellow-500",
-  },
-  [IssueStatus.ACTIVE]: { name: "Active", color: "bg-red-500" },
-  [IssueStatus.REMEDIATED]: { name: "Remediated", color: "bg-green-500" },
-};
-
-export const IssueStatusBadge = ({ status }: { status: IssueStatus }) => {
-  const statusDetail = statusDetails[status];
-  return <Badge className={statusDetail.color}>{statusDetail.name}</Badge>;
-};
+export { IssueStatusBadge } from "@/components/status-form";
 
 export const IssueLoading = () => {
   return <LoadingView message="Loading issue..." />;
@@ -62,63 +49,14 @@ export const IssueStatusForm = ({
   issue: Issue | IssueWithRelations;
   className?: string;
 }) => {
-  const [status, setStatus] = useState<IssueStatus>(issue.status);
   const updateIssueStatus = useUpdateIssueStatus();
-  const lastSubmittedStatusRef = useRef<IssueStatus>(issue.status);
-
-  useEffect(() => {
-    // Don't submit if status hasn't changed or if we already submitted this status
-    if (status === issue.status || status === lastSubmittedStatusRef.current) {
-      return;
-    }
-
-    const updateStatus = async () => {
-      lastSubmittedStatusRef.current = status;
-      try {
-        await updateIssueStatus.mutateAsync({
-          id: issue.id,
-          status: status,
-        });
-      } catch {
-        setStatus(issue.status);
-        lastSubmittedStatusRef.current = issue.status;
-      }
-    };
-
-    updateStatus();
-  }, [status, issue.id, issue.status, updateIssueStatus]);
-
-  const statusDetail = statusDetails[status];
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        asChild
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-        className={className}
-      >
-        <Badge className={statusDetail.color}>
-          {statusDetail.name} <ChevronDown className="ml-2" />
-        </Badge>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {Object.values(IssueStatus)
-          .filter((s) => s !== status)
-          .map((s) => (
-            <DropdownMenuItem
-              onClick={(e) => {
-                e.stopPropagation();
-                setStatus(s);
-              }}
-              key={s}
-            >
-              <IssueStatusBadge status={s} />
-            </DropdownMenuItem>
-          ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <StatusFormBase
+      id={issue.id}
+      initialStatus={issue.status}
+      onUpdate={(input) => updateIssueStatus.mutateAsync(input)}
+      className={className}
+    />
   );
 };
 

--- a/src/features/user/server/params-loader.ts
+++ b/src/features/user/server/params-loader.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { createLoader } from "nuqs/server";
 import { apiTokenParams } from "../params";
 

--- a/src/features/vulnerabilities/components/prioritized-columns.tsx
+++ b/src/features/vulnerabilities/components/prioritized-columns.tsx
@@ -2,18 +2,10 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { SortableHeader } from "@/components/ui/data-table";
-
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import { QuestionTooltip } from "@/components/ui/question-tooltip";
 import {
   Tooltip,
@@ -139,24 +131,15 @@ export const issueColumns: ColumnDef<VulnerabilityIssue>[] = [
     id: "actions",
     header: "",
     cell: ({ row }) => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-            <span className="sr-only">Open menu</span>
-            <MoreVertical className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <Link href={`/assets/${row.original.asset.id}`}>
-              Go to Asset Details
-            </Link>
-          </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href={`/issues/${row.original.id}`}>Go to Issue Details</Link>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <MoreVerticalDropdownMenu
+        items={[
+          {
+            label: "Go to Asset Details",
+            href: `/assets/${row.original.asset.id}`,
+          },
+          { label: "Go to Issue Details", href: `/issues/${row.original.id}` },
+        ]}
+      />
     ),
   },
 ];

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -206,8 +206,12 @@ export const syncIntegration = inngest.createFunction(
       try {
         if (integration.integrationType === IntegrationType.AI) {
           return await syncAiIntegration(integration);
-        } else {
+        } else if (integration.integrationType === IntegrationType.PARTNER) {
           return await syncPartnerIntegration(integration);
+        } else if (integration.integrationType === IntegrationType.CSAF) {
+          throw "TODO: VW-227";
+        } else {
+          throw "Invalid integration type";
         }
       } catch (error) {
         return {

--- a/src/inngest/functions/sync-integrations.ts
+++ b/src/inngest/functions/sync-integrations.ts
@@ -7,7 +7,7 @@ import type { IntegrationWithStringDates } from "@/features/integrations/types";
 import { integrationRemediationInputSchema } from "@/features/remediations/types";
 import { integrationVulnerabilityInputSchema } from "@/features/vulnerabilities/types";
 import type { ResourceType } from "@/generated/prisma";
-import { AuthType, SyncStatusEnum } from "@/generated/prisma";
+import { AuthType, IntegrationType, SyncStatusEnum } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { createUserToken, DEFAULT_TOKEN_TTL_SECONDS } from "@/lib/tokens";
 import { getBaseUrl } from "@/lib/url-utils";
@@ -204,7 +204,7 @@ export const syncIntegration = inngest.createFunction(
 
     const syncResult = await step.run("fetch-integration-data", async () => {
       try {
-        if (integration.isGeneric) {
+        if (integration.integrationType === IntegrationType.AI) {
           return await syncAiIntegration(integration);
         } else {
           return await syncPartnerIntegration(integration);

--- a/src/lib/csaf.ts
+++ b/src/lib/csaf.ts
@@ -13,6 +13,7 @@ export interface CsafReference {
 export interface CsafRemediation {
   category: string;
   details: string;
+  url?: string;
 }
 
 export interface CsafVulnerability {
@@ -88,6 +89,7 @@ export function parseCsaf(csaf: unknown): ParsedCsaf {
         return {
           category: asString(rem.category),
           details: asString(rem.details),
+          url: rem.url ? asString(rem.url) : undefined,
         };
       },
     );

--- a/src/lib/csaf.ts
+++ b/src/lib/csaf.ts
@@ -1,0 +1,104 @@
+export interface CsafNote {
+  title: string;
+  text: string;
+  category: string;
+}
+
+export interface CsafReference {
+  url: string;
+  summary: string;
+  category: string;
+}
+
+export interface CsafRemediation {
+  category: string;
+  details: string;
+}
+
+export interface CsafVulnerability {
+  cve: string;
+  /** baseSeverity from scores[0].cvss_v3 e.g. "CRITICAL", "HIGH" */
+  severity: string | null;
+  /** text of the note where category === "summary" */
+  summary: string | null;
+  remediations: CsafRemediation[];
+}
+
+export interface ParsedCsaf {
+  notes: CsafNote[];
+  references: CsafReference[];
+  vulnerabilities: CsafVulnerability[];
+}
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function asObject(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : {};
+}
+
+export function parseCsaf(csaf: unknown): ParsedCsaf {
+  const root = asObject(csaf);
+  const document = asObject(root.document);
+
+  const notes: CsafNote[] = asArray(document.notes).map((n) => {
+    const note = asObject(n);
+    return {
+      title: asString(note.title),
+      text: asString(note.text),
+      category: asString(note.category),
+    };
+  });
+
+  const references: CsafReference[] = asArray(document.references).map((r) => {
+    const ref = asObject(r);
+    return {
+      url: asString(ref.url),
+      summary: asString(ref.summary),
+      category: asString(ref.category),
+    };
+  });
+
+  const vulnerabilities: CsafVulnerability[] = asArray(
+    root.vulnerabilities,
+  ).map((v) => {
+    const vuln = asObject(v);
+
+    const scores = asArray(vuln.scores);
+    const firstScore = asObject(scores[0]);
+    const cvssV3 = asObject(firstScore.cvss_v3);
+    const severity = cvssV3.baseSeverity ? asString(cvssV3.baseSeverity) : null;
+
+    const vulnNotes = asArray(vuln.notes);
+    const summaryNote = vulnNotes
+      .map(asObject)
+      .find((n) => n.category === "summary");
+    const summary = summaryNote ? asString(summaryNote.text) : null;
+
+    const remediations: CsafRemediation[] = asArray(vuln.remediations).map(
+      (r) => {
+        const rem = asObject(r);
+        return {
+          category: asString(rem.category),
+          details: asString(rem.details),
+        };
+      },
+    );
+
+    return {
+      cve: asString(vuln.cve),
+      severity,
+      summary,
+      remediations,
+    };
+  });
+
+  return { notes, references, vulnerabilities };
+}

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,3 +1,4 @@
+import { advisoriesRouter } from "@/features/advisories/server/routers";
 import { apiKeyConnectorsRouter } from "@/features/api-key-connectors/server/routers";
 import { artifactsRouter } from "@/features/artifacts/server/routers";
 import { assetsRouter } from "@/features/assets/server/routers";
@@ -14,6 +15,7 @@ import { workflowsRouter } from "@/features/workflows/server/routers";
 import { createTRPCRouter } from "../init";
 
 export const appRouter = createTRPCRouter({
+  advisories: advisoriesRouter,
   workflows: workflowsRouter,
   assets: assetsRouter,
   vulnerabilities: vulnerabilitiesRouter,


### PR DESCRIPTION
* Adds "Advisories" model, and CSAF as an integration type (but only for vulnerability integrations). [CSAF is the common security advisory framework](https://www.csaf.io/specification/), and is used by CISA-ICS, Siemens, Microsoft, and a few other vendors to produce machine-readable security advisories
* Advisories are currently only populated via a seed script. This is to demo how they appear on the site. Future work will be needed to automatically sync with existing CSAF sources (VW-227)
* Re-usable dropdown component for "MoreVertical" menus, re-usable severity badge component

This ticket would close VW-223, VW-224, and VW-225.

Preview, I seeded the db for testing: https://viper-34kf15tqp-pulse-team-dcb08ec2.vercel.app/advisories/cmnhtgv020025y9lilofmvcpa

Screenshots of vercel preview pages below


<img width="3426" height="5848" alt="Screenshot of advisories detail page" src="https://github.com/user-attachments/assets/59ea3556-913f-49f4-8af5-e000bb1df74b" />

<img width="3456" height="2000" alt="screenshot of advisories list page" src="https://github.com/user-attachments/assets/8a4a6262-6dc7-4930-b627-6c7c71ebd84f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Advisories experience: list and detail pages, search, pagination, sidebar entry and navigation.
  * Advisory detail: CSAF-parsed notes, references, vulnerabilities, severity, TLP badges, affected assets and progress.
  * Inline status editor with save feedback.

* **UX / UI**
  * Unified "more" action menus across tables for consistent per-row actions and links.
  * New severity badge component and improved TLP display.

* **Integrations**
  * Integration creation uses explicit Integration Type (AI / Partner / CSAF).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->