### PR TITLE
[VW-0] Dark Mode Fixes for Workflow Editor, Asset / Vuln Dashboard

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-red-300 bg-red-100 text-red-600 [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-destructive/30 bg-destructive/10 text-destructive [a&]:hover:bg-destructive/15 focus-visible:ring-destructive/20 dark:border-destructive/50 dark:bg-destructive/25 dark:text-destructive-foreground dark:[a&]:hover:bg-destructive/35 dark:focus-visible:ring-destructive/40",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -18,6 +18,7 @@ import {
 import { useCallback, useState } from "react";
 import { ErrorView, LoadingView } from "@/components/entity-components";
 import { useSuspenseWorkflow } from "@/features/workflows/hooks/use-workflows";
+import { useTheme } from "next-themes";
 
 import "@xyflow/react/dist/style.css";
 import { useSetAtom } from "jotai";
@@ -35,8 +36,12 @@ export const EditorError = () => {
 
 export const Editor = ({ workflowId }: { workflowId: string }) => {
   const { data: workflow } = useSuspenseWorkflow(workflowId);
+  const { resolvedTheme } = useTheme();
 
   const setEditor = useSetAtom(editorAtom);
+  const colorMode = resolvedTheme === "dark" ? "dark" : "light";
+  const miniMapMaskColor =
+    colorMode === "dark" ? "rgb(2 6 23 / 0.55)" : "rgb(255 255 255 / 0.65)";
 
   const [nodes, setNodes] = useState<Node[]>(workflow.nodes);
   const [edges, setEdges] = useState<Edge[]>(workflow.edges);
@@ -73,10 +78,30 @@ export const Editor = ({ workflowId }: { workflowId: string }) => {
         panOnScroll
         panOnDrag={false}
         selectionOnDrag
+        colorMode={colorMode}
       >
-        <Background />
-        <Controls />
-        <MiniMap />
+        <Background color="var(--border)" gap={16} />
+        <Controls
+          style={{
+            backgroundColor: "var(--card)",
+            color: "var(--card-foreground)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            boxShadow: "var(--shadow-sm)",
+          }}
+        />
+        <MiniMap
+          pannable
+          zoomable
+          nodeColor="var(--primary)"
+          maskColor={miniMapMaskColor}
+          style={{
+            backgroundColor: "var(--card)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            boxShadow: "var(--shadow-sm)",
+          }}
+        />
         <Panel position="top-right">
           <AddNodeButton />
         </Panel>

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -15,10 +15,10 @@ import {
   Panel,
   ReactFlow,
 } from "@xyflow/react";
+import { useTheme } from "next-themes";
 import { useCallback, useState } from "react";
 import { ErrorView, LoadingView } from "@/components/entity-components";
 import { useSuspenseWorkflow } from "@/features/workflows/hooks/use-workflows";
-import { useTheme } from "next-themes";
 
 import "@xyflow/react/dist/style.css";
 import { useSetAtom } from "jotai";
@@ -84,7 +84,11 @@ export const Editor = ({ workflowId }: { workflowId: string }) => {
         selectionOnDrag
         colorMode={colorMode}
       >
-        <Background color={backgroundDotColor} gap={16} size={backgroundDotSize} />
+        <Background
+          color={backgroundDotColor}
+          gap={16}
+          size={backgroundDotSize}
+        />
         <Controls
           style={{
             backgroundColor: "var(--card)",

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -42,6 +42,10 @@ export const Editor = ({ workflowId }: { workflowId: string }) => {
   const colorMode = resolvedTheme === "dark" ? "dark" : "light";
   const miniMapMaskColor =
     colorMode === "dark" ? "rgb(2 6 23 / 0.55)" : "rgb(255 255 255 / 0.65)";
+  // Workaround to make the background dots more visible in light mode, since the default color is too light
+  const backgroundDotColor =
+    colorMode === "dark" ? "var(--border)" : "rgb(100 116 139 / 0.55)";
+  const backgroundDotSize = colorMode === "dark" ? 1 : 1.25;
 
   const [nodes, setNodes] = useState<Node[]>(workflow.nodes);
   const [edges, setEdges] = useState<Edge[]>(workflow.edges);
@@ -80,7 +84,7 @@ export const Editor = ({ workflowId }: { workflowId: string }) => {
         selectionOnDrag
         colorMode={colorMode}
       >
-        <Background color="var(--border)" gap={16} />
+        <Background color={backgroundDotColor} gap={16} size={backgroundDotSize} />
         <Controls
           style={{
             backgroundColor: "var(--card)",

--- a/src/features/vulnerabilities/components/vulnerabilities.tsx
+++ b/src/features/vulnerabilities/components/vulnerabilities.tsx
@@ -127,8 +127,10 @@ const PrioritiesExplained = {
   Critical: {
     help: "Immediate remediation required. Confirmed exploitation of high-impact vulnerabilities.",
     icon: ShieldAlert,
-    color: "text-red-600",
-    colorBg: "bg-red-50",
+    color: "text-red-600 dark:text-red-400",
+    colorBg: "bg-red-50 dark:bg-red-950/25",
+    alertClass:
+      "border-red-200/80 bg-red-50/80 dark:border-red-900/70 dark:bg-red-950/40",
     alertHeader: "Critical - Immediate Remediation",
     alertBody:
       "These vulnerabilities have confirmed exploitation of high-impact systems and require immediate action. They pose the highest risk to patient safety and data security.",
@@ -136,8 +138,10 @@ const PrioritiesExplained = {
   High: {
     help: "Scheduled remediation required. Predicted exploitation of high-impact vulnerabilities.",
     icon: ShieldClose,
-    color: "text-orange-600",
-    colorBg: "bg-orange-50",
+    color: "text-orange-600 dark:text-orange-400",
+    colorBg: "bg-orange-50 dark:bg-orange-950/25",
+    alertClass:
+      "border-orange-200/80 bg-orange-50/80 dark:border-orange-900/70 dark:bg-orange-950/40",
     alertHeader: "High - Scheduled Remediation",
     alertBody:
       "These vulnerabilities indicate predicted exploitation of high-impact systems. Plan and schedule remediation activities within your next maintenance window.",
@@ -145,8 +149,10 @@ const PrioritiesExplained = {
   Monitor: {
     help: "Track for changes in threat landscape or impact assessment.",
     icon: Eye,
-    color: "text-yellow-600",
-    colorBg: "bg-yellow-50",
+    color: "text-yellow-700 dark:text-yellow-300",
+    colorBg: "bg-yellow-50 dark:bg-yellow-950/25",
+    alertClass:
+      "border-yellow-200/80 bg-yellow-50/80 dark:border-yellow-900/70 dark:bg-yellow-950/40",
     alertHeader: "Monitor - Track Changes",
     alertBody:
       "These vulnerabilities should be monitored for changes in threat landscape or impact assessment. No immediate action required.",
@@ -154,8 +160,10 @@ const PrioritiesExplained = {
   Defer: {
     help: "Standard patching. No exploitation evidence, can be addressed through standard patching cycles.",
     icon: Clock,
-    color: "text-blue-600",
-    colorBg: "bg-blue-50",
+    color: "text-blue-600 dark:text-blue-400",
+    colorBg: "bg-blue-50 dark:bg-blue-950/25",
+    alertClass:
+      "border-blue-200/80 bg-blue-50/80 dark:border-blue-900/70 dark:bg-blue-950/40",
     alertHeader: "Defer - Standard Patching",
     alertBody:
       "These vulnerabilities have no exploitation evidence and can be addressed through standard patching cycles.",
@@ -163,8 +171,9 @@ const PrioritiesExplained = {
   Unsorted: {
     help: "Not yet prioritized. Awaiting enrichment data or manual triage.",
     icon: BugIcon,
-    color: "text-gray-500",
-    colorBg: "bg-gray-50",
+    color: "text-gray-500 dark:text-gray-400",
+    colorBg: "bg-gray-50 dark:bg-gray-900/40",
+    alertClass: "",
     alertHeader: "",
     alertBody: "",
   },
@@ -256,7 +265,7 @@ export const PrioritizedVulnerabilitiesList = () => {
         />
       )}
       {explained.alertBody && explained.alertHeader && (
-        <Alert className={explained.colorBg}>
+        <Alert className={explained.alertClass}>
           {<explained.icon className={explained.color} />}
           <AlertDescription className="text-foreground">
             <strong>{explained.alertHeader}</strong> {explained.alertBody}


### PR DESCRIPTION
Minor UI fixes for dark mode components, particularly in the Workflow Editor, Asset Dashboard and Vulnerability Dashboard

# Workflow Editor 
## Before
<img width="2672" height="1522" alt="Workflow Dark no fix" src="https://github.com/user-attachments/assets/a2512b71-f0ed-4ad9-b8df-9cc6b4e536a1" />

## After
Background, controls and minimap are the main changes. Background turned charcoal grey as that's the default react-flow color, can make it more in line with other colors if needed

<img width="2672" height="1522" alt="Workflow Dark fix" src="https://github.com/user-attachments/assets/c1d4ef12-8875-4a00-b776-6ac4993f4088" />

# Asset Dashboard
Remediation Badges are the main change

<img width="1609" height="1184" alt="Asset Dark" src="https://github.com/user-attachments/assets/5ceb9368-e0a6-4719-aa09-7fbbeb3bfacb" />

# Vulnerability Dashboard
Badges & Alert Banner are the main changes here

<img width="2106" height="1048" alt="Vuln Dark" src="https://github.com/user-attachments/assets/b7444d6b-79e3-4d60-9e29-8d4aef08e81c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode support across badge, editor, and vulnerability components with theme-aware styling.
  * Updated destructive badge variant with improved design tokens.
  * Implemented theme-based color configuration for the editor UI elements including minimap and background.
  * Expanded vulnerability priority styling with dark mode variants for better visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PATCH-UPGRADE/viper/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->