### PR TITLE
[VW-218] deviceArtifact hosting in S3

### DIFF
--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -211,10 +211,12 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       .post("/deviceArtifacts")
       .set(authHeader)
       .send(payload);
+    const createdDeviceArtifact = createRes.body.deviceArtifact;
 
     expect(createRes.status).toBe(200);
-    expect(createRes.body).toHaveProperty("id");
-    const deviceArtifactId = createRes.body.id;
+    expect(createRes.body).toHaveProperty("deviceArtifact");
+    expect(createRes.body).toHaveProperty("uploadInstructions");
+    const deviceArtifactId = createdDeviceArtifact.id;
 
     onTestFinished(async () => {
       // Cleanup - delete the device artifact (which cascades to artifacts)
@@ -228,16 +230,16 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     });
 
     // Verify the response structure
-    expect(createRes.body).toHaveProperty("deviceGroup");
-    expect(createRes.body.deviceGroup).toEqual(
+    expect(createdDeviceArtifact).toHaveProperty("deviceGroup");
+    expect(createdDeviceArtifact.deviceGroup).toEqual(
       expect.objectContaining({ cpe: payload.cpe }),
     );
 
-    expect(createRes.body).toHaveProperty("artifacts");
-    expect(Array.isArray(createRes.body.artifacts)).toBe(true);
-    expect(createRes.body.artifacts.length).toBe(1);
-    expect(createRes.body.artifacts[0]).toHaveProperty("latestArtifact");
-    expect(createRes.body.artifacts[0].latestArtifact).toEqual(
+    expect(createdDeviceArtifact).toHaveProperty("artifacts");
+    expect(Array.isArray(createdDeviceArtifact.artifacts)).toBe(true);
+    expect(createdDeviceArtifact.artifacts.length).toBe(1);
+    expect(createdDeviceArtifact.artifacts[0]).toHaveProperty("latestArtifact");
+    expect(createdDeviceArtifact.artifacts[0].latestArtifact).toEqual(
       expect.objectContaining({
         name: payload.artifacts[0].name,
         artifactType: payload.artifacts[0].artifactType,
@@ -246,8 +248,8 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       }),
     );
 
-    expect(createRes.body.role).toBe(payload.role);
-    expect(createRes.body.description).toBe(payload.description);
+    expect(createdDeviceArtifact.role).toBe(payload.role);
+    expect(createdDeviceArtifact.description).toBe(payload.description);
 
     // Get single device artifact
     const getOneRes = await request(BASE_URL)
@@ -343,11 +345,12 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       .post("/deviceArtifacts")
       .set(authHeader)
       .send(multiArtifactPayload);
+    const createdDeviceArtifact = createRes.body.deviceArtifact;
 
     onTestFinished(async () => {
       await prisma.deviceArtifact
         .delete({
-          where: { id: createRes.body.id },
+          where: { id: createdDeviceArtifact.id },
         })
         .catch(() => {
           /* already deleted */
@@ -355,10 +358,11 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     });
 
     expect(createRes.status).toBe(200);
-    expect(createRes.body.artifacts.length).toBe(4);
+    expect(createRes.body).toHaveProperty("uploadInstructions");
+    expect(createdDeviceArtifact.artifacts.length).toBe(4);
 
     // Verify each artifact was created correctly
-    const artifactTypes = createRes.body.artifacts.map(
+    const artifactTypes = createdDeviceArtifact.artifacts.map(
       (wrapper: ArtifactWrapperWithUrls) => wrapper.latestArtifact.artifactType,
     );
     expect(artifactTypes).toContain(ArtifactType.Firmware);
@@ -382,7 +386,9 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     );
 
     const createResults = await Promise.all(createPromises);
-    const deviceArtifactIds = createResults.map((r) => r.body.id);
+    const deviceArtifactIds = createResults.map(
+      (r) => r.body.deviceArtifact.id,
+    );
 
     onTestFinished(async () => {
       await Promise.all(
@@ -424,7 +430,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
       });
 
     expect(createRes.status).toBe(200);
-    const deviceArtifactId = createRes.body.id;
+    const deviceArtifactId = createRes.body.deviceArtifact.id;
 
     onTestFinished(async () => {
       await prisma.deviceArtifact
@@ -475,17 +481,17 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     expect(createRes1.status).toBe(200);
     expect(createRes2.status).toBe(200);
 
-    const deviceGroupId1 = createRes1.body.deviceGroup.id;
-    const deviceGroupId2 = createRes2.body.deviceGroup.id;
+    const deviceGroupId1 = createRes1.body.deviceArtifact.deviceGroup.id;
+    const deviceGroupId2 = createRes2.body.deviceArtifact.deviceGroup.id;
 
     onTestFinished(async () => {
       await prisma.deviceArtifact
-        .delete({ where: { id: createRes1.body.id } })
+        .delete({ where: { id: createRes1.body.deviceArtifact.id } })
         .catch(() => {
           /* already deleted */
         });
       await prisma.deviceArtifact
-        .delete({ where: { id: createRes2.body.id } })
+        .delete({ where: { id: createRes2.body.deviceArtifact.id } })
         .catch(() => {
           /* already deleted */
         });

--- a/src/features/artifacts/types.ts
+++ b/src/features/artifacts/types.ts
@@ -68,11 +68,24 @@ export const artifactUpdateSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
   artifactType: z.enum(ArtifactType).optional(),
+  downloadUrl: safeUrlSchema.nullish(),
+  hash: z.string().nullish(),
   size: z.number().optional(),
 });
 
 export const createArtifactVersionSchema = artifactInputSchema.extend({
   wrapperId: z.string(),
+});
+
+const uploadInstructionsSchema = z.object({
+  artifactName: z.string(),
+  uploadUrl: z.string().url(),
+  requiredHeader: z.string(),
+});
+
+export const artifactUploadResponseSchema = z.object({
+  artifact: artifactWithUrlsSchema,
+  uploadInstructions: z.array(uploadInstructionsSchema),
 });
 
 export const paginatedArtifactResponseSchema = createPaginatedResponseSchema(

--- a/src/features/device-artifacts/hooks/use-device-artifacts.ts
+++ b/src/features/device-artifacts/hooks/use-device-artifacts.ts
@@ -57,7 +57,7 @@ export const useCreateDeviceArtifact = () => {
   return useMutation(
     trpc.deviceArtifacts.create.mutationOptions({
       onSuccess: (data) => {
-        toast.success(`DeviceArtifact "${data.role}" created`);
+        toast.success(`DeviceArtifact "${data.deviceArtifact.role}" created`);
         invalidateDeviceArtifactQueries(queryClient, trpc);
       },
       onError: (error) => {

--- a/src/features/device-artifacts/server/routers.ts
+++ b/src/features/device-artifacts/server/routers.ts
@@ -23,9 +23,9 @@ import {
   deviceArtifactInputSchema,
   deviceArtifactResponseSchema,
   deviceArtifactUpdateSchema,
+  deviceArtifactUploadResponseSchema,
   integrationDeviceArtifactInputSchema,
   paginatedDeviceArtifactResponseSchema,
-  deviceArtifactUploadResponseSchema,
 } from "../types";
 
 // TODO: do something DRY with `createSearchFilter` in other routers

--- a/src/features/device-artifacts/server/routers.ts
+++ b/src/features/device-artifacts/server/routers.ts
@@ -10,6 +10,7 @@ import {
   processIntegrationToken,
   transformArtifactWrapper,
 } from "@/lib/router-utils";
+import { processArtifactHosting } from "@/lib/s3";
 import { integrationResponseSchema } from "@/lib/schemas";
 import {
   baseProcedure,
@@ -24,6 +25,7 @@ import {
   deviceArtifactUpdateSchema,
   integrationDeviceArtifactInputSchema,
   paginatedDeviceArtifactResponseSchema,
+  deviceArtifactUploadResponseSchema,
 } from "../types";
 
 // TODO: do something DRY with `createSearchFilter` in other routers
@@ -169,14 +171,22 @@ export const deviceArtifactsRouter = createTRPCRouter({
         path: "/deviceArtifacts",
         tags: ["DeviceArtifacts"],
         summary: "Create DeviceArtifact",
-        description:
-          "Create a new DeviceArtifact. The authenticated user will be recorded as the creator.",
+        description: `
+          Create a new DeviceArtifact. The authenticated user will be recorded as the creator.
+          
+          **Artifact hosting**
+          See docs/upload_artifact.md
+          `.trim(),
       },
     })
-    .output(deviceArtifactResponseSchema)
+    .output(deviceArtifactUploadResponseSchema)
     .mutation(async ({ ctx, input }) => {
       const deviceGroup = await cpeToDeviceGroup(input.cpe);
       const userId = ctx.auth.user.id;
+
+      // Handle S3 upload URL -- if the user included a hash/size but no downloadUrl, they want us to host it
+      const { processedArtifacts, uploadInstructions } =
+        await processArtifactHosting(input.artifacts);
 
       // Create device artifact with wrappers and initial artifacts in a transaction
       const result = await prisma.$transaction(async (tx) => {
@@ -193,7 +203,7 @@ export const deviceArtifactsRouter = createTRPCRouter({
 
         await createArtifactWrappers(
           tx,
-          input.artifacts,
+          processedArtifacts,
           deviceArtifact.id,
           "deviceArtifactId",
           userId,
@@ -206,9 +216,13 @@ export const deviceArtifactsRouter = createTRPCRouter({
         });
       });
 
-      return transformArtifactWrapper(result);
+      return {
+        deviceArtifact: transformArtifactWrapper(result),
+        uploadInstructions: uploadInstructions,
+      };
     }),
 
+  // POST - Device artifact integrations
   processIntegrationCreate: baseProcedure
     .input(integrationDeviceArtifactInputSchema)
     .meta({

--- a/src/features/device-artifacts/types.ts
+++ b/src/features/device-artifacts/types.ts
@@ -53,6 +53,17 @@ export type DeviceArtifactResponse = z.infer<
   typeof deviceArtifactResponseSchema
 >;
 
+const uploadInstructionsSchema = z.object({
+  artifactName: z.string(),
+  uploadUrl: z.string().url(),
+  requiredHeader: z.string(),
+});
+
+export const deviceArtifactUploadResponseSchema = z.object({
+  deviceArtifact: deviceArtifactResponseSchema,
+  uploadInstructions: z.array(uploadInstructionsSchema),
+});
+
 export const paginatedDeviceArtifactResponseSchema =
   createPaginatedResponseSchema(deviceArtifactResponseSchema);
 

--- a/src/features/remediations/server/routers.ts
+++ b/src/features/remediations/server/routers.ts
@@ -140,7 +140,7 @@ export const remediationsRouter = createTRPCRouter({
       const deviceGroups = await cpesToDeviceGroups(uniqueCpes);
       const userId = ctx.auth.user.id;
 
-      // Handle S3 URL -- if the user included a hash/size but no downloadUrl, they want us to host it
+      // Handle S3 upload URL -- if the user included a hash/size but no downloadUrl, they want us to host it
       const { processedArtifacts, uploadInstructions } =
         await processArtifactHosting(artifacts);
 


### PR DESCRIPTION
- Related to VW-218, but sort of also a VW-0 cleanup. 
- S3 hosting was originally only setup for remediations in VW-61; this PR extends that to deviceArtifacts for Vanderbilt's use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device artifact creation now returns upload instructions (URLs and required headers) alongside the created artifact.
  * Artifact metadata updates now accept download URLs, content hashes, and file sizes.

* **Documentation**
  * API create endpoint docs updated to include artifact hosting/upload guidance.

* **Tests**
  * Integration tests updated to validate the new response shape and upload instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->