### PR TITLE
[VW-358] Adding Inngest function to create EntityFilterMatchings 

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -8,6 +8,10 @@ import { manageMemoriesFn } from "@/inngest/functions/manage-memories";
 import { processInboxEmail } from "@/inngest/functions/process-inbox-email";
 import { purgeExpiredTokensFn } from "@/inngest/functions/purge-expired-user-tokens";
 import {
+  resolveAllEntityFilters,
+  resolveEntityFilterFn,
+} from "@/inngest/functions/resolve-entity-filters";
+import {
   syncAllIntegrations,
   syncIntegration,
 } from "@/inngest/functions/sync-integrations";
@@ -22,5 +26,7 @@ export const { GET, POST, PUT } = serve({
     manageMemoriesFn,
     purgeExpiredTokensFn,
     processInboxEmail,
+    resolveAllEntityFilters,
+    resolveEntityFilterFn,
   ],
 });

--- a/src/features/notes/server/get-relevant-notes.ts
+++ b/src/features/notes/server/get-relevant-notes.ts
@@ -34,11 +34,23 @@ export async function getNotesForInstance(
 ): Promise<RelevantNote[]> {
   if (ids.length === 0) return [];
 
-  // TODO(EntityFilterMatch): VW-358 -- also include notes that match
-  // via EntityFilterMatch
-
+  // A note is relevant to one of these ids either directly (targetModel +
+  // instanceId) or because one of its EntityFilters resolved to a match on that
+  // id. Matches are materialized by the resolve-entity-filters Inngest job.
   return prisma.note.findMany({
-    where: { targetModel, instanceId: { in: ids } },
+    where: {
+      OR: [
+        { targetModel, instanceId: { in: ids } },
+        {
+          filters: {
+            some: {
+              targetModel,
+              matches: { some: { targetId: { in: ids } } },
+            },
+          },
+        },
+      ],
+    },
     select: NOTE_SELECT,
   });
 }

