### PR TITLE
[VW-351] Allow User to mark incorrect LLM Notification <-> Device Grouping linking from UI

### DIFF
--- a/prisma/migrations/20260708193227_match_feedback/migration.sql
+++ b/prisma/migrations/20260708193227_match_feedback/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "MatchFeedbackTargetType" AS ENUM ('NotificationDeviceGroupMapping', 'NotificationAssetMapping', 'NotificationRemediationMapping', 'NotificationVulnerabilityMapping');
+
+-- CreateEnum
+CREATE TYPE "MatchFeedbackCategory" AS ENUM ('Incorrect', 'Correct');
+
+-- AlterEnum
+ALTER TYPE "ConfidenceLevel" ADD VALUE 'Rejected';
+
+-- CreateTable
+CREATE TABLE "match_feedback" (
+    "id" TEXT NOT NULL,
+    "targetType" "MatchFeedbackTargetType" NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "category" "MatchFeedbackCategory" NOT NULL,
+    "comment" TEXT,
+    "userId" TEXT NOT NULL,
+    "notificationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "match_feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "match_feedback_targetType_targetId_idx" ON "match_feedback"("targetType", "targetId");
+
+-- CreateIndex
+CREATE INDEX "match_feedback_notificationId_idx" ON "match_feedback"("notificationId");
+
+-- AddForeignKey
+ALTER TABLE "match_feedback" ADD CONSTRAINT "match_feedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match_feedback" ADD CONSTRAINT "match_feedback_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "notification"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260709151903_match_feedback_default/migration.sql
+++ b/prisma/migrations/20260709151903_match_feedback_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "match_feedback" ALTER COLUMN "category" SET DEFAULT 'Incorrect';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1304,7 +1304,7 @@ model MatchFeedback {
   id String @id @default(cuid())
   targetType MatchFeedbackTargetType
   targetId  String
-  category  MatchFeedbackCategory
+  category  MatchFeedbackCategory @default(Incorrect)
   comment String?
 
   userId String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   threads    ChatThread[]
   memories   Memory[]
   notificationReads         NotificationRead[]
+  matchFeedback             MatchFeedback[]
 
   departmentId           String?
   department             Department?     @relation(fields: [departmentId], references: [id], onDelete: SetNull)
@@ -1134,6 +1135,7 @@ enum ConfidenceLevel {
   NeedsReview // An LLM matched this but with low confidence
   Matched // An LLM matched this with high confidence
   Confirmed // A human confirmed this match was correct
+  Rejected  // A human marked this match as incorrect
 }
 
 enum NotificationSourceType {
@@ -1161,6 +1163,7 @@ model Notification {
   deviceGroupsMatchings NotificationDeviceGroupMapping[]
   vulnerabilities NotificationVulnerabilityMapping[]
   remediations    NotificationRemediationMapping[]
+  matchFeedback   MatchFeedback[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1281,4 +1284,38 @@ model NotificationRemediationMapping {
 
   @@unique([notificationId, remediationId])
   @@map("notification_remediation_mapping")
+}
+
+// ─── Feedback ────────────────────────────────────────────────────────────
+
+enum MatchFeedbackTargetType {
+  NotificationDeviceGroupMapping
+  NotificationAssetMapping
+  NotificationRemediationMapping
+  NotificationVulnerabilityMapping
+}
+
+enum MatchFeedbackCategory {
+  Incorrect
+  Correct
+}
+
+model MatchFeedback {
+  id String @id @default(cuid())
+  targetType MatchFeedbackTargetType
+  targetId  String
+  category  MatchFeedbackCategory
+  comment String?
+
+  userId String
+  user User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  notificationId  String?
+  notification  Notification? @relation(fields:[notificationId], references:[id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+
+  @@index([targetType, targetId])
+  @@index([notificationId])
+  @@map("match_feedback")
 }

--- a/src/features/inbox/agent/match.ts
+++ b/src/features/inbox/agent/match.ts
@@ -299,8 +299,8 @@ export async function applyDecisions(
   const rejectedDeviceGroupMatchingIds = new Set(
     (
       await prisma.notificationDeviceGroupMapping.findMany({
-        where: { notificationId, confidence: "Rejected"},
-        select: { deviceGroupMatchingId: true }
+        where: { notificationId, confidence: "Rejected" },
+        select: { deviceGroupMatchingId: true },
       })
     ).map((m) => m.deviceGroupMatchingId),
   );
@@ -310,8 +310,9 @@ export async function applyDecisions(
 
   const validIds = {
     deviceGroupMatching: new Set(
-      candidates.deviceGroups.flatMap((e) => e.matches.map((m) => m.id))
-      .filter((id) => !rejectedDeviceGroupMatchingIds.has(id)),
+      candidates.deviceGroups
+        .flatMap((e) => e.matches.map((m) => m.id))
+        .filter((id) => !rejectedDeviceGroupMatchingIds.has(id)),
     ),
     vulnerability: new Set(
       candidates.vulnerabilities.flatMap((e) => e.matches.map((m) => m.id)),
@@ -442,7 +443,7 @@ export async function applyDecisions(
             hasCpe: false,
           });
 
-          if(rejectedDeviceGroupMatchingIds.has(matchingId)) {
+          if (rejectedDeviceGroupMatchingIds.has(matchingId)) {
             summary.skipped++;
             continue;
           }

--- a/src/features/inbox/agent/match.ts
+++ b/src/features/inbox/agent/match.ts
@@ -281,6 +281,7 @@ export async function matchAndLinkEntities(
  * Idempotent: mappings are upserted on (notificationId, deviceGroupId) and new
  * device groups are resolved to their canonical (vendor/product/version)
  * identity via resolveDeviceGroup, so replaying does not duplicate rows.
+ * Also it does not resurrect a match a human already rejected
  */
 export async function applyDecisions(
   notificationId: string,
@@ -294,12 +295,23 @@ export async function applyDecisions(
     skipped: 0,
   };
 
+  // Pull rejectedDeviceGroupMatching ids
+  const rejectedDeviceGroupMatchingIds = new Set(
+    (
+      await prisma.notificationDeviceGroupMapping.findMany({
+        where: { notificationId, confidence: "Rejected"},
+        select: { deviceGroupMatchingId: true }
+      })
+    ).map((m) => m.deviceGroupMatchingId),
+  );
+
   // Only allow link/update against ids the search actually surfaced — guards
   // against hallucinated targetIds causing FK errors.
 
   const validIds = {
     deviceGroupMatching: new Set(
-      candidates.deviceGroups.flatMap((e) => e.matches.map((m) => m.id)),
+      candidates.deviceGroups.flatMap((e) => e.matches.map((m) => m.id))
+      .filter((id) => !rejectedDeviceGroupMatchingIds.has(id)),
     ),
     vulnerability: new Set(
       candidates.vulnerabilities.flatMap((e) => e.matches.map((m) => m.id)),
@@ -429,6 +441,12 @@ export async function applyDecisions(
             versionRange: data.versionRange,
             hasCpe: false,
           });
+
+          if(rejectedDeviceGroupMatchingIds.has(matchingId)) {
+            summary.skipped++;
+            continue;
+          }
+
           await upsertMapping(matchingId);
           await enrichDeviceGroup(matchingId, data);
           summary.created++;

--- a/src/features/inbox/components/notification-affected-assets-tab.tsx
+++ b/src/features/inbox/components/notification-affected-assets-tab.tsx
@@ -1,7 +1,24 @@
 "use client";
 
+import { Unlink } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { MoreVerticalDropdownMenu } from "@/components/ui/dropdown-menu";
 import {
   Table,
@@ -11,15 +28,43 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
 import { deviceGroupMatchingLabel, parseLocation } from "@/lib/string-utils";
+import { useMarkMatchIncorrect } from "../hooks/use-notifications";
 import type { NotificationDetailWithRelations } from "../types";
 
+type DeviceGroupMapping =
+  NotificationDetailWithRelations["deviceGroupsMatchings"][number];
+
 export function NotificationAffectedAssetsTab({
+  notificationId,
   deviceGroupsMatchings,
 }: {
+  notificationId: string;
   deviceGroupsMatchings: NotificationDetailWithRelations["deviceGroupsMatchings"];
 }) {
   const withAssets = deviceGroupsMatchings.filter((m) => m.assetCount > 0);
+  const [rejecting, setRejecting] = useState<DeviceGroupMapping | null>(null);
+  const [comment, setComment] = useState("");
+  const markMatchIncorrect = useMarkMatchIncorrect();
+
+  const closeDialog = () => {
+    setRejecting(null);
+    setComment("");
+  };
+
+  const confirmUnlink = async (commentToSave: string | undefined) => {
+    if (!rejecting) return;
+    const label = deviceGroupMatchingLabel(rejecting.deviceGroupMatching);
+    await markMatchIncorrect.mutateAsync({
+      targetType: "NotificationDeviceGroupMapping",
+      targetId: rejecting.id,
+      notificationId,
+      comment: commentToSave,
+    });
+    toast.success(`${label} unlinked from notification`);
+    closeDialog();
+  };
 
   if (withAssets.length === 0) {
     return (
@@ -42,6 +87,17 @@ export function NotificationAffectedAssetsTab({
             </CardTitle>
           </CardHeader>
           <CardContent>
+            <CardAction>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive"
+                onClick={() => setRejecting(mapping)}
+                aria-label="Unlink this device group"
+              >
+                <Unlink className="size-4" />
+              </Button>
+            </CardAction>
             <Table>
               <TableHeader>
                 <TableRow>
@@ -78,6 +134,53 @@ export function NotificationAffectedAssetsTab({
           </CardContent>
         </Card>
       ))}
+      <Dialog
+        open={!!rejecting}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Unlink className="size-4 text-destructive" />
+              Unlink{" "}
+              {rejecting
+                ? deviceGroupMatchingLabel(rejecting.deviceGroupMatching)
+                : ""}
+              ?
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {rejecting && (
+              <>
+                This device group has been unlinked from the notification. Add a
+                short note on why - it's recorded in the activity log.
+              </>
+            )}
+          </p>
+          <Textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Add a comment (optional)"
+            rows={3}
+          />
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => confirmUnlink(undefined)}
+              disabled={markMatchIncorrect.isPending}
+            >
+              Skip
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => confirmUnlink(comment.trim() || undefined)}
+              disabled={markMatchIncorrect.isPending}
+            >
+              Save reason
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/features/inbox/components/notification-detail.tsx
+++ b/src/features/inbox/components/notification-detail.tsx
@@ -172,6 +172,7 @@ export const NotificationDetailPage = ({ id }: { id: string }) => {
           className="flex flex-col gap-4 mt-4"
         >
           <NotificationAffectedAssetsTab
+            notificationId={notification.id}
             deviceGroupsMatchings={notification.deviceGroupsMatchings}
           />
         </TabsContent>

--- a/src/features/inbox/hooks/use-notifications.ts
+++ b/src/features/inbox/hooks/use-notifications.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useTRPC } from "@/trpc/client";
 import { useNotificationsParams } from "./use-notifications-params";
 
@@ -32,6 +33,27 @@ export const useMarkNotificationRead = () => {
             id: variables.notificationId,
           }),
         );
+      },
+    }),
+  );
+};
+
+export const useMarkMatchIncorrect = () => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.notifications.markMatchIncorrect.mutationOptions({
+      onSuccess: (_data, variables) => {
+        queryClient.invalidateQueries(trpc.notifications.getMany.queryFilter());
+        queryClient.invalidateQueries(
+          trpc.notifications.getOne.queryFilter({
+            id: variables.notificationId,
+          }),
+        );
+      },
+      onError: (error) => {
+        toast.error(`Failed to unlink match: ${error.message}`);
       },
     }),
   );

--- a/src/features/inbox/server/routers.ts
+++ b/src/features/inbox/server/routers.ts
@@ -1,6 +1,10 @@
 import "server-only";
 import { z } from "zod";
-import { NotificationType, Priority } from "@/generated/prisma";
+import {
+  NotificationType,
+  Priority,
+  MatchFeedbackTargetType,
+} from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
   deviceGroupWhereForMatching,
@@ -130,12 +134,14 @@ export const notificationsRouter = createTRPCRouter({
         notifications.map(async (n) => ({
           ...n,
           deviceGroupsMatchings: await Promise.all(
-            n.deviceGroupsMatchings.map(async (m) => ({
-              ...m,
-              assetCount: await resolvedDeviceGroupAssetCount(
-                m.deviceGroupMatching,
-              ),
-            })),
+            n.deviceGroupsMatchings
+              .filter((m) => m.confidence !== "Rejected")
+              .map(async (m) => ({
+                ...m,
+                assetCount: await resolvedDeviceGroupAssetCount(
+                  m.deviceGroupMatching,
+                ),
+              })),
           ),
         })),
       );
@@ -161,10 +167,14 @@ export const notificationsRouter = createTRPCRouter({
         throw new Error("Notification not found");
       }
       const deviceGroupsMatchings = await Promise.all(
-        notification.deviceGroupsMatchings.map(async (m) => {
-          const assets = await resolveDeviceGroupAssets(m.deviceGroupMatching);
-          return { ...m, assetCount: assets.length, assets };
-        }),
+        notification.deviceGroupsMatchings
+          .filter((m) => m.confidence !== "Rejected")
+          .map(async (m) => {
+            const assets = await resolveDeviceGroupAssets(
+              m.deviceGroupMatching,
+            );
+            return { ...m, assetCount: assets.length, assets };
+          }),
       );
       return { ...notification, deviceGroupsMatchings };
     }),
@@ -184,6 +194,35 @@ export const notificationsRouter = createTRPCRouter({
           notificationId: input.notificationId,
           userId: ctx.auth.user.id,
         },
+      });
+    }),
+
+  markMatchIncorrect: protectedProcedure
+    .input(
+      z.object({
+        targetType: z.enum(MatchFeedbackTargetType),
+        targetId: z.string(),
+        notificationId: z.string(),
+        comment: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await prisma.$transaction(async (tx) => {
+        if (input.targetType === "NotificationDeviceGroupMapping") {
+          await tx.notificationDeviceGroupMapping.update({
+            where: { id: input.targetId },
+            data: { confidence: "Rejected" },
+          });
+        }
+        await tx.matchFeedback.create({
+          data: {
+            targetType: input.targetType,
+            targetId: input.targetId,
+            comment: input.comment,
+            userId: ctx.auth.user.id,
+            notificationId: input.notificationId,
+          },
+        });
       });
     }),
 });

--- a/src/features/inbox/server/routers.ts
+++ b/src/features/inbox/server/routers.ts
@@ -1,9 +1,9 @@
 import "server-only";
 import { z } from "zod";
 import {
+  MatchFeedbackTargetType,
   NotificationType,
   Priority,
-  MatchFeedbackTargetType,
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-351 

## Summary
- Add a mark as incorrect action on the notification's Affected Assets tab. Users can unlink an LLM-matched device group from a notification, with an optional comment explaining why.
- New MatchFeedback table and Rejected confidence value. This is using TargetType approach so it can later extends to Vulnerability/Remediation without schema changes
- Guards the inbox pipeline so a reprocessed notification can never silently relinked




https://github.com/user-attachments/assets/e41c260f-a407-4443-9e78-2564602080ca




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feedback flow for match results, including the ability to mark an item as incorrect, add an optional comment, and save the response.
  * Introduced support for rejected match states so previously dismissed matches are no longer shown as active.
  * Added a new action in the affected assets view to unlink a match with confirmation.

* **Bug Fixes**
  * Prevented rejected device-group matches from being recreated or re-linked.
  * Improved notification views to hide rejected match entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->