### PR TITLE
[VW-0] remove advisories sidebar entry

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -77,11 +77,6 @@ const mainItems = [
     url: "/vulnerabilities",
   },
   {
-    title: "Advisories",
-    icon: ShieldAlertIcon,
-    url: "/advisories",
-  },
-  {
     title: "Work Orders",
     icon: ListChecksIcon,
     url: "/tracking",

--- a/src/components/ui/question-tooltip.tsx
+++ b/src/components/ui/question-tooltip.tsx
@@ -20,7 +20,7 @@ export function QuestionTooltip({
           <CircleQuestionMark />
         </Button>
       </TooltipTrigger>
-      <TooltipContent className="pr-1.5">{children}</TooltipContent>
+      <TooltipContent className="pr-1.5 max-w-xs">{children}</TooltipContent>
     </Tooltip>
   );
 }

--- a/src/features/inbox/components/notification-overview-tab.tsx
+++ b/src/features/inbox/components/notification-overview-tab.tsx
@@ -338,7 +338,7 @@ export function NotificationOverviewTab({
         open={!!rejecting}
         onOpenChange={(open) => !open && closeDialog()}
       >
-        <DialogContent className="w-fit min-w-80 sm:max-w-xl">
+        <DialogContent className="w-full min-w-0 sm:w-fit sm:min-w-80 sm:max-w-xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 wrap-anywhere">
               <Unlink className="size-4 text-destructive shrink-0" />

--- a/src/features/inbox/components/notification-overview-tab.tsx
+++ b/src/features/inbox/components/notification-overview-tab.tsx
@@ -338,10 +338,10 @@ export function NotificationOverviewTab({
         open={!!rejecting}
         onOpenChange={(open) => !open && closeDialog()}
       >
-        <DialogContent>
+        <DialogContent className="w-fit min-w-80 sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Unlink className="size-4 text-destructive" />
+            <DialogTitle className="flex items-center gap-2 wrap-anywhere">
+              <Unlink className="size-4 text-destructive shrink-0" />
               Unlink{" "}
               {rejecting
                 ? deviceGroupMatchingLabel(rejecting.deviceGroupMatching)


### PR DESCRIPTION
**fix 1: remove advisories sidebar entry**
it was removed from the clean up pr, but I think it was added back accidentally.

**fix 2: overflow on unlink modal**
Before
<img width="651" height="385" alt="Screenshot 2026-07-16 at 4 38 58 PM" src="https://github.com/user-attachments/assets/51c1201d-6061-4bc6-93ce-109d5d04b3d6" />

After
<img width="636" height="339" alt="Screenshot 2026-07-16 at 4 52 39 PM" src="https://github.com/user-attachments/assets/25417120-5fd4-4249-8ca5-3aebec8d2714" />

**fix 3: tooltip size**
Before
<img width="1325" height="414" alt="Screenshot 2026-07-16 at 6 04 28 PM" src="https://github.com/user-attachments/assets/969ba28a-c82c-449c-8d88-12498261112d" />

After
<img width="515" height="266" alt="Screenshot 2026-07-16 at 6 05 47 PM" src="https://github.com/user-attachments/assets/a4820757-f484-4cd8-aef6-27a51dc5dc88" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Removed the Advisories link from the sidebar.

* **UI Improvements**
  * Constrained question tooltip widths for more readable display.
  * Improved the unlink confirmation dialog layout across screen sizes.
  * Allowed long dialog titles to wrap cleanly and kept the unlink icon properly aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->