--- a/src/inngest/functions/resolve-entity-filters.ts
+++ b/src/inngest/functions/resolve-entity-filters.ts
@@ -1,0 +1,118 @@
+import "server-only";
+import prisma from "@/lib/db";
+import { EntityFilterError, resolveEntityFilter } from "@/lib/entity-filter";
+import { inngest } from "../client";
+
+// Materializes EntityFilter -> EntityFilterMatch rows. Two entry points:
+//   - resolveAllEntityFilters: hourly cron job
+//   - resolveEntityFilterFn: resolves a single filter. Also dispatched directly
+//     via requestEntityFilterResolve on filter create/update for immediacy.
+
+const RESOLVE_EVENT = "entity-filter/resolve.requested" as const;
+
+/** Ask the resolver to (re)materialize matches for one filter. */
+export async function requestEntityFilterResolve(
+  entityFilterId: string,
+): Promise<void> {
+  await inngest.send({ name: RESOLVE_EVENT, data: { entityFilterId } });
+}
+
+export const resolveAllEntityFilters = inngest.createFunction(
+  { id: "resolve-all-entity-filters" },
+  { cron: "0 * * * *" }, // hourly cron job
+  async ({ step }) => {
+    const filters = await step.run("fetch-entity-filters", () =>
+      prisma.entityFilter.findMany({ select: { id: true } }),
+    );
+
+    if (filters.length === 0) return { count: 0 };
+
+    await step.sendEvent(
+      "trigger-entity-filter-resolves",
+      filters.map((filter) => ({
+        name: RESOLVE_EVENT,
+        data: { entityFilterId: filter.id },
+      })),
+    );
+
+    return { count: filters.length };
+  },
+);
+
+export const resolveEntityFilterFn = inngest.createFunction(
+  { id: "resolve-entity-filter" },
+  { event: RESOLVE_EVENT },
+  async ({ event, step, logger }) => {
+    const { entityFilterId } = event.data as { entityFilterId: string };
+
+    const filter = await step.run("fetch-filter", () =>
+      prisma.entityFilter.findUnique({
+        where: { id: entityFilterId },
+        select: { id: true, targetModel: true, filter: true },
+      }),
+    );
+
+    if (!filter) return { skipped: true, reason: "filter not found" };
+
+    // Resolve inside a step so a bad filter is a returned result, not a thrown
+    // error that triggers Inngest retries.
+    const resolved = await step.run("resolve-filter", async () => {
+      try {
+        const ids = await resolveEntityFilter(
+          filter.targetModel,
+          filter.filter,
+        );
+        return { ok: true as const, ids };
+      } catch (err) {
+        if (err instanceof EntityFilterError) {
+          return { ok: false as const, reason: err.message };
+        }
+        throw err;
+      }
+    });
+
+    if (!resolved.ok) {
+      logger.warn(
+        `Skipping entity filter ${entityFilterId}: ${resolved.reason}`,
+      );
+      // Leave existing matches and lastResolvedAt untouched.
+      return { skipped: true, reason: resolved.reason };
+    }
+
+    const targetIds = resolved.ids;
+
+    const created = await step.run("sync-matches", async () =>
+      prisma.$transaction(async (tx) => {
+        // Drop matches that no longer apply.
+        await tx.entityFilterMatch.deleteMany({
+          where:
+            targetIds.length === 0
+              ? { entityFilterId }
+              : { entityFilterId, targetId: { notIn: targetIds } },
+        });
+
+        // Add newly-matching rows (idempotent via the [entityFilterId,targetId]
+        // unique constraint).
+        const result =
+          targetIds.length === 0
+            ? { count: 0 }
+            : await tx.entityFilterMatch.createMany({
+                data: targetIds.map((targetId) => ({
+                  entityFilterId,
+                  targetId,
+                })),
+                skipDuplicates: true,
+              });
+
+        await tx.entityFilter.update({
+          where: { id: entityFilterId },
+          data: { lastResolvedAt: new Date() },
+        });
+
+        return result.count;
+      }),
+    );
+
+    return { entityFilterId, matched: targetIds.length, created };
+  },
+);

