### PR TITLE
[VW-334] add missing cvssScore, cvssVector in extracted and pass to LLM, fix typo in remediation

### DIFF
--- a/src/features/inbox/agent/match.ts
+++ b/src/features/inbox/agent/match.ts
@@ -138,13 +138,13 @@ function renderCandidates(candidates: Candidates): string {
         candidates.vulnerabilities
           .map((entry, i) => {
             const e = entry.extracted;
-            const line = `Vulnerability #${i + 1}: cveId=${e.cveId ?? "?"}`;
+            const line = `Vulnerability #${i + 1} extracted: cveId=${e.cveId ?? "?"} | cvssScore: ${e.cvssScore ?? "?"} | cvssVector: ${e.cvssVector ?? "?"}`;
             const matches =
               entry.matches.length > 0
                 ? entry.matches
                     .map(
                       (m) =>
-                        ` - id: ${m.id} | cveId: ${m.cveId ?? "(none)"} | description: ${m.description} ?? "(none)"} | cvssScore: ${m.cvssScore ?? "(none)"} | cvssVector: ${m.cvssVector ?? "(none)"}`,
+                        ` - id: ${m.id} | cveId: ${m.cveId ?? "(none)"} | cvssScore: ${m.cvssScore ?? "(none)"} | cvssVector: ${m.cvssVector ?? "(none)"}`,
                     )
                     .join("\n")
                 : "    - (no candidates found)";
@@ -161,7 +161,7 @@ function renderCandidates(candidates: Candidates): string {
         candidates.remediations
           .map((entry, i) => {
             const e = entry.extracted;
-            const line = `Remediations #${i + 1}: linkedtoCveId=${e.linkedCveId ?? "?"} | description=${e.description} ?? "?"}`;
+            const line = `Remediations #${i + 1} extracted: linkedtoCveId=${e.linkedCveId ?? "?"} | description=${e.description} ?? "?"}`;
             const matches =
               entry.matches.length > 0
                 ? entry.matches
@@ -184,13 +184,13 @@ function renderCandidates(candidates: Candidates): string {
         candidates.assets
           .map((entry, i) => {
             const e = entry.extracted;
-            const line = `Asset #${i + 1}: ip=${e.ip ?? "?"} | hostname=${e.hostname ?? "?"} | macAddress=${e.macAddress ?? "?"} | serialNumber=${e.serialNumber ?? "?"}`;
+            const line = `Asset #${i + 1} extracted: ip=${e.ip ?? "?"} | hostname=${e.hostname ?? "?"} | macAddress=${e.macAddress ?? "?"} | serialNumber=${e.serialNumber ?? "?"}`;
             const matches =
               entry.matches.length > 0
                 ? entry.matches
                     .map(
                       (m) =>
-                        ` - id: ${m.id} | ip: ${m.ip ?? "(none)"} | hostname: ${m.hostname ?? "(none)"} | macAddress: ${m.macAddress ?? "(none)"} | serialNumber=${e.serialNumber ?? "(none)"}`,
+                        ` - id: ${m.id} | ip: ${m.ip ?? "(none)"} | hostname: ${m.hostname ?? "(none)"} | macAddress: ${m.macAddress ?? "(none)"} | serialNumber=${m.serialNumber ?? "(none)"}`,
                     )
                     .join("\n")
                 : "    - (no candidates found)";

--- a/src/features/inbox/agent/match.ts
+++ b/src/features/inbox/agent/match.ts
@@ -161,7 +161,7 @@ function renderCandidates(candidates: Candidates): string {
         candidates.remediations
           .map((entry, i) => {
             const e = entry.extracted;
-            const line = `Remediations #${i + 1} extracted: linkedtoCveId=${e.linkedCveId ?? "?"} | description=${e.description} ?? "?"}`;
+            const line = `Remediations #${i + 1} extracted: linkedtoCveId=${e.linkedCveId ?? "?"} | description=${e.description ?? "?"}`;
             const matches =
               entry.matches.length > 0
                 ? entry.matches


### PR DESCRIPTION
Jira ticket: https://northeastern-patch.atlassian.net/browse/VW-334 and https://northeastern-patch.atlassian.net/browse/VW-335

While Testing, I found a bug where updates to existing Vulnerability records were not working correctly. The issue was caused by cvssScore and cvssVector not being included in the renderCandidate function, preventing those extracted values from being passed to LLM for comparison during the update workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for asset records so serial numbers are handled more accurately.
  * Updated candidate details used in matching to include more complete vulnerability information and better-structured asset identifiers.
  * Refined remediation labeling in matching output for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->