### PR TITLE
[VW-249] Have AI generate title for conversations based on first exchange

### DIFF
--- a/src/app/api/inngest/realtime.ts
+++ b/src/app/api/inngest/realtime.ts
@@ -4,6 +4,8 @@ import "server-only";
 import type { AgentMessageChunk } from "@inngest/agent-kit";
 import { channel, topic } from "@inngest/realtime";
 
-export const createChannel = channel(
-  (userId: string) => `user:${userId}`,
-).addTopic(topic("agent_stream").type<AgentMessageChunk>());
+export const createChannel = channel((userId: string) => `user:${userId}`)
+  .addTopic(topic("agent_stream").type<AgentMessageChunk>())
+  .addTopic(
+    topic("thread_updated").type<{ threadId: string; title: string }>(),
+  );

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -540,6 +540,7 @@ function ChatInputForm({
   hasActiveQuestions: boolean;
 }) {
   const { userRole, setUserRole } = useChatUI();
+  const formRef = useRef<HTMLFormElement>(null);
 
   const inputPlaceholder = (() => {
     switch (true) {
@@ -557,18 +558,26 @@ function ChatInputForm({
   return (
     <div className="border-t p-4">
       <form
+        ref={formRef}
         onSubmit={onSubmit}
         className={cn(
           "flex flex-col border-2 rounded-xl bg-background drop-shadow-accent drop-shadow-sm focus-within:drop-shadow-md focus-within:border-primary transition-colors",
           isDisabled ? "cursor-not-allowed" : "",
         )}
       >
-        <input
+        <textarea
           value={input}
           onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              formRef.current?.requestSubmit();
+            }
+          }}
+          rows={1}
           placeholder={inputPlaceholder}
           disabled={isDisabled}
-          className="flex-1 border-0 drop-shadow-none text-sm outline-0 selection:outline-0 focus:outline-0 p-2"
+          className="w-full resize-none border-0 drop-shadow-none text-sm outline-0 selection:bg-primary/25 focus:outline-0 p-2 overflow-y-auto max-h-32 field-sizing-content"
         />
         <div className="flex items-center justify-end gap-1.5 text-xs text-muted-foreground whitespace-nowrap p-1">
           <span>Ask as</span>
@@ -633,13 +642,33 @@ function ThreadSelector({
     }
   };
 
-  // Radix SelectValue caches the trigger label from the SelectItem matched at
-  // mount time. For a brand-new chat, the matching SelectItem only appears in
-  // `threads` after refreshThreads runs (post title-generation), so we re-mount
-  // the Select when that title flips in to force a fresh resolution.
+  // Add key to Select to force re-mount when thread title changes
   const currentTitle =
     threads.find((t) => t.id === currentThreadId)?.title ?? null;
-  const currentThreadExists = threads?.some(t => t.id === currentThreadId);
+  const currentThreadExists = threads?.some((t) => t.id === currentThreadId);
+
+  const [displayedTitle, setDisplayedTitle] = useState<string | null>(null);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (!currentTitle) {
+      setDisplayedTitle(null);
+      setIsAnimating(false);
+      return;
+    }
+    setDisplayedTitle("");
+    setIsAnimating(true);
+    let i = 0;
+    const id = setInterval(() => {
+      i++;
+      setDisplayedTitle(currentTitle.slice(0, i));
+      if (i >= currentTitle.length) {
+        clearInterval(id);
+        setIsAnimating(false);
+      }
+    }, 40);
+    return () => clearInterval(id);
+  }, [currentTitle]);
 
   return (
     <Select
@@ -651,12 +680,21 @@ function ThreadSelector({
       disabled={threadsLoading && threads.length === 0}
     >
       <SelectTrigger className="w-[240px]">
-        <SelectValue placeholder="New Chat" />
+        <SelectValue placeholder="New Chat">
+          {displayedTitle !== null ? (
+            <span className="truncate max-w-[200px] block">
+              {displayedTitle}
+              {isAnimating ? "▌" : ""}
+            </span>
+          ) : undefined}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent onScroll={handleScroll}>
         {threads.map((thread) => (
           <SelectItem key={thread.id} value={thread.id}>
-            <span className="truncate max-w-[200px] block">{thread.title || "New Chat"}</span>
+            <span className="truncate max-w-[200px] block">
+              {thread.title || "New Chat"}
+            </span>
           </SelectItem>
         ))}
         {threadsLoading && (
@@ -706,7 +744,7 @@ function ChatInner({
   const [input, setInput] = useState("");
   const [configOverride, setConfigOverride] =
     useState<Partial<UseChatAgentConfig>>();
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const isAgentBusy = status !== "ready" || !isConnected;
 
@@ -729,11 +767,8 @@ function ChatInner({
       if (override && Object.keys(override).length > 0) {
         setConfigOverride(override);
       }
-      // For a brand-new chat, currentThreadId is null and useAgent's internal
-      // sendMessage uses a hidden fallback UUID without ever syncing it back to
-      // currentThreadId — leaving the thread picker with no "selected" value.
-      // Materializing the thread explicitly gives us a stable id to send under
-      // and select against.
+      // Get threadId and use sendMessageToThread instead of sendMessage for
+      // persistent thread information
       const threadId = currentThreadId ?? agent.createNewThread();
       const effective = override ?? configOverride;
       const stateOverride =
@@ -764,8 +799,9 @@ function ChatInner({
   }, [currentThreadId]);
 
   useEffect(() => {
-    if (messages.length)
-      scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = containerRef.current;
+    if (messages.length && el)
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
   }, [messages]);
 
   useEffect(() => {
@@ -827,7 +863,7 @@ function ChatInner({
           )}
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div ref={containerRef} className="flex-1 overflow-y-auto p-4 space-y-4">
         {isLoadingInitialThread || isLoadingHistory ? (
           <ChatMessagesSkeletonList />
         ) : (
@@ -851,8 +887,6 @@ function ChatInner({
             )}
           </>
         )}
-
-        <div ref={scrollRef} />
       </div>
 
       {status === "error" && error && (

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -642,7 +642,7 @@ function ThreadSelector({
     }
   };
 
-  // Add key to Select to force re-mount when thread title changes
+  // add `key` to Select to force re-mount when thread title changes
   const currentTitle =
     threads.find((t) => t.id === currentThreadId)?.title ?? null;
   const currentThreadExists = threads?.some((t) => t.id === currentThreadId);
@@ -650,6 +650,7 @@ function ThreadSelector({
   const [displayedTitle, setDisplayedTitle] = useState<string | null>(null);
   const [isAnimating, setIsAnimating] = useState(false);
 
+  // animate the title as it comes in with type-writer effect
   useEffect(() => {
     if (!currentTitle) {
       setDisplayedTitle(null);

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -633,8 +633,16 @@ function ThreadSelector({
     }
   };
 
+  // Radix SelectValue caches the trigger label from the SelectItem matched at
+  // mount time. For a brand-new chat, the matching SelectItem only appears in
+  // `threads` after refreshThreads runs (post title-generation), so we re-mount
+  // the Select when that title flips in to force a fresh resolution.
+  const currentTitle =
+    threads.find((t) => t.id === currentThreadId)?.title ?? null;
+
   return (
     <Select
+      key={`${currentThreadId ?? "none"}:${currentTitle ?? ""}`}
       value={currentThreadId ?? ""}
       onValueChange={(val) => {
         if (val) selectThread(val);
@@ -676,7 +684,6 @@ function ChatInner({
   const agent = useChatAgent(config);
   const {
     messages,
-    sendMessage,
     sendMessageToThread,
     threads,
     currentThreadId,
@@ -721,23 +728,27 @@ function ChatInner({
       if (override && Object.keys(override).length > 0) {
         setConfigOverride(override);
       }
+      // For a brand-new chat, currentThreadId is null and useAgent's internal
+      // sendMessage uses a hidden fallback UUID without ever syncing it back to
+      // currentThreadId — leaving the thread picker with no "selected" value.
+      // Materializing the thread explicitly gives us a stable id to send under
+      // and select against.
+      const threadId = currentThreadId ?? agent.createNewThread();
       const effective = override ?? configOverride;
-      if (!effective || Object.keys(effective).length === 0) {
-        return sendMessage(message);
-      }
-      // Priority chain: effective override > page-level config > userRole base.
-      // Server (chat-agent.ts) defaults the agent when none is set.
-      const stateOverride = {
-        userRole,
-        ...config,
-        ...effective,
-      };
-      return sendMessageToThread(currentThreadId ?? "", message, {
-        state: stateOverride,
-      });
+      const stateOverride =
+        effective && Object.keys(effective).length > 0
+          ? // Priority chain: effective override > page-level config > userRole base.
+            // Server (chat-agent.ts) defaults the agent when none is set.
+            { userRole, ...config, ...effective }
+          : undefined;
+      return sendMessageToThread(
+        threadId,
+        message,
+        stateOverride ? { state: stateOverride } : undefined,
+      );
     },
     [
-      sendMessage,
+      agent.createNewThread,
       sendMessageToThread,
       currentThreadId,
       config,

--- a/src/features/chat/components/chat.tsx
+++ b/src/features/chat/components/chat.tsx
@@ -639,11 +639,12 @@ function ThreadSelector({
   // the Select when that title flips in to force a fresh resolution.
   const currentTitle =
     threads.find((t) => t.id === currentThreadId)?.title ?? null;
+  const currentThreadExists = threads?.some(t => t.id === currentThreadId);
 
   return (
     <Select
       key={`${currentThreadId ?? "none"}:${currentTitle ?? ""}`}
-      value={currentThreadId ?? ""}
+      value={currentThreadExists ? currentThreadId || "" : ""}
       onValueChange={(val) => {
         if (val) selectThread(val);
       }}
@@ -655,7 +656,7 @@ function ThreadSelector({
       <SelectContent onScroll={handleScroll}>
         {threads.map((thread) => (
           <SelectItem key={thread.id} value={thread.id}>
-            <span className="truncate max-w-[200px] block">{thread.title}</span>
+            <span className="truncate max-w-[200px] block">{thread.title || "New Chat"}</span>
           </SelectItem>
         ))}
         {threadsLoading && (

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useInngestSubscription } from "@inngest/realtime/hooks";
 import { useAgent } from "@inngest/use-agent";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -25,6 +26,10 @@ export function useChatAgent(config?: UseChatAgentConfig) {
     }),
   );
 
+  const { mutateAsync: fetchRealtimeToken } = useMutation(
+    trpc.chat.token.mutationOptions(),
+  );
+
   // Return [] so formatRawHistoryMessages (always called by useAgent) is bypassed.
   // Tool calls can't survive formatRawHistoryMessages — we inject full history via
   // replaceThreadMessages below instead.
@@ -43,9 +48,37 @@ export function useChatAgent(config?: UseChatAgentConfig) {
     fetchHistory,
   });
 
-  const { currentThreadId, replaceThreadMessages } = agent;
+  const { currentThreadId, replaceThreadMessages, refreshThreads } = agent;
   const loadedThreadRef = useRef<string | null>(null);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+  // Subscribe to thread_updated events so AI-generated titles appear without
+  // requiring a manual refresh. The server publishes after the first exchange
+  // in src/inngest/functions/chat-agent.ts.
+  const refreshTokenForTitle = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: token returned from getSubscriptionToken; structural shape matches what useInngestSubscription needs
+    async (): Promise<any> => fetchRealtimeToken({}),
+    [fetchRealtimeToken],
+  );
+  const { latestData: latestTitleUpdate } = useInngestSubscription({
+    refreshToken: refreshTokenForTitle,
+  });
+  const lastSeenTitleSignatureRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!latestTitleUpdate) return;
+    const msg = latestTitleUpdate as {
+      topic?: string;
+      data?: { threadId?: string; title?: string };
+    };
+    if (msg.topic !== "thread_updated") return;
+    const threadId = msg.data?.threadId;
+    const title = msg.data?.title;
+    if (!threadId || !title) return;
+    const sig = `${threadId}:${title}`;
+    if (lastSeenTitleSignatureRef.current === sig) return;
+    lastSeenTitleSignatureRef.current = sig;
+    refreshThreads();
+  }, [latestTitleUpdate, refreshThreads]);
 
   useEffect(() => {
     if (!currentThreadId || loadedThreadRef.current === currentThreadId) return;
@@ -62,7 +95,10 @@ export function useChatAgent(config?: UseChatAgentConfig) {
         replaceThreadMessages(currentThreadId, built);
       })
       .catch(() => {
-        // Thread not yet in DB (brand-new thread) — no history to inject
+        // Thread not yet in DB (brand-new thread created client-side via
+        // createNewThread). Mark history as loaded with no messages so the
+        // skeleton clears — without this, isLoadingInitialThread stays true.
+        replaceThreadMessages(currentThreadId, []);
       })
       .finally(() => {
         setIsLoadingHistory(false);

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -30,9 +30,9 @@ export function useChatAgent(config?: UseChatAgentConfig) {
     trpc.chat.token.mutationOptions(),
   );
 
-  // Return [] so formatRawHistoryMessages (always called by useAgent) is bypassed.
-  // Tool calls can't survive formatRawHistoryMessages — we inject full history via
-  // replaceThreadMessages below instead.
+  // Inngest's fetchHistory is broken, undocumented, and will not render tool
+  // calls. We set history to [] here and just handle getting messages for
+  // threads ourselves in a useEffect below.
   const fetchHistory = useCallback(
     async (_threadId: string): Promise<unknown[]> => [],
     [],
@@ -53,11 +53,9 @@ export function useChatAgent(config?: UseChatAgentConfig) {
   const freshThreadsRef = useRef<Set<string>>(new Set());
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
 
-  // Wraps useAgent.createNewThread so that, for threads we materialise
-  // client-side, we immediately flip historyLoaded=true (via an empty
-  // replaceThreadMessages) and mark the id as "fresh" so the history-load
-  // effect below skips the doomed DB fetch (the server only writes the
-  // ChatThread row once the Inngest function runs).
+  // Threads created client side don't exist in the db yet until messages get
+  // saved. Set `loadedThreadRef` so we skip a call to the db to get those
+  // threads' messages -- see the useEffect hook below this.
   const createNewThread = useCallback((): string => {
     const id = agent.createNewThread();
     freshThreadsRef.current.add(id);
@@ -94,11 +92,15 @@ export function useChatAgent(config?: UseChatAgentConfig) {
     refreshThreads();
   }, [latestTitleUpdate, refreshThreads]);
 
+  /* Use the getHistory trpc endpoint to get messages from the user
+   * use `buildConversationMessages` + `replaceThreadMessages to structure
+   * these for Inngest.
+   * If we're looking at a thread that was just created, skip the db call
+   * since that thread doesn't live in the db yet. */
   useEffect(() => {
     if (!currentThreadId || loadedThreadRef.current === currentThreadId) return;
     // Threads created client-side via the wrapped createNewThread above don't
-    // yet have a DB row; skip the fetch (the .catch path would otherwise wipe
-    // the user's just-sent message via replaceThreadMessages([])).
+    // yet have a DB row; skip the fetch
     if (freshThreadsRef.current.has(currentThreadId)) {
       loadedThreadRef.current = currentThreadId;
       return;
@@ -116,8 +118,7 @@ export function useChatAgent(config?: UseChatAgentConfig) {
         replaceThreadMessages(currentThreadId, built);
       })
       .catch(() => {
-        // Unknown thread (deep-linked to one that doesn't exist or isn't
-        // owned by this user). Leave messages untouched.
+        // Unknown thread? Leave messages untouched.
       })
       .finally(() => {
         setIsLoadingHistory(false);

--- a/src/features/chat/hooks/use-chat.ts
+++ b/src/features/chat/hooks/use-chat.ts
@@ -50,7 +50,21 @@ export function useChatAgent(config?: UseChatAgentConfig) {
 
   const { currentThreadId, replaceThreadMessages, refreshThreads } = agent;
   const loadedThreadRef = useRef<string | null>(null);
+  const freshThreadsRef = useRef<Set<string>>(new Set());
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+  // Wraps useAgent.createNewThread so that, for threads we materialise
+  // client-side, we immediately flip historyLoaded=true (via an empty
+  // replaceThreadMessages) and mark the id as "fresh" so the history-load
+  // effect below skips the doomed DB fetch (the server only writes the
+  // ChatThread row once the Inngest function runs).
+  const createNewThread = useCallback((): string => {
+    const id = agent.createNewThread();
+    freshThreadsRef.current.add(id);
+    loadedThreadRef.current = id;
+    replaceThreadMessages(id, []);
+    return id;
+  }, [agent, replaceThreadMessages]);
 
   // Subscribe to thread_updated events so AI-generated titles appear without
   // requiring a manual refresh. The server publishes after the first exchange
@@ -82,6 +96,13 @@ export function useChatAgent(config?: UseChatAgentConfig) {
 
   useEffect(() => {
     if (!currentThreadId || loadedThreadRef.current === currentThreadId) return;
+    // Threads created client-side via the wrapped createNewThread above don't
+    // yet have a DB row; skip the fetch (the .catch path would otherwise wipe
+    // the user's just-sent message via replaceThreadMessages([])).
+    if (freshThreadsRef.current.has(currentThreadId)) {
+      loadedThreadRef.current = currentThreadId;
+      return;
+    }
     loadedThreadRef.current = currentThreadId;
     setIsLoadingHistory(true);
 
@@ -95,10 +116,8 @@ export function useChatAgent(config?: UseChatAgentConfig) {
         replaceThreadMessages(currentThreadId, built);
       })
       .catch(() => {
-        // Thread not yet in DB (brand-new thread created client-side via
-        // createNewThread). Mark history as loaded with no messages so the
-        // skeleton clears — without this, isLoadingInitialThread stays true.
-        replaceThreadMessages(currentThreadId, []);
+        // Unknown thread (deep-linked to one that doesn't exist or isn't
+        // owned by this user). Leave messages untouched.
       })
       .finally(() => {
         setIsLoadingHistory(false);
@@ -110,5 +129,5 @@ export function useChatAgent(config?: UseChatAgentConfig) {
     trpc.chat.getHistory,
   ]);
 
-  return { ...agent, isLoadingHistory };
+  return { ...agent, createNewThread, isLoadingHistory };
 }

--- a/src/features/chat/server/routers.ts
+++ b/src/features/chat/server/routers.ts
@@ -71,7 +71,7 @@ export const chatRouter = createTRPCRouter({
 
       const result = await getSubscriptionToken(inngest, {
         channel: createChannel(channelKey),
-        topics: ["agent_stream"],
+        topics: ["agent_stream", "thread_updated"],
       });
 
       return result;

--- a/src/features/chat/viper-agent/agents/chat-agent.ts
+++ b/src/features/chat/viper-agent/agents/chat-agent.ts
@@ -1,12 +1,21 @@
-import { createAgent } from "@inngest/agent-kit";
+import {
+  createAgent,
+  type NetworkRun,
+  type StateData,
+} from "@inngest/agent-kit";
+import type { NetworkState } from "@/features/chat/types";
+import {
+  RECOMMENDATION_ROLE_INSTRUCTIONS,
+  type UserRole,
+} from "@/features/chat/utils";
 import { DEFAULT_CHAT_MODEL } from "../constants";
+import { askUserQuestions } from "../tools/ask-user-questions";
 import { manageMemoriesTool } from "../tools/manage-memories";
 import { readMemories } from "../tools/read-memories";
-import { askUserQuestions } from "../tools/ask-user-questions";
 
 const MODEL = DEFAULT_CHAT_MODEL;
 
-const SYSTEM_PROMPT = `You are a helpful AI assistant for a hospital vulnerability management platform (Viper).
+const BASE_PROMPT = `You are a helpful AI assistant for a hospital vulnerability management platform (Viper).
 You help hospital administrators and security engineers understand the operational impact
 of vulnerabilities and remediations across systems, safety, and clinical workflows.
 Be concise, accurate, and prioritize patient safety in your recommendations.
@@ -41,11 +50,22 @@ Good memories to create:
 
 Do NOT save: "User asked about PACS patches" — that is a one-time query, not a persistent fact.`;
 
+const buildSystemPrompt = (
+  network: NetworkRun<StateData> | undefined,
+): string => {
+  const data = network?.state.data as NetworkState | undefined;
+  const role: UserRole = data?.userRole ?? "hospital administration";
+  return [
+    BASE_PROMPT,
+    `<user_role>The user's role is: ${role}. ${RECOMMENDATION_ROLE_INSTRUCTIONS[role]}</user_role>`,
+  ].join("\n\n");
+};
+
 export const createChatAgent = () =>
   createAgent({
     name: "Viper Chat Assistant",
     description: "General assistant for hospital vulnerability management.",
-    system: SYSTEM_PROMPT,
+    system: ({ network }) => buildSystemPrompt(network),
     model: MODEL,
     tools: [readMemories, manageMemoriesTool, askUserQuestions],
   });

--- a/src/features/chat/viper-agent/agents/chat-agent.ts
+++ b/src/features/chat/viper-agent/agents/chat-agent.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import {
   createAgent,
   type NetworkRun,

--- a/src/features/chat/viper-agent/agents/chat-agent.ts
+++ b/src/features/chat/viper-agent/agents/chat-agent.ts
@@ -2,6 +2,7 @@ import { createAgent } from "@inngest/agent-kit";
 import { DEFAULT_CHAT_MODEL } from "../constants";
 import { manageMemoriesTool } from "../tools/manage-memories";
 import { readMemories } from "../tools/read-memories";
+import { askUserQuestions } from "../tools/ask-user-questions";
 
 const MODEL = DEFAULT_CHAT_MODEL;
 
@@ -9,6 +10,13 @@ const SYSTEM_PROMPT = `You are a helpful AI assistant for a hospital vulnerabili
 You help hospital administrators and security engineers understand the operational impact
 of vulnerabilities and remediations across systems, safety, and clinical workflows.
 Be concise, accurate, and prioritize patient safety in your recommendations.
+
+<tools>
+- ask_user_questions: ask the user 1–4 clarifying questions with suggested answers.
+  The agent turn ends here until the user replies.
+- read_memories: read memories from chat history
+- manage_memories: create, update, or delete persistent memories for this user.
+</tools>
 
 ## Startup
 Always call the read_memories tool before your first response in every
@@ -39,5 +47,5 @@ export const createChatAgent = () =>
     description: "General assistant for hospital vulnerability management.",
     system: SYSTEM_PROMPT,
     model: MODEL,
-    tools: [readMemories, manageMemoriesTool],
+    tools: [readMemories, manageMemoriesTool, askUserQuestions],
   });

--- a/src/features/chat/viper-agent/generate-thread-title.ts
+++ b/src/features/chat/viper-agent/generate-thread-title.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText } from "ai";
+
+const TITLE_MODEL = "claude-haiku-4-5-20251001";
+const MAX_TITLE_LENGTH = 60;
+
+const SYSTEM_PROMPT = `You name conversation threads. Given the first user message (and optionally the assistant's first reply), produce a concise 3-7 word title that captures the topic.
+
+Rules:
+- Output ONLY the title text. No quotes, no leading/trailing punctuation, no prefix like "Title:".
+- 3 to 7 words. Title Case.
+- Be specific to the topic, not generic ("ICU Monitor Patch Risk" not "Help With Question").`;
+
+export async function generateThreadTitle(args: {
+  userMessage: string;
+  assistantText?: string;
+}): Promise<string | null> {
+  const userMessage = args.userMessage.trim();
+  const assistantText = args.assistantText?.trim() ?? "";
+  if (!userMessage) return null;
+
+  const prompt = assistantText
+    ? `User:\n${userMessage}\n\nAssistant:\n${assistantText}`
+    : `User:\n${userMessage}`;
+
+  try {
+    const { text } = await generateText({
+      model: anthropic(TITLE_MODEL),
+      system: SYSTEM_PROMPT,
+      prompt,
+    });
+
+    const cleaned = text
+      .trim()
+      .replace(/^["'`]+|["'`]+$/g, "")
+      .replace(/[.!?]+$/g, "")
+      .trim();
+
+    if (!cleaned) return null;
+    return cleaned.length > MAX_TITLE_LENGTH
+      ? cleaned.slice(0, MAX_TITLE_LENGTH).trimEnd()
+      : cleaned;
+  } catch {
+    return null;
+  }
+}

--- a/src/inngest/functions/chat-agent.ts
+++ b/src/inngest/functions/chat-agent.ts
@@ -10,7 +10,9 @@ import { createChannel } from "@/app/api/inngest/realtime";
 import type { NetworkState } from "@/features/chat/types";
 import { createChatAgent } from "@/features/chat/viper-agent/agents/chat-agent";
 import { createGiveRecommendationsAgent } from "@/features/chat/viper-agent/agents/give-recommendations";
+import { generateThreadTitle } from "@/features/chat/viper-agent/generate-thread-title";
 import { conversationHistoryAdapter } from "@/features/chat/viper-agent/history-adapter";
+import prisma from "@/lib/db";
 import { inngest } from "../client";
 
 export const chatAgent = inngest.createFunction(
@@ -20,7 +22,7 @@ export const chatAgent = inngest.createFunction(
     retries: 0,
   },
   { event: "agent/chat.requested" },
-  async ({ event, publish }) => {
+  async ({ event, publish, step }) => {
     const { userMessage, threadId, userId, history } = event.data;
 
     if (!userId) {
@@ -74,6 +76,54 @@ export const chatAgent = inngest.createFunction(
         },
       },
     });
+
+    if (threadId) {
+      await step.run("maybe-generate-thread-title", async () => {
+        // Only generate on the first exchange. We gate on user-message count
+        // because a single user turn can produce multiple assistant rows (tool
+        // loops, multiple iterations of the router).
+        const userCount = await prisma.chatMessage.count({
+          where: { threadId, role: "USER" },
+        });
+        if (userCount !== 1) return { skipped: "not-first-exchange" as const };
+
+        const [firstUser, assistantMessages] = await Promise.all([
+          prisma.chatMessage.findFirst({
+            where: { threadId, role: "USER" },
+            orderBy: { createdAt: "asc" },
+          }),
+          prisma.chatMessage.findMany({
+            where: { threadId, role: "ASSISTANT" },
+            orderBy: { createdAt: "asc" },
+          }),
+        ]);
+
+        const assistantText = assistantMessages
+          .map((m) => m.content ?? "")
+          .filter((c) => c.trim().length > 0)
+          .join("\n\n")
+          .trim();
+
+        if (!firstUser?.content) {
+          return { skipped: "missing-user-message" as const };
+        }
+
+        const title = await generateThreadTitle({
+          userMessage: firstUser.content,
+          assistantText,
+        });
+        if (!title) return { skipped: "generation-failed" as const };
+
+        await prisma.chatThread.update({
+          where: { id: threadId },
+          data: { title },
+        });
+        await publish(
+          createChannel(userId).thread_updated({ threadId, title }),
+        );
+        return { title };
+      });
+    }
 
     return {
       success: true,

--- a/src/inngest/functions/chat-agent.ts
+++ b/src/inngest/functions/chat-agent.ts
@@ -115,7 +115,7 @@ export const chatAgent = inngest.createFunction(
         if (!title) return { skipped: "generation-failed" as const };
 
         await prisma.chatThread.update({
-          where: { id: threadId },
+          where: { id: threadId, userId },
           data: { title },
         });
         await publish(


### PR DESCRIPTION
* Another haiku api call generates a title for the user's conversation based on first exchange between user and agent
* Fix some css / js bugs
  * chat input grows upwards (doesn't work in firefox :/)
  * scroll to latest message scrolls the ai chat container, not the entire page
  * fixed a problem where we couldn't see user's selection in ai chat container, oops
* Added user's role to AI chat agent system prompt (different from recommendations agent prompt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic generation of thread titles from conversation content
  * Real-time thread title updates and synchronization across the application

* **Improvements**
  * Enhanced chat input handling with improved form submission
  * Improved message display and auto-scrolling behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PATCH-UPGRADE/viper/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->