--- a/src/inngest/functions/resolve-entity-filters.ts
+++ b/src/inngest/functions/resolve-entity-filters.ts
@@ -40,7 +40,10 @@ export const resolveAllEntityFilters = inngest.createFunction(
 );
 
 export const resolveEntityFilterFn = inngest.createFunction(
-  { id: "resolve-entity-filter" },
+  {
+    id: "resolve-entity-filter",
+    concurrency: { key: "event.data.entityFilterId", limit: 1 },
+  },
   { event: RESOLVE_EVENT },
   async ({ event, step, logger }) => {
     const { entityFilterId } = event.data as { entityFilterId: string };

--- a/src/lib/__tests__/entity-filter.test.ts
+++ b/src/lib/__tests__/entity-filter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  EntityFilterError,
+  resolveEntityFilter,
+  TARGET_MODEL_REGISTRY,
+  validateEntityFilter,
+} from "../entity-filter";
+
+describe("validateEntityFilter", () => {
+  describe("ASSET", () => {
+    it("accepts a scalar equality filter (shorthand and long form)", () => {
+      expect(
+        validateEntityFilter("ASSET", { role: "CT Scanner" }).success,
+      ).toBe(true);
+      expect(
+        validateEntityFilter("ASSET", {
+          role: { equals: "CT Scanner" },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts string operators (in / contains)", () => {
+      expect(
+        validateEntityFilter("ASSET", {
+          networkSegment: { contains: "ICU" },
+          status: { in: ["Active", "Maintenance"] },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a single relation hop through deviceGroup", () => {
+      const result = validateEntityFilter("ASSET", {
+        deviceGroup: { productId: "prod_infusion_pump" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts AND / OR / NOT composition", () => {
+      const result = validateEntityFilter("ASSET", {
+        OR: [
+          { networkSegment: { contains: "ICU" } },
+          { deviceGroup: { vendorId: "vendor_1" } },
+        ],
+        NOT: { status: "Decommissioned" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an empty filter (matches all)", () => {
+      expect(validateEntityFilter("ASSET", {}).success).toBe(true);
+    });
+
+    it("returns the parsed where object on success", () => {
+      const result = validateEntityFilter("ASSET", { role: "CT Scanner" });
+      expect(result).toEqual({ success: true, data: { role: "CT Scanner" } });
+    });
+
+    it("rejects an unknown field", () => {
+      const result = validateEntityFilter("ASSET", { bogusColumn: "x" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an unknown operator", () => {
+      const result = validateEntityFilter("ASSET", {
+        role: { startsWithh: "CT" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a relation hop into a non-allowlisted relation", () => {
+      const result = validateEntityFilter("ASSET", {
+        user: { id: "user_1" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a wrongly-typed value", () => {
+      const result = validateEntityFilter("ASSET", { role: 42 });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects Json columns that are intentionally not exposed", () => {
+      // `location` is a Json column and is deliberately omitted from the
+      // allowlist.
+      expect(
+        validateEntityFilter("ASSET", { location: { facility: "Main" } })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe("VULNERABILITY", () => {
+    it("accepts numeric and boolean operators", () => {
+      expect(
+        validateEntityFilter("VULNERABILITY", {
+          cvssScore: { gte: 7 },
+          inKEV: true,
+          severity: "Critical",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a string-list filter on affectedComponents", () => {
+      expect(
+        validateEntityFilter("VULNERABILITY", {
+          affectedComponents: { has: "openssl" },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects a number operator given a string", () => {
+      expect(
+        validateEntityFilter("VULNERABILITY", { cvssScore: { gte: "7" } })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe("REMEDIATION and DEVICE_GROUP_MATCHING", () => {
+    it("accepts allowlisted remediation fields", () => {
+      expect(
+        validateEntityFilter("REMEDIATION", {
+          vulnerabilityId: "vuln_1",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts allowlisted device group matching fields", () => {
+      expect(
+        validateEntityFilter("DEVICE_GROUP_MATCHING", {
+          vendorId: "vendor_1",
+          productId: { in: ["p1", "p2"] },
+        }).success,
+      ).toBe(true);
+    });
+  });
+
+  it("covers every ScopeTargetModel in the registry", () => {
+    expect(Object.keys(TARGET_MODEL_REGISTRY).sort()).toEqual([
+      "ASSET",
+      "DEVICE_GROUP_MATCHING",
+      "REMEDIATION",
+      "VULNERABILITY",
+    ]);
+  });
+});
+
+describe("resolveEntityFilter", () => {
+  it("throws EntityFilterError for an invalid filter before touching the db", async () => {
+    await expect(
+      resolveEntityFilter("ASSET", { bogusColumn: "x" }),
+    ).rejects.toBeInstanceOf(EntityFilterError);
+  });
+});

--- a/src/lib/__tests__/entity-filter.test.ts
+++ b/src/lib/__tests__/entity-filter.test.ts
@@ -79,6 +79,28 @@ describe("validateEntityFilter", () => {
       expect(result.success).toBe(false);
     });
 
+    it("accepts a valid ISO datetime on a date field", () => {
+      expect(
+        validateEntityFilter("ASSET", {
+          createdAt: { gte: "2024-01-01T00:00:00.000Z" },
+        }).success,
+      ).toBe(true);
+      expect(
+        validateEntityFilter("ASSET", { createdAt: "2024-01-01T00:00:00Z" })
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects a malformed datetime on a date field", () => {
+      expect(
+        validateEntityFilter("ASSET", { createdAt: "2024-01-01" }).success,
+      ).toBe(false);
+      expect(
+        validateEntityFilter("ASSET", { createdAt: { gte: "not-a-date" } })
+          .success,
+      ).toBe(false);
+    });
+
     it("rejects Json columns that are intentionally not exposed", () => {
       // `location` is a Json column and is deliberately omitted from the
       // allowlist.

--- a/src/lib/entity-filter.ts
+++ b/src/lib/entity-filter.ts
@@ -68,16 +68,16 @@ const booleanFilter = z.union([
   }),
 ]);
 
-// Dates are carried as ISO strings in JSON; Prisma accepts ISO strings for
-// DateTime filters.
+// Dates are carried as ISO-8601 datetime strings in JSON; validate the format
+// up front so malformed values fail here rather than at query time.
 const dateFilter = z.union([
-  z.string(),
+  z.iso.datetime(),
   z.strictObject({
-    equals: z.string().optional(),
-    lt: z.string().optional(),
-    lte: z.string().optional(),
-    gt: z.string().optional(),
-    gte: z.string().optional(),
+    equals: z.iso.datetime().optional(),
+    lt: z.iso.datetime().optional(),
+    lte: z.iso.datetime().optional(),
+    gt: z.iso.datetime().optional(),
+    gte: z.iso.datetime().optional(),
   }),
 ]);
 
@@ -243,8 +243,9 @@ export function validateEntityFilter(
 
 /**
  * Resolve a filter to the ids of the rows it matches. Throws EntityFilterError
- * if the filter is invalid or the query fails, so callers can skip a single bad
- * filter without aborting a batch.
+ * only when the filter is malformed, so callers can skip a single bad filter
+ * without aborting a batch. Database/query failures propagate unchanged so
+ * transient errors can be retried (e.g. by Inngest) rather than swallowed.
  */
 export async function resolveEntityFilter(
   targetModel: ScopeTargetModel,
@@ -257,14 +258,6 @@ export async function resolveEntityFilter(
     );
   }
 
-  try {
-    const rows = await TARGET_MODEL_REGISTRY[targetModel].query(
-      validation.data,
-    );
-    return rows.map((row) => row.id);
-  } catch (err) {
-    throw new EntityFilterError(`Query failed for ${targetModel}`, {
-      cause: err,
-    });
-  }
+  const rows = await TARGET_MODEL_REGISTRY[targetModel].query(validation.data);
+  return rows.map((row) => row.id);
 }

--- a/src/lib/entity-filter.ts
+++ b/src/lib/entity-filter.ts
@@ -1,0 +1,270 @@
+import "server-only";
+import { z } from "zod";
+import type { Prisma, ScopeTargetModel } from "@/generated/prisma";
+import prisma from "@/lib/db";
+
+// ============================================================================
+// EntityFilter contract
+// ============================================================================
+//
+// An EntityFilter carries a `filter` JSON value that selects rows of the table
+// named by its `targetModel`. To keep authoring safe (filters may be written by
+// the UI or an LLM) we do NOT accept raw SQL. Instead `filter` is a *structured*
+// Prisma `where` object, validated here against a conservative per-model
+// allowlist before it is ever handed to Prisma.
+//
+// The allowlist intentionally exposes only indexed / cheap-to-filter scalar
+// fields (plus a single relation hop where it earns its keep, e.g. Asset ->
+// deviceGroup so a note can target "all infusion pumps"). Unknown fields or
+// operators are rejected
+
+/** Thrown when a filter is malformed, disallowed, or its query fails. */
+export class EntityFilterError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "EntityFilterError";
+    if (options?.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Scalar filter primitives — mirror the safe subset of Prisma's field filters.
+// Each rejects unknown operators via strictObject.
+// ----------------------------------------------------------------------------
+
+const stringFilter = z.union([
+  z.string(),
+  z.strictObject({
+    equals: z.string().optional(),
+    not: z.string().optional(),
+    in: z.array(z.string()).optional(),
+    notIn: z.array(z.string()).optional(),
+    contains: z.string().optional(),
+    startsWith: z.string().optional(),
+    endsWith: z.string().optional(),
+    mode: z.enum(["default", "insensitive"]).optional(),
+  }),
+]);
+
+const numberFilter = z.union([
+  z.number(),
+  z.strictObject({
+    equals: z.number().optional(),
+    not: z.number().optional(),
+    in: z.array(z.number()).optional(),
+    notIn: z.array(z.number()).optional(),
+    lt: z.number().optional(),
+    lte: z.number().optional(),
+    gt: z.number().optional(),
+    gte: z.number().optional(),
+  }),
+]);
+
+const booleanFilter = z.union([
+  z.boolean(),
+  z.strictObject({
+    equals: z.boolean().optional(),
+    not: z.boolean().optional(),
+  }),
+]);
+
+// Dates are carried as ISO strings in JSON; Prisma accepts ISO strings for
+// DateTime filters.
+const dateFilter = z.union([
+  z.string(),
+  z.strictObject({
+    equals: z.string().optional(),
+    lt: z.string().optional(),
+    lte: z.string().optional(),
+    gt: z.string().optional(),
+    gte: z.string().optional(),
+  }),
+]);
+
+const stringListFilter = z.strictObject({
+  has: z.string().optional(),
+  hasEvery: z.array(z.string()).optional(),
+  hasSome: z.array(z.string()).optional(),
+  isEmpty: z.boolean().optional(),
+});
+
+type FieldMap = Record<string, z.ZodTypeAny>;
+
+/**
+ * Build a recursive `where` schema from a scalar field allowlist plus optional
+ * single-hop relation sub-schemas. Every field is optional; AND/OR/NOT compose
+ * the same schema; unknown keys are rejected.
+ */
+function buildWhereSchema(
+  fields: FieldMap,
+  relations: FieldMap = {},
+): z.ZodType<Record<string, unknown>> {
+  const optional = (map: FieldMap): FieldMap =>
+    Object.fromEntries(Object.entries(map).map(([k, v]) => [k, v.optional()]));
+
+  const schema: z.ZodType<Record<string, unknown>> = z.lazy(() =>
+    z.strictObject({
+      ...optional(fields),
+      ...optional(relations),
+      AND: z.array(schema).optional(),
+      OR: z.array(schema).optional(),
+      NOT: z.union([schema, z.array(schema)]).optional(),
+    }),
+  );
+  return schema;
+}
+
+// ----------------------------------------------------------------------------
+// Per-model allowlists. Enum-valued columns are typed as strings here; Prisma is
+// the final arbiter of valid enum members (an invalid value surfaces as an
+// EntityFilterError at query time).
+// ----------------------------------------------------------------------------
+
+// Single relation hop off Asset: lets a note target e.g. all device groups of a
+// vendor/product ("all infusion pumps").
+const deviceGroupWhere = buildWhereSchema({
+  vendorId: stringFilter,
+  productId: stringFilter,
+  versionId: stringFilter,
+  versionStatus: stringFilter,
+  udi: stringFilter,
+  helmSbomId: stringFilter,
+});
+
+const assetFilterSchema = buildWhereSchema(
+  {
+    id: stringFilter,
+    ip: stringFilter,
+    networkSegment: stringFilter,
+    role: stringFilter,
+    hostname: stringFilter,
+    macAddress: stringFilter,
+    serialNumber: stringFilter,
+    status: stringFilter,
+    deviceGroupId: stringFilter,
+    createdAt: dateFilter,
+    updatedAt: dateFilter,
+  },
+  { deviceGroup: deviceGroupWhere },
+);
+
+const vulnerabilityFilterSchema = buildWhereSchema({
+  id: stringFilter,
+  cveId: stringFilter,
+  severity: stringFilter,
+  cvssScore: numberFilter,
+  epss: numberFilter,
+  inKEV: booleanFilter,
+  priority: stringFilter,
+  alohaStatus: stringFilter,
+  affectedComponents: stringListFilter,
+  createdAt: dateFilter,
+});
+
+const remediationFilterSchema = buildWhereSchema({
+  id: stringFilter,
+  vulnerabilityId: stringFilter,
+  alohaStatus: stringFilter,
+  createdAt: dateFilter,
+});
+
+const deviceGroupMatchingFilterSchema = buildWhereSchema({
+  id: stringFilter,
+  vendorId: stringFilter,
+  productId: stringFilter,
+  versionId: stringFilter,
+  versionRange: stringFilter,
+  createdAt: dateFilter,
+});
+
+type RegistryEntry = {
+  schema: z.ZodType<Record<string, unknown>>;
+  query: (where: Record<string, unknown>) => Promise<{ id: string }[]>;
+};
+
+/**
+ * Maps each ScopeTargetModel to its filter schema and the read-only query that
+ * materializes matching ids. `select: { id: true }` keeps the query cheap.
+ */
+export const TARGET_MODEL_REGISTRY: Record<ScopeTargetModel, RegistryEntry> = {
+  ASSET: {
+    schema: assetFilterSchema,
+    query: (where) =>
+      prisma.asset.findMany({
+        where: where as Prisma.AssetWhereInput,
+        select: { id: true },
+      }),
+  },
+  VULNERABILITY: {
+    schema: vulnerabilityFilterSchema,
+    query: (where) =>
+      prisma.vulnerability.findMany({
+        where: where as Prisma.VulnerabilityWhereInput,
+        select: { id: true },
+      }),
+  },
+  REMEDIATION: {
+    schema: remediationFilterSchema,
+    query: (where) =>
+      prisma.remediation.findMany({
+        where: where as Prisma.RemediationWhereInput,
+        select: { id: true },
+      }),
+  },
+  DEVICE_GROUP_MATCHING: {
+    schema: deviceGroupMatchingFilterSchema,
+    query: (where) =>
+      prisma.deviceGroupMatching.findMany({
+        where: where as Prisma.DeviceGroupMatchingWhereInput,
+        select: { id: true },
+      }),
+  },
+};
+
+/**
+ * Validate a filter against its target model's allowlist without running it.
+ * Returns the parsed where object on success.
+ */
+export function validateEntityFilter(
+  targetModel: ScopeTargetModel,
+  filter: unknown,
+):
+  | { success: true; data: Record<string, unknown> }
+  | {
+      success: false;
+      error: string;
+    } {
+  const parsed = TARGET_MODEL_REGISTRY[targetModel].schema.safeParse(filter);
+  if (!parsed.success) {
+    return { success: false, error: z.prettifyError(parsed.error) };
+  }
+  return { success: true, data: parsed.data };
+}
+
+/**
+ * Resolve a filter to the ids of the rows it matches. Throws EntityFilterError
+ * if the filter is invalid or the query fails, so callers can skip a single bad
+ * filter without aborting a batch.
+ */
+export async function resolveEntityFilter(
+  targetModel: ScopeTargetModel,
+  filter: unknown,
+): Promise<string[]> {
+  const validation = validateEntityFilter(targetModel, filter);
+  if (!validation.success) {
+    throw new EntityFilterError(
+      `Invalid filter for ${targetModel}: ${validation.error}`,
+    );
+  }
+
+  try {
+    const rows = await TARGET_MODEL_REGISTRY[targetModel].query(
+      validation.data,
+    );
+    return rows.map((row) => row.id);
+  } catch (err) {
+    throw new EntityFilterError(`Query failed for ${targetModel}`, {
+      cause: err,
+    });
+  }
+}


### PR DESCRIPTION
[Jira Ticket](https://northeastern-patch.atlassian.net/browse/VW-358)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and resolving entity filters across supported asset, vulnerability, remediation, and device-group data.
  * Entity filters now validate supported fields and operators before finding matching records.
  * Filter matches refresh automatically hourly and can be resolved on demand.
  * Relevant notes now appear for records matched through resolved entity filters.

* **Bug Fixes**
  * Improved note retrieval to include filter-based matches alongside direct matches.

* **Tests**
  * Added comprehensive coverage for valid and invalid filter syntax and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->