### PR TITLE
[VW-0] Change compose name to lowercase

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,4 @@
-name: Viper
+name: viper
 
 services:
   postgres:


### PR DESCRIPTION
Viper's docker compose setup will fail with podman-compose because it's super picky about the name: 

```
podman-compose build
Error: tag Viper_viper: invalid reference format: repository name must be lowercase
Error: tag Viper_inngest: invalid reference format: repository name must be lowercase
Error: tag Viper_postgres: invalid reference format: repository name must be lowercase
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project name in the compose configuration from `Viper` to `viper` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->