### PR TITLE
[VW-379] Pass PDF attachments through Inngest steps instead of refetching

### DIFF
--- a/docs/email-pipeline-setup.md
+++ b/docs/email-pipeline-setup.md
@@ -1,0 +1,129 @@
+# Email Pipeline (Resend) Setup
+
+Detailed, step-by-step reference for getting a real inbound email to run through
+the VIPER inbox pipeline on your machine. For the short version and when you'd
+need this, see the "Email Pipeline (Resend)" section in
+[onboarding.md](./onboarding.md).
+
+VIPER turns inbound security emails into Notifications and Work Order tickets.
+Resend receives the mail, parses it, and calls a webhook on your machine;
+`processInboxEmail` (Inngest) does the rest.
+
+This walks you from nothing to a real email being processed locally. You only
+need it if you're working on the inbox pipeline. Allow ~20 minutes.
+
+## 1. Sign up with a personal email
+
+**Use a personal email address, not your work one.**
+
+Our Google Workspace blocks outbound mail to `*.resend.app`, which is exactly where you'll be sending test emails. If your Resend account is tied to your work address you'll be stuck immediately. Sign up at [resend.com](https://resend.com) with a personal address, and send your test emails from that account.
+
+The free tier is plenty, and you get your own sandbox — no shared credentials.
+
+## 2. Sending vs receiving, and API key permissions
+
+Two distinctions trip people up, and they're unrelated:
+
+**The product has two halves.** *Sending* is transactional email your app pushes out. *Receiving* (inbound) is Resend accepting mail on your behalf, parsing it, and calling a webhook. The inbox pipeline only uses **receiving**.
+
+**API keys have two permission levels.** New keys default to **Sending access**, which cannot read received email. The pipeline calls `emails.receiving.get()` and `attachments.get()`, so it needs **Full access** or it dies immediately with a 401.
+
+Create the key under **API Keys → Create API Key → Full access**, then add it to `.env`:
+
+```
+RESEND_API_KEY=re_xxxxxxxxxxxx
+```
+
+Verify before going further — a `restricted_api_key` error means you made a sending-only key:
+
+```bash
+curl -s -H "Authorization: Bearer $RESEND_API_KEY" https://api.resend.com/emails/receiving
+```
+
+> ⚠️ Secrets go in `.env`, **never `.env.ci`**. Despite `.gitignore` listing `.env*`, `.env.ci` is *tracked* — tracked files ignore that pattern — and it feeds a GitHub Actions workflow. A key committed there is a leaked key.
+
+## 3. Get your receiving address
+
+Resend gives you a working inbound address with **no domain and no DNS setup**:
+
+> **Emails → Receiving** tab → **⋯** → **Receiving address**
+
+You'll get something like `anything@ab12cd34.resend.app`. The part before the `@` is freeform, so `test@`, `advisories@` etc. all land in the same inbox.
+
+> 🚫 If the dashboard pushes you to "Add a domain", back out. Adding a company domain would reroute real company email into Resend. You do not need it.
+
+## 4. Expose your local app to the internet
+
+Resend has to reach your laptop, so you need a tunnel. (Same applies if you're testing with n8n.)
+
+**cloudflared** is easiest — no account needed:
+
+```bash
+brew install cloudflared
+cloudflared tunnel --url http://localhost:3000
+```
+
+It prints a URL like `https://corps-issn-portrait-fighter.trycloudflare.com`. Keep the terminal open; **if the process dies the URL changes** and you'll have to update the webhook.
+
+**ngrok** works too, but needs a free account and `ngrok config add-authtoken <token>` first, then `ngrok http 3000`.
+
+Run VIPER with the tunnel URL so the links it generates are correct:
+
+```bash
+NEXT_PUBLIC_APP_URL="https://<YOUR_TUNNEL_URL>" npm run dev:all
+```
+
+## 5. Point a webhook at your machine
+
+> **Webhooks → Add Webhook**
+> - **Endpoint URL:** `https://<YOUR_TUNNEL_URL>/api/email`
+> - **Event:** `email.received` — that one only
+
+Copy the **signing secret** it shows you into `.env`:
+
+```
+RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
+```
+
+`/api/email` returns a 500 until *both* `RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET` are set. Restart the dev server after editing `.env` — it's only read at boot.
+
+Sanity check — a **400 is correct** here, it means the route is live and rejecting an unsigned payload. A 500 means a missing env var; a 404 means the tunnel is pointing at the wrong port.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X POST \
+  https://<YOUR_TUNNEL_URL>/api/email -H 'content-type: application/json' -d '{}'
+```
+
+## 6. Set your Anthropic key
+
+The pipeline makes several Anthropic calls (relevance triage, classification, entity extraction, hospital-impact triage), so `ANTHROPIC_API_KEY` must be set in `.env` or the run fails partway through.
+
+## 7. Send a test email
+
+From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
+
+Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
+
+## 8. Watch it run
+
+Resend POSTs to `/api/email`, which enqueues an Inngest event.
+
+**Inngest dev UI — <http://localhost:8288>** → *Runs* → newest `process-inbox-email`. Every step and its output is visible, which makes this the best place to debug.
+
+Note the webhook payload is **metadata only** — no body, no attachment bytes. The pipeline calls Resend back for the email content and downloads each attachment separately.
+
+**MinIO console — <http://localhost:9001>** (login `minioadmin` / `minioadmin`) → the `viper` bucket → `inbox/<emailId>/`. Attachments are uploaded here, and it's the quickest way to confirm they made it.
+
+**Database** — a successful run leaves a `notification_source` row joined to a `notification` (with `type`, `priority` and a populated `hospitalImpact`), plus one `notification_attachment` per file.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Run dies at `fetch-email-content` with a 401 | Sending-only API key | Step 2 |
+| `/api/email` returns 500 | `RESEND_API_KEY` or `RESEND_WEBHOOK_SECRET` missing from `.env` | Steps 2 & 5 |
+| `/api/email` returns 404 | Tunnel pointing at the wrong port | Step 4 |
+| Webhook never arrives | Tunnel died, so its URL changed | Restart it, update the webhook URL |
+| Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account (step 1) |
+| Run returns `{skipped: true, reason: "duplicate"}` | That email was already processed — `externalId` is unique | Send a new email |
+| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory (step 7) |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -101,46 +101,25 @@ How do I log in?
 What's our production environment?
 - See, "What's our staging environment?". This is a research project.
 
-## Exposing your local app to the internet
+## Email Pipeline (Resend) Setup
 
-If you're testing with Resend or n8n, an external service needs to reach your laptop, so you need a tunnel.
+VIPER turns inbound security emails into Notifications and Work Order tickets. Resend receives the mail, parses it, and calls a webhook on your machine; `processInboxEmail` (Inngest) does the rest.
 
-**cloudflared** is the easiest — no account needed:
-
-```bash
-brew install cloudflared
-cloudflared tunnel --url http://localhost:3000
-```
-
-It prints a URL like `https://corps-issn-portrait-fighter.trycloudflare.com`. Keep the terminal open; **if the process dies the URL changes**, and you'll have to update anything pointing at it.
-
-**ngrok** works too, but needs a free account and `ngrok config add-authtoken <token>` first, then `ngrok http 3000`.
-
-Either way, run VIPER with the tunnel URL so links it generates are correct:
-
-```bash
-NEXT_PUBLIC_APP_URL="https://<YOUR_TUNNEL_URL>" npm run dev:all
-```
-
-## Setting up Resend (inbound email)
-
-VIPER turns inbound security emails into Notifications and Work Order tickets. This walks you from nothing to a real email being processed on your machine.
-
-You only need this if you're working on the inbox pipeline. Allow ~20 minutes.
+This walks you from nothing to a real email being processed locally. You only need it if you're working on the inbox pipeline. Allow ~20 minutes.
 
 ### 1. Sign up with a personal email
 
 **Use a personal email address, not your work one.**
 
-Our Google Workspace blocks outbound mail to `*.resend.app`, which is exactly where you'll be sending test emails. If your Resend account is tied to your work address you'll be stuck immediately. Sign up at [resend.com](https://resend.com) with a personal address and send your test emails from there.
+Our Google Workspace blocks outbound mail to `*.resend.app`, which is exactly where you'll be sending test emails. If your Resend account is tied to your work address you'll be stuck immediately. Sign up at [resend.com](https://resend.com) with a personal address, and send your test emails from that account.
 
-You get your own free sandbox — no need to share credentials with anyone.
+The free tier is plenty, and you get your own sandbox — no shared credentials.
 
-### 2. Sending vs receiving
+### 2. Sending vs receiving, and API key permissions
 
 Two distinctions trip people up, and they're unrelated:
 
-**The product has two halves.** *Sending* is transactional email your app pushes out. *Receiving* (inbound) is Resend accepting mail on your behalf, parsing it, and calling a webhook. VIPER's inbox pipeline only uses **receiving**.
+**The product has two halves.** *Sending* is transactional email your app pushes out. *Receiving* (inbound) is Resend accepting mail on your behalf, parsing it, and calling a webhook. The inbox pipeline only uses **receiving**.
 
 **API keys have two permission levels.** New keys default to **Sending access**, which cannot read received email. The pipeline calls `emails.receiving.get()` and `attachments.get()`, so it needs **Full access** or it dies immediately with a 401.
 
@@ -150,13 +129,11 @@ Create the key under **API Keys → Create API Key → Full access**, then add i
 RESEND_API_KEY=re_xxxxxxxxxxxx
 ```
 
-Verify before going further:
+Verify before going further — a `restricted_api_key` error means you made a sending-only key:
 
 ```bash
 curl -s -H "Authorization: Bearer $RESEND_API_KEY" https://api.resend.com/emails/receiving
 ```
-
-A `restricted_api_key` error means you made a sending-only key.
 
 > ⚠️ Secrets go in `.env`, **never `.env.ci`**. Despite `.gitignore` listing `.env*`, `.env.ci` is *tracked* — tracked files ignore that pattern — and it feeds a GitHub Actions workflow. A key committed there is a leaked key.
 
@@ -170,9 +147,28 @@ You'll get something like `anything@ab12cd34.resend.app`. The part before the `@
 
 > 🚫 If the dashboard pushes you to "Add a domain", back out. Adding a company domain would reroute real company email into Resend. You do not need it.
 
-### 4. Point a webhook at your machine
+### 4. Expose your local app to the internet
 
-Start your tunnel (see the section above), then:
+Resend has to reach your laptop, so you need a tunnel. (Same applies if you're testing with n8n.)
+
+**cloudflared** is easiest — no account needed:
+
+```bash
+brew install cloudflared
+cloudflared tunnel --url http://localhost:3000
+```
+
+It prints a URL like `https://corps-issn-portrait-fighter.trycloudflare.com`. Keep the terminal open; **if the process dies the URL changes** and you'll have to update the webhook.
+
+**ngrok** works too, but needs a free account and `ngrok config add-authtoken <token>` first, then `ngrok http 3000`.
+
+Run VIPER with the tunnel URL so the links it generates are correct:
+
+```bash
+NEXT_PUBLIC_APP_URL="https://<YOUR_TUNNEL_URL>" npm run dev:all
+```
+
+### 5. Point a webhook at your machine
 
 > **Webhooks → Add Webhook**
 > - **Endpoint URL:** `https://<YOUR_TUNNEL_URL>/api/email`
@@ -186,84 +182,47 @@ RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
 
 `/api/email` returns a 500 until *both* `RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET` are set. Restart the dev server after editing `.env` — it's only read at boot.
 
-Sanity check — a 400 here is **correct**, it means the route is live and rejecting an unsigned payload:
+Sanity check — a **400 is correct** here, it means the route is live and rejecting an unsigned payload. A 500 means a missing env var; a 404 means the tunnel is pointing at the wrong port.
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" -X POST \
   https://<YOUR_TUNNEL_URL>/api/email -H 'content-type: application/json' -d '{}'
 ```
 
-A 500 means a missing env var; a 404 means the tunnel is pointing at the wrong port.
-
-### 5. Set your Anthropic key
+### 6. Set your Anthropic key
 
 The pipeline makes several Anthropic calls (relevance triage, classification, entity extraction, hospital-impact triage), so `ANTHROPIC_API_KEY` must be set in `.env` or the run fails partway through.
 
-### 6. Send a test email
+### 7. Send a test email
 
 From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
 
 Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
 
-### 7. Watch the pipeline run
+### 8. Watch it run
 
-Resend POSTs to `/api/email`, which enqueues an Inngest event; `processInboxEmail` does the rest.
+Resend POSTs to `/api/email`, which enqueues an Inngest event.
 
 **Inngest dev UI — <http://localhost:8288>** → *Runs* → newest `process-inbox-email`. Every step and its output is visible, which makes this the best place to debug.
 
-Note the webhook payload is **metadata only** — no body, no attachment bytes. The pipeline calls Resend back for the email content and downloads each attachment separately. That's why a failure to reach Resend can leave you with a Notification that has no attachments.
+Note the webhook payload is **metadata only** — no body, no attachment bytes. The pipeline calls Resend back for the email content and downloads each attachment separately.
 
-**MinIO console — <http://localhost:9001>** (login `minioadmin` / `minioadmin`) → the `viper` bucket → `inbox/<emailId>/`. Attachments are uploaded here, and this is the quickest way to confirm they actually made it.
+**MinIO console — <http://localhost:9001>** (login `minioadmin` / `minioadmin`) → the `viper` bucket → `inbox/<emailId>/`. Attachments are uploaded here, and it's the quickest way to confirm they made it.
 
-**Database** — a successful run leaves a `notification_source` row joined to a `notification` (with `type`, `priority` and a populated `hospitalImpact`) plus one `notification_attachment` per file.
+**Database** — a successful run leaves a `notification_source` row joined to a `notification` (with `type`, `priority` and a populated `hospitalImpact`), plus one `notification_attachment` per file.
 
 ### Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Notification created but **zero attachments**, log shows `Failed to download attachment` | Cisco Umbrella on company laptops sinkholes `cdn.resend.app` as malware. `api.resend.com` is *not* blocked, so everything else looks fine | See below |
 | Run dies at `fetch-email-content` with a 401 | Sending-only API key | Step 2 |
-| `/api/email` returns 500 | `RESEND_API_KEY` or `RESEND_WEBHOOK_SECRET` missing | Steps 2 & 4 |
-| Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account |
+| `/api/email` returns 500 | `RESEND_API_KEY` or `RESEND_WEBHOOK_SECRET` missing from `.env` | Steps 2 & 5 |
+| `/api/email` returns 404 | Tunnel pointing at the wrong port | Step 4 |
+| Webhook never arrives | Tunnel died, so its URL changed | Restart it, update the webhook URL |
+| Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account (step 1) |
 | Run returns `{skipped: true, reason: "duplicate"}` | That email was already processed — `externalId` is unique | Send a new email |
-| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory |
+| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory (step 7) |
 
-**The Umbrella block.** Check with `dig +short cdn.resend.app` — `146.112.61.x` means blocked, a `cloudfront.net` address means fine. Turning off the VPN won't help (the DNS module is separate from AnyConnect), a hotspot won't help (the agent is on the machine), and `/etc/hosts` needs `sudo`.
-
-Umbrella intercepts *name resolution*, not the connection, so the workaround is to have Node resolve that one hostname via public DNS. Save this outside the repo as `~/viper-dev/dns-public.cjs`:
-
-```js
-const dns = require("node:dns");
-const OVERRIDE = /(^|\.)resend\.app$/i;
-const resolver = new dns.Resolver();
-resolver.setServers(["1.1.1.1", "8.8.8.8"]);
-const originalLookup = dns.lookup;
-
-dns.lookup = function (hostname, options, callback) {
-  if (typeof options === "function") { callback = options; options = {}; }
-  const opts = typeof options === "number" ? { family: options } : options || {};
-  if (!OVERRIDE.test(hostname)) {
-    return originalLookup.call(dns, hostname, options, callback);
-  }
-  resolver.resolve4(hostname, (err, addresses) => {
-    if (err || !addresses?.length) {
-      return originalLookup.call(dns, hostname, options, callback);
-    }
-    if (opts.all) {
-      return callback(null, addresses.map((address) => ({ address, family: 4 })));
-    }
-    callback(null, addresses[0], 4);
-  });
-};
-```
-
-Then start the dev server with it preloaded:
-
-```bash
-NODE_OPTIONS="--require $HOME/viper-dev/dns-public.cjs" npm run dev:all
-```
-
-This is a local workaround. The real fix is IT allowlisting `*.resend.app` — worth asking, since it blocks every developer.
 
 ## Additional Resources
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -101,127 +101,37 @@ How do I log in?
 What's our production environment?
 - See, "What's our staging environment?". This is a research project.
 
-## Email Pipeline (Resend) Setup
+## Email Pipeline (Resend)
+The email pipeline is essential for testing anything in the inbox flow (e.g. Notifications, Work Orders). 
 
-VIPER turns inbound security emails into Notifications and Work Order tickets. Resend receives the mail, parses it, and calls a webhook on your machine; `processInboxEmail` (Inngest) does the rest.
+What do I need?
+- You need access to Resend. This is separate from the core-project access IT sets you up with on your first day, so you'll need your own Resend account. Reach out to the team for a project-dedicated email, or use your personal email if you don't have one.
 
-This walks you from nothing to a real email being processed locally. You only need it if you're working on the inbox pipeline. Allow ~20 minutes.
+Where do I get Resend API keys and Secrets?
+- You need two values in your `.env`: `RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET`. The `/api/email` route checks for both on every request and returns a 500 if either is missing, so the pipeline does nothing until you have both.
+- The API key: once you're in the Resend dashboard, three sections in the side nav matter — Emails, API keys, and Webhooks. Signing up automatically creates an "Onboarding" API key. Go to API keys, find that key, click the ellipsis (...) at the end of the row, hit Edit, and change its permission to "Full Access". By default it's sending-only, which can't read inbound email, and the pipeline reads inbound email — so a sending-only key fails. Copy the key into `.env` as `RESEND_API_KEY`.
+- The webhook secret comes from the webhook step below, not here.
 
-### 1. Sign up with a personal email
+How to set up the webhook?
+- First make your local server reachable from the internet with ngrok or cloudflared (more info **[here](./email-pipeline-setup.md)**). That gives you a public URL like `https://something.trycloudflare.com`; your webhook target is that URL plus `/api/email`.
+- In Resend's Webhooks section, create a webhook pointing at `https://<your-tunnel>/api/email` and subscribe to the "email.received" event.
+- Creating the webhook gives you a signing secret (it looks like `whsec_...`). Copy it into `.env` as `RESEND_WEBHOOK_SECRET`. The route verifies every incoming webhook against this secret, so if it's missing or wrong you'll get a 400 and the email never reaches Inngest — with no obvious error on the Resend side. This is the second of the two values from the section above.
 
-**Use a personal email address, not your work one.**
+How to trigger an "email.received" event?
+- To replicate the event, go to the Email section in the side nav and open the "Receiving" tab. It shows the Resend test address to send to. Send a test email to that address from your own inbox.
 
-Our Google Workspace blocks outbound mail to `*.resend.app`, which is exactly where you'll be sending test emails. If your Resend account is tied to your work address you'll be stuck immediately. Sign up at [resend.com](https://resend.com) with a personal address, and send your test emails from that account.
+TIPS: 
+- If you don't see the test address, it's probably because you've already received an email. Use the address in the "To" column, or click the ellipsis (...) at the top right and choose "Receiving Address" to see it.
+- Give the email a real subject, like "Hospital Equipment Details". Don't just put "testing": Google may flag it, and if you fire off a lot of test emails back-to-back (which happens when you're testing), Google can block you from sending more, thinking you're a spammer.
 
-The free tier is plenty, and you get your own sandbox — no shared credentials.
+How to know if it works?
+- Have the Inngest dev server running first (`npm run dev:all` runs everything, or `npm run inngest:dev` on its own). Its UI is at http://localhost:8288.
+- If it worked, the Inngest UI shows a new run for the `process-inbox-email` function — that's the event landing and the pipeline kicking off. Open the run to watch each step (classify, extract, match) and see the Notification or Work Order it creates.
+- If nothing shows up, the usual causes are: a sending-only API key, a missing or mismatched `RESEND_WEBHOOK_SECRET`, or a dead tunnel (if the ngrok/cloudflared process restarts, the URL changes and the old webhook points nowhere — update the webhook URL in Resend).
 
-### 2. Sending vs receiving, and API key permissions
 
-Two distinctions trip people up, and they're unrelated:
-
-**The product has two halves.** *Sending* is transactional email your app pushes out. *Receiving* (inbound) is Resend accepting mail on your behalf, parsing it, and calling a webhook. The inbox pipeline only uses **receiving**.
-
-**API keys have two permission levels.** New keys default to **Sending access**, which cannot read received email. The pipeline calls `emails.receiving.get()` and `attachments.get()`, so it needs **Full access** or it dies immediately with a 401.
-
-Create the key under **API Keys → Create API Key → Full access**, then add it to `.env`:
-
-```
-RESEND_API_KEY=re_xxxxxxxxxxxx
-```
-
-Verify before going further — a `restricted_api_key` error means you made a sending-only key:
-
-```bash
-curl -s -H "Authorization: Bearer $RESEND_API_KEY" https://api.resend.com/emails/receiving
-```
-
-> ⚠️ Secrets go in `.env`, **never `.env.ci`**. Despite `.gitignore` listing `.env*`, `.env.ci` is *tracked* — tracked files ignore that pattern — and it feeds a GitHub Actions workflow. A key committed there is a leaked key.
-
-### 3. Get your receiving address
-
-Resend gives you a working inbound address with **no domain and no DNS setup**:
-
-> **Emails → Receiving** tab → **⋯** → **Receiving address**
-
-You'll get something like `anything@ab12cd34.resend.app`. The part before the `@` is freeform, so `test@`, `advisories@` etc. all land in the same inbox.
-
-> 🚫 If the dashboard pushes you to "Add a domain", back out. Adding a company domain would reroute real company email into Resend. You do not need it.
-
-### 4. Expose your local app to the internet
-
-Resend has to reach your laptop, so you need a tunnel. (Same applies if you're testing with n8n.)
-
-**cloudflared** is easiest — no account needed:
-
-```bash
-brew install cloudflared
-cloudflared tunnel --url http://localhost:3000
-```
-
-It prints a URL like `https://corps-issn-portrait-fighter.trycloudflare.com`. Keep the terminal open; **if the process dies the URL changes** and you'll have to update the webhook.
-
-**ngrok** works too, but needs a free account and `ngrok config add-authtoken <token>` first, then `ngrok http 3000`.
-
-Run VIPER with the tunnel URL so the links it generates are correct:
-
-```bash
-NEXT_PUBLIC_APP_URL="https://<YOUR_TUNNEL_URL>" npm run dev:all
-```
-
-### 5. Point a webhook at your machine
-
-> **Webhooks → Add Webhook**
-> - **Endpoint URL:** `https://<YOUR_TUNNEL_URL>/api/email`
-> - **Event:** `email.received` — that one only
-
-Copy the **signing secret** it shows you into `.env`:
-
-```
-RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
-```
-
-`/api/email` returns a 500 until *both* `RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET` are set. Restart the dev server after editing `.env` — it's only read at boot.
-
-Sanity check — a **400 is correct** here, it means the route is live and rejecting an unsigned payload. A 500 means a missing env var; a 404 means the tunnel is pointing at the wrong port.
-
-```bash
-curl -s -o /dev/null -w "%{http_code}\n" -X POST \
-  https://<YOUR_TUNNEL_URL>/api/email -H 'content-type: application/json' -d '{}'
-```
-
-### 6. Set your Anthropic key
-
-The pipeline makes several Anthropic calls (relevance triage, classification, entity extraction, hospital-impact triage), so `ANTHROPIC_API_KEY` must be set in `.env` or the run fails partway through.
-
-### 7. Send a test email
-
-From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
-
-Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
-
-### 8. Watch it run
-
-Resend POSTs to `/api/email`, which enqueues an Inngest event.
-
-**Inngest dev UI — <http://localhost:8288>** → *Runs* → newest `process-inbox-email`. Every step and its output is visible, which makes this the best place to debug.
-
-Note the webhook payload is **metadata only** — no body, no attachment bytes. The pipeline calls Resend back for the email content and downloads each attachment separately.
-
-**MinIO console — <http://localhost:9001>** (login `minioadmin` / `minioadmin`) → the `viper` bucket → `inbox/<emailId>/`. Attachments are uploaded here, and it's the quickest way to confirm they made it.
-
-**Database** — a successful run leaves a `notification_source` row joined to a `notification` (with `type`, `priority` and a populated `hospitalImpact`), plus one `notification_attachment` per file.
-
-### Troubleshooting
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| Run dies at `fetch-email-content` with a 401 | Sending-only API key | Step 2 |
-| `/api/email` returns 500 | `RESEND_API_KEY` or `RESEND_WEBHOOK_SECRET` missing from `.env` | Steps 2 & 5 |
-| `/api/email` returns 404 | Tunnel pointing at the wrong port | Step 4 |
-| Webhook never arrives | Tunnel died, so its URL changed | Restart it, update the webhook URL |
-| Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account (step 1) |
-| Run returns `{skipped: true, reason: "duplicate"}` | That email was already processed — `externalId` is unique | Send a new email |
-| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory (step 7) |
+Full walkthrough (agentic) — API key, tunnel, webhook, sending a test email, and where to
+watch it land: **[Email Pipeline (Resend) Setup](./email-pipeline-setup.md)**.
 
 
 ## Additional Resources

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -101,15 +101,169 @@ How do I log in?
 What's our production environment?
 - See, "What's our staging environment?". This is a research project.
 
-## Using ngrok
+## Exposing your local app to the internet
 
-If you're testing with Resend or n8n, you'll likely need to use ngrok (or a similar tool, like localtunnel).
+If you're testing with Resend or n8n, an external service needs to reach your laptop, so you need a tunnel.
 
-Install ngrok (homebrew should work on mac). Run `ngrok 3000` to tunnel/forward localhost:3000 to the public internet. This should give you a url.
+**cloudflared** is the easiest — no account needed:
 
-Run VIPER with `NEXT_PUBLIC_APP_URL="https://<YOUR_URL_HERE>.ngrok-free.dev" npm run dev:all`
+```bash
+brew install cloudflared
+cloudflared tunnel --url http://localhost:3000
+```
 
-You should be able to view your app on the web at `https://<YOUR_URL_HERE>.ngrok-free.dev`.
+It prints a URL like `https://corps-issn-portrait-fighter.trycloudflare.com`. Keep the terminal open; **if the process dies the URL changes**, and you'll have to update anything pointing at it.
+
+**ngrok** works too, but needs a free account and `ngrok config add-authtoken <token>` first, then `ngrok http 3000`.
+
+Either way, run VIPER with the tunnel URL so links it generates are correct:
+
+```bash
+NEXT_PUBLIC_APP_URL="https://<YOUR_TUNNEL_URL>" npm run dev:all
+```
+
+## Setting up Resend (inbound email)
+
+VIPER turns inbound security emails into Notifications and Work Order tickets. This walks you from nothing to a real email being processed on your machine.
+
+You only need this if you're working on the inbox pipeline. Allow ~20 minutes.
+
+### 1. Sign up with a personal email
+
+**Use a personal email address, not your work one.**
+
+Our Google Workspace blocks outbound mail to `*.resend.app`, which is exactly where you'll be sending test emails. If your Resend account is tied to your work address you'll be stuck immediately. Sign up at [resend.com](https://resend.com) with a personal address and send your test emails from there.
+
+You get your own free sandbox — no need to share credentials with anyone.
+
+### 2. Sending vs receiving
+
+Two distinctions trip people up, and they're unrelated:
+
+**The product has two halves.** *Sending* is transactional email your app pushes out. *Receiving* (inbound) is Resend accepting mail on your behalf, parsing it, and calling a webhook. VIPER's inbox pipeline only uses **receiving**.
+
+**API keys have two permission levels.** New keys default to **Sending access**, which cannot read received email. The pipeline calls `emails.receiving.get()` and `attachments.get()`, so it needs **Full access** or it dies immediately with a 401.
+
+Create the key under **API Keys → Create API Key → Full access**, then add it to `.env`:
+
+```
+RESEND_API_KEY=re_xxxxxxxxxxxx
+```
+
+Verify before going further:
+
+```bash
+curl -s -H "Authorization: Bearer $RESEND_API_KEY" https://api.resend.com/emails/receiving
+```
+
+A `restricted_api_key` error means you made a sending-only key.
+
+> ⚠️ Secrets go in `.env`, **never `.env.ci`**. Despite `.gitignore` listing `.env*`, `.env.ci` is *tracked* — tracked files ignore that pattern — and it feeds a GitHub Actions workflow. A key committed there is a leaked key.
+
+### 3. Get your receiving address
+
+Resend gives you a working inbound address with **no domain and no DNS setup**:
+
+> **Emails → Receiving** tab → **⋯** → **Receiving address**
+
+You'll get something like `anything@ab12cd34.resend.app`. The part before the `@` is freeform, so `test@`, `advisories@` etc. all land in the same inbox.
+
+> 🚫 If the dashboard pushes you to "Add a domain", back out. Adding a company domain would reroute real company email into Resend. You do not need it.
+
+### 4. Point a webhook at your machine
+
+Start your tunnel (see the section above), then:
+
+> **Webhooks → Add Webhook**
+> - **Endpoint URL:** `https://<YOUR_TUNNEL_URL>/api/email`
+> - **Event:** `email.received` — that one only
+
+Copy the **signing secret** it shows you into `.env`:
+
+```
+RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
+```
+
+`/api/email` returns a 500 until *both* `RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET` are set. Restart the dev server after editing `.env` — it's only read at boot.
+
+Sanity check — a 400 here is **correct**, it means the route is live and rejecting an unsigned payload:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X POST \
+  https://<YOUR_TUNNEL_URL>/api/email -H 'content-type: application/json' -d '{}'
+```
+
+A 500 means a missing env var; a 404 means the tunnel is pointing at the wrong port.
+
+### 5. Set your Anthropic key
+
+The pipeline makes several Anthropic calls (relevance triage, classification, entity extraction, hospital-impact triage), so `ANTHROPIC_API_KEY` must be set in `.env` or the run fails partway through.
+
+### 6. Send a test email
+
+From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
+
+Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
+
+### 7. Watch the pipeline run
+
+Resend POSTs to `/api/email`, which enqueues an Inngest event; `processInboxEmail` does the rest.
+
+**Inngest dev UI — <http://localhost:8288>** → *Runs* → newest `process-inbox-email`. Every step and its output is visible, which makes this the best place to debug.
+
+Note the webhook payload is **metadata only** — no body, no attachment bytes. The pipeline calls Resend back for the email content and downloads each attachment separately. That's why a failure to reach Resend can leave you with a Notification that has no attachments.
+
+**MinIO console — <http://localhost:9001>** (login `minioadmin` / `minioadmin`) → the `viper` bucket → `inbox/<emailId>/`. Attachments are uploaded here, and this is the quickest way to confirm they actually made it.
+
+**Database** — a successful run leaves a `notification_source` row joined to a `notification` (with `type`, `priority` and a populated `hospitalImpact`) plus one `notification_attachment` per file.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Notification created but **zero attachments**, log shows `Failed to download attachment` | Cisco Umbrella on company laptops sinkholes `cdn.resend.app` as malware. `api.resend.com` is *not* blocked, so everything else looks fine | See below |
+| Run dies at `fetch-email-content` with a 401 | Sending-only API key | Step 2 |
+| `/api/email` returns 500 | `RESEND_API_KEY` or `RESEND_WEBHOOK_SECRET` missing | Steps 2 & 4 |
+| Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account |
+| Run returns `{skipped: true, reason: "duplicate"}` | That email was already processed — `externalId` is unique | Send a new email |
+| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory |
+
+**The Umbrella block.** Check with `dig +short cdn.resend.app` — `146.112.61.x` means blocked, a `cloudfront.net` address means fine. Turning off the VPN won't help (the DNS module is separate from AnyConnect), a hotspot won't help (the agent is on the machine), and `/etc/hosts` needs `sudo`.
+
+Umbrella intercepts *name resolution*, not the connection, so the workaround is to have Node resolve that one hostname via public DNS. Save this outside the repo as `~/viper-dev/dns-public.cjs`:
+
+```js
+const dns = require("node:dns");
+const OVERRIDE = /(^|\.)resend\.app$/i;
+const resolver = new dns.Resolver();
+resolver.setServers(["1.1.1.1", "8.8.8.8"]);
+const originalLookup = dns.lookup;
+
+dns.lookup = function (hostname, options, callback) {
+  if (typeof options === "function") { callback = options; options = {}; }
+  const opts = typeof options === "number" ? { family: options } : options || {};
+  if (!OVERRIDE.test(hostname)) {
+    return originalLookup.call(dns, hostname, options, callback);
+  }
+  resolver.resolve4(hostname, (err, addresses) => {
+    if (err || !addresses?.length) {
+      return originalLookup.call(dns, hostname, options, callback);
+    }
+    if (opts.all) {
+      return callback(null, addresses.map((address) => ({ address, family: 4 })));
+    }
+    callback(null, addresses[0], 4);
+  });
+};
+```
+
+Then start the dev server with it preloaded:
+
+```bash
+NODE_OPTIONS="--require $HOME/viper-dev/dns-public.cjs" npm run dev:all
+```
+
+This is a local workaround. The real fix is IT allowlisting `*.resend.app` — worth asking, since it blocks every developer.
 
 ## Additional Resources
 

--- a/src/features/inbox/agent/classify.ts
+++ b/src/features/inbox/agent/classify.ts
@@ -4,7 +4,7 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { z } from "zod";
-import { buildUserMessage } from "@/lib/agent-messages";
+import { buildUserMessage, type PdfAttachment } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { notificationPayloadSchema } from "../types";
 import { fetchPdfAttachments } from "../utils";
@@ -85,9 +85,10 @@ ${existing}`;
 export async function classifyNotification(
   sourceId: string,
   email: InboundEmail,
+  inlinedPdfs?: PdfAttachment[],
 ): Promise<ClassifyResult> {
   const [pdfAttachments, existingNotifications] = await Promise.all([
-    fetchPdfAttachments(sourceId),
+    inlinedPdfs ?? fetchPdfAttachments(sourceId),
     prisma.notification.findMany({
       select: { id: true, type: true, title: true, summary: true },
       orderBy: { createdAt: "desc" },

--- a/src/features/inbox/agent/extract-work-order.ts
+++ b/src/features/inbox/agent/extract-work-order.ts
@@ -4,7 +4,7 @@
 
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { buildUserMessage } from "@/lib/agent-messages";
+import { buildUserMessage, type PdfAttachment } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { type WorkOrderPayload, workOrderPayloadSchema } from "../types";
 import { fetchPdfAttachments } from "../utils";
@@ -26,9 +26,10 @@ Only include values you are reasonably confident about. Do not invent dates or a
 export async function extractWorkOrder(
   sourceId: string,
   email: InboundEmail,
+  inlinedPdfs?: PdfAttachment[],
 ): Promise<WorkOrderPayload> {
   const [pdfAttachments, departments] = await Promise.all([
-    fetchPdfAttachments(sourceId),
+    inlinedPdfs ?? fetchPdfAttachments(sourceId),
     prisma.department.findMany({
       select: { name: true },
       orderBy: { name: "asc" },

--- a/src/features/inbox/agent/extract.ts
+++ b/src/features/inbox/agent/extract.ts
@@ -3,7 +3,7 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { z } from "zod";
-import { buildUserMessage } from "@/lib/agent-messages";
+import { buildUserMessage, type PdfAttachment } from "@/lib/agent-messages";
 import { fetchPdfAttachments } from "../utils";
 import { emailPromptText, type InboundEmail } from "./prompt";
 
@@ -102,8 +102,9 @@ RULES:
 export async function extractEntities(
   sourceId: string,
   email: InboundEmail,
+  inlinedPdfs?: PdfAttachment[],
 ): Promise<ExtractResult> {
-  const pdfAttachments = await fetchPdfAttachments(sourceId);
+  const pdfAttachments = inlinedPdfs ?? (await fetchPdfAttachments(sourceId));
 
   const model = new ChatAnthropic({
     model: MODEL,

--- a/src/features/inbox/agent/triage/index.ts
+++ b/src/features/inbox/agent/triage/index.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { z } from "zod";
-import { buildUserMessage } from "@/lib/agent-messages";
+import { buildUserMessage, type PdfAttachment } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { hospitalImpactSchema } from "../../types";
 import { fetchPdfAttachments } from "../../utils";
@@ -62,6 +62,7 @@ ${input.contextMarkdown}`;
 export async function triageNotification(
   sourceId: string,
   notificationId: string,
+  inlinedPdfs?: PdfAttachment[],
 ): Promise<TriageResult> {
   const [source, notification, pdfAttachments, context] = await Promise.all([
     prisma.notificationSource.findUnique({
@@ -72,7 +73,7 @@ export async function triageNotification(
       where: { id: notificationId },
       select: { type: true, title: true, summary: true },
     }),
-    fetchPdfAttachments(sourceId),
+    inlinedPdfs ?? fetchPdfAttachments(sourceId),
     gatherTriageContext(notificationId),
   ]);
 

--- a/src/features/inbox/utils.ts
+++ b/src/features/inbox/utils.ts
@@ -14,39 +14,18 @@ const isPdf = (a: {
   );
 
 /**
- * Ceiling on the summed Resend-reported `size` of an email's PDFs for them to
- * be carried through Inngest step state instead of re-fetched from S3.
- *
- * Resend does not document the unit, so we assume the worst case (decoded
- * bytes). Base64 inflates ~4/3, and the encoded string is what rides in the
- * step output, which Inngest caps at 4MiB — so 3MB here lands at ~4MB encoded.
+ * Ceiling on the total base64 length of an email's PDFs for them to be carried
+ * through Inngest step state instead of re-fetched from S3. The encoded string
+ * is what rides in the step output, which Inngest caps at 4MiB (4,194,304) —
+ * the remainder is headroom for the rest of the step's JSON.
  */
-export const INLINE_ATTACHMENT_BUDGET = 3_000_000;
-
-type ResendAttachmentMeta = {
-  filename?: string | null;
-  content_type?: string | null;
-  size?: number | null;
-};
+export const INLINE_ATTACHMENT_BUDGET = 4_000_000;
 
 /** A PDF carried through step state, keyed back to its Resend attachment. */
 export type InlinePdfAttachment = PdfAttachment & { id: string };
 
-/**
- * Whether an email's PDFs are small enough to pass through step state. An
- * attachment with no reported size is treated as too big — the S3 fallback is
- * always correct, so unknowns resolve that way.
- */
-export function pdfsFitInlineBudget(
-  attachments: ResendAttachmentMeta[],
-): boolean {
-  const pdfs = attachments.filter((a) =>
-    isPdf({ filename: a.filename, contentType: a.content_type }),
-  );
-  if (pdfs.length === 0) return true;
-  if (pdfs.some((a) => typeof a.size !== "number")) return false;
-
-  const total = pdfs.reduce((sum, a) => sum + (a.size ?? 0), 0);
+export function pdfsFitInlineBudget(pdfs: PdfAttachment[]): boolean {
+  const total = pdfs.reduce((sum, pdf) => sum + pdf.base64.length, 0);
   return total <= INLINE_ATTACHMENT_BUDGET;
 }
 

--- a/src/features/inbox/utils.ts
+++ b/src/features/inbox/utils.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import type { PdfAttachment } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { normalizeName } from "@/lib/router-utils";
 import { downloadBufferFromS3, keyFromDownloadUrl } from "@/lib/s3";
@@ -13,9 +14,50 @@ const isPdf = (a: {
   );
 
 /**
+ * Ceiling on the summed Resend-reported `size` of an email's PDFs for them to
+ * be carried through Inngest step state instead of re-fetched from S3.
+ *
+ * Resend does not document the unit, so we assume the worst case (decoded
+ * bytes). Base64 inflates ~4/3, and the encoded string is what rides in the
+ * step output, which Inngest caps at 4MiB — so 3MB here lands at ~4MB encoded.
+ */
+export const INLINE_ATTACHMENT_BUDGET = 3_000_000;
+
+type ResendAttachmentMeta = {
+  filename?: string | null;
+  content_type?: string | null;
+  size?: number | null;
+};
+
+/** A PDF carried through step state, keyed back to its Resend attachment. */
+export type InlinePdfAttachment = PdfAttachment & { id: string };
+
+/**
+ * Whether an email's PDFs are small enough to pass through step state. An
+ * attachment with no reported size is treated as too big — the S3 fallback is
+ * always correct, so unknowns resolve that way.
+ */
+export function pdfsFitInlineBudget(
+  attachments: ResendAttachmentMeta[],
+): boolean {
+  const pdfs = attachments.filter((a) =>
+    isPdf({ filename: a.filename, contentType: a.content_type }),
+  );
+  if (pdfs.length === 0) return true;
+  if (pdfs.some((a) => typeof a.size !== "number")) return false;
+
+  const total = pdfs.reduce((sum, a) => sum + (a.size ?? 0), 0);
+  return total <= INLINE_ATTACHMENT_BUDGET;
+}
+
+/**
  * Fetch an inbound email's PDF attachments straight from Resend, as base64
  * `document` blocks. Used by the triage gate, which runs before we upload to
  * S3 or write a NotificationSource and so cannot use `fetchPdfAttachments`
+ *
+ * `complete` is false when any PDF failed to download. Callers must not pass a
+ * partial set downstream — the missing PDF would be silently absent, where the
+ * S3 fallback might still have retrieved it.
  */
 export async function fetchPdfAttachmentsFromResend(
   emailId: string,
@@ -24,11 +66,11 @@ export async function fetchPdfAttachmentsFromResend(
     filename?: string | null;
     content_type?: string | null;
   }>,
-): Promise<Array<{ filename: string | null; base64: string }>> {
+): Promise<{ pdfs: InlinePdfAttachment[]; complete: boolean }> {
   const pdfs = attachments.filter((a) =>
     isPdf({ filename: a.filename, contentType: a.content_type }),
   );
-  if (pdfs.length === 0) return [];
+  if (pdfs.length === 0) return { pdfs: [], complete: true };
 
   const { Resend } = await import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
@@ -47,6 +89,7 @@ export async function fetchPdfAttachmentsFromResend(
 
         const buffer = Buffer.from(await res.arrayBuffer());
         return {
+          id: a.id,
           filename: a.filename ?? null,
           base64: buffer.toString("base64"),
         };
@@ -57,7 +100,8 @@ export async function fetchPdfAttachmentsFromResend(
     }),
   );
 
-  return results.filter((a) => a !== null);
+  const downloaded = results.filter((a) => a !== null);
+  return { pdfs: downloaded, complete: downloaded.length === pdfs.length };
 }
 
 /**

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -11,7 +11,10 @@ import { extractWorkOrder } from "@/features/inbox/agent/extract-work-order";
 import { matchAndLinkEntities } from "@/features/inbox/agent/match";
 import { triageNotification } from "@/features/inbox/agent/triage";
 import { sortNotificationVulnerabilities } from "@/features/inbox/agent/vex";
-import { fetchPdfAttachmentsFromResend } from "@/features/inbox/utils";
+import {
+  fetchPdfAttachmentsFromResend,
+  pdfsFitInlineBudget,
+} from "@/features/inbox/utils";
 import { Prisma } from "@/generated/prisma";
 import { getAutomationUser } from "@/lib/automation-user";
 import prisma from "@/lib/db";
@@ -54,20 +57,30 @@ export const processInboxEmail = inngest.createFunction(
 
     // 3. Triage: is this relevant at all, and if so is it an informational
     // Notification or an actionable Work Order?
-    const { kind } = await step.run("classify-email", async () => {
-      const pdfAttachments = await fetchPdfAttachmentsFromResend(
-        emailId,
-        email.attachments ?? [],
-      );
-      return classifyEmailKind(
-        {
-          from: email.from,
-          subject: email.subject,
-          markdown: markdown ?? "",
-        },
-        pdfAttachments,
-      );
-    });
+    //
+    // The PDFs downloaded here are carried forward to every later step when
+    // they fit the budget, so nothing below re-fetches them from S3.
+    const { kind, attachments: inlinedPdfs } = await step.run(
+      "classify-email",
+      async () => {
+        const { pdfs, complete } = await fetchPdfAttachmentsFromResend(
+          emailId,
+          email.attachments ?? [],
+        );
+        const result = await classifyEmailKind(
+          {
+            from: email.from,
+            subject: email.subject,
+            markdown: markdown ?? "",
+          },
+          pdfs,
+        );
+
+        const inlineable =
+          complete && pdfsFitInlineBudget(email.attachments ?? []);
+        return { ...result, attachments: inlineable ? pdfs : null };
+      },
+    );
 
     if (kind === "not_relevant") {
       return { skipped: true, emailId };
@@ -79,29 +92,41 @@ export const processInboxEmail = inngest.createFunction(
       async () => {
         if (!email.attachments?.length) return [];
 
+        const inlinedById = new Map(
+          (inlinedPdfs ?? []).map((a) => [a.id, a.base64]),
+        );
+
         const { Resend } = await import("resend");
         const resend = new Resend(process.env.RESEND_API_KEY);
 
+        const loadBuffer = async (att: { id: string }) => {
+          const inlined = inlinedById.get(att.id);
+          if (inlined) return Buffer.from(inlined, "base64");
+
+          // Get the time-limited download URL from Resend
+          const { data: attData, error } =
+            await resend.emails.receiving.attachments.get({
+              emailId,
+              id: att.id,
+            });
+          if (error || !attData?.download_url) {
+            console.warn(`Skipping attachment ${att.id}: ${error?.message}`);
+            return null;
+          }
+
+          const res = await fetch(attData.download_url);
+          if (!res.ok) {
+            console.warn(`Failed to download attachment ${att.id}`);
+            return null;
+          }
+          return Buffer.from(await res.arrayBuffer());
+        };
+
         return Promise.all(
           email.attachments.map(async (att) => {
-            // Get the time-limited download URL from Resend
-            const { data: attData, error } =
-              await resend.emails.receiving.attachments.get({
-                emailId,
-                id: att.id,
-              });
-            if (error || !attData?.download_url) {
-              console.warn(`Skipping attachment ${att.id}: ${error?.message}`);
-              return null;
-            }
+            const buffer = await loadBuffer(att);
+            if (!buffer) return null;
 
-            const res = await fetch(attData.download_url);
-            if (!res.ok) {
-              console.warn(`Failed to download attachment ${att.id}`);
-              return null;
-            }
-
-            const buffer = Buffer.from(await res.arrayBuffer());
             const { createHash } = await import("node:crypto");
             const hashHex = createHash("md5").update(buffer).digest("hex");
 
@@ -191,11 +216,15 @@ export const processInboxEmail = inngest.createFunction(
     // email source, then tag matched device groups onto the ticket.
     if (kind === "work_order") {
       const wo = await step.run("extract-work-order", () =>
-        extractWorkOrder(sourceId, {
-          from: email.from,
-          subject: email.subject,
-          markdown: markdown ?? "",
-        }),
+        extractWorkOrder(
+          sourceId,
+          {
+            from: email.from,
+            subject: email.subject,
+            markdown: markdown ?? "",
+          },
+          inlinedPdfs ?? undefined,
+        ),
       );
 
       const workOrderTicketId = await step.run(
@@ -240,11 +269,15 @@ export const processInboxEmail = inngest.createFunction(
       );
 
       const extracted = await step.run("extract-work-order-entities", () =>
-        extractEntities(sourceId, {
-          from: email.from,
-          subject: email.subject,
-          markdown: markdown ?? "",
-        }),
+        extractEntities(
+          sourceId,
+          {
+            from: email.from,
+            subject: email.subject,
+            markdown: markdown ?? "",
+          },
+          inlinedPdfs ?? undefined,
+        ),
       );
 
       const linkSummary = await step.run(
@@ -267,11 +300,15 @@ export const processInboxEmail = inngest.createFunction(
 
     // 7. Classify email and upsert Notification
     const notificationId = await step.run("classify-notification", async () => {
-      const result = await classifyNotification(sourceId, {
-        from: email.from,
-        subject: email.subject,
-        markdown: markdown ?? "",
-      });
+      const result = await classifyNotification(
+        sourceId,
+        {
+          from: email.from,
+          subject: email.subject,
+          markdown: markdown ?? "",
+        },
+        inlinedPdfs ?? undefined,
+      );
 
       if (result.action === "update") {
         await prisma.$transaction(async (tx) => {
@@ -308,11 +345,15 @@ export const processInboxEmail = inngest.createFunction(
 
     // 8. Extract entities (device groups) referenced in the notification
     const extracted = await step.run("extract-entities", () =>
-      extractEntities(sourceId, {
-        from: email.from,
-        subject: email.subject,
-        markdown: markdown ?? "",
-      }),
+      extractEntities(
+        sourceId,
+        {
+          from: email.from,
+          subject: email.subject,
+          markdown: markdown ?? "",
+        },
+        inlinedPdfs ?? undefined,
+      ),
     );
 
     // 9. Fuzzy-search the DB for matches and link/update/create them
@@ -342,7 +383,11 @@ export const processInboxEmail = inngest.createFunction(
     // 11. Triage: assign priority, reason, and hospital impact
     if (notificationId) {
       await step.run("triage-notification", async () => {
-        const result = await triageNotification(sourceId, notificationId);
+        const result = await triageNotification(
+          sourceId,
+          notificationId,
+          inlinedPdfs ?? undefined,
+        );
         await prisma.notification.update({
           where: { id: notificationId },
           data: {

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -76,8 +76,7 @@ export const processInboxEmail = inngest.createFunction(
           pdfs,
         );
 
-        const inlineable =
-          complete && pdfsFitInlineBudget(email.attachments ?? []);
+        const inlineable = complete && pdfsFitInlineBudget(pdfs);
         return { ...result, attachments: inlineable ? pdfs : null };
       },
     );


### PR DESCRIPTION
[VW-379](https://northeastern-patch.atlassian.net/browse/VW-379)

Processing one inbound email with one PDF moved the same bytes across the network **six times** — 2 Resend downloads, 1 S3 PUT, 3 S3 GETs — with no cache anywhere. Inngest's per-step retries multiplied it: each download sits inside a `step.run` co-located with a long, failure-prone LLM call, so one Anthropic 429 in `triage-notification` re-downloaded the PDF.

## What changed
- `classify-email` already downloads every PDF (it judges the attachment, not just the body), so it now **returns those buffers in its step output** instead of discarding them at the step boundary.
- `upload-attachments` reuses that buffer — matched by Resend attachment `id`, not filename, since filenames collide — skipping both the signed-URL mint and the re-download.
- The four agents (`classifyNotification`, `extractEntities`, `extractWorkOrder`, `triageNotification`) take an optional PDF array that replaces their `fetchPdfAttachments(sourceId)` S3 GET.
- `fetchPdfAttachmentsFromResend` now returns `{ pdfs, complete }` and includes the Resend `id`.

Two conditions gate the pass-through; failing either yields `null`, which restores today's flow byte-for-byte at every consumer:
- **Size** — total base64 length ≤ `INLINE_ATTACHMENT_BUDGET` (4,000,000), under Inngest's 4MiB step-output cap.
- **Completeness** — every PDF downloaded. A partial set is refused rather than inlined; silently dropping a PDF the S3 fallback could still have retrieved is a behavior regression disguised as an optimization.

| | Resend downloads | S3 PUT | S3 GET |
|---|---|---|---|
| Before | 2 | 1 | 3 |
| After, under budget | 1 | 1 | **0** |
| After, over budget or partial | 2 | 1 | 3 (unchanged) |

## Testing

Measured how many times a single inbound email's PDF crosses the network.
S3 counts are real MinIO requests (`mc admin trace`), reconciled against the bucket.

### Before → After

One email, one PDF under the budget:

| | Resend downloads | S3 PUT | S3 GET | total |
|---|---:|---:|---:|---:|
| **Before** | 2 | 1 | 3 | **6** |
| **After** | 1 | 1 | **0** | **2** |

Over the budget (base64 > 4,000,000 chars ≈ 2.86 MiB raw) it falls back to the old
path, unchanged by design.

Retries improve too: each agent step used to re-fetch the PDF on every retry, so one
Anthropic 429 cost 3 more S3 reads. Now a retried step costs **0**.

### Runs

| run | source | PDFs | bytes | path | S3 GET |
|---|---|---:|---:|---|---:|
| small | mocked | 1 | 61,440 | inlined | **0** |
| large | mocked | 1 | 3,500,000 | fallback | 3 |
| retry (forced step failure) | mocked | 1 | 90,083 | inlined | **0** |
| `8cf5010a` | **real email** | 4 | 78,068 | inlined | **0** |
| `ffcc9339` | **real email** | 4 | 78,068 | inlined | **0** |
| `6c71839c` | **real email** | 3 | 5,335,072 | fallback | 9 |


## Notes
- The budget measures the **actual** `base64.length` of the downloaded PDFs, not Resend's reported `size`. The check runs after the download, so the exact byte count that gets serialized is already in hand, and base64 is escape-free single-byte in JSON — so `.length` *is* the contribution to the step output. An earlier revision estimated from `size` (undocumented unit) with a 4/3 expansion margin; the second commit drops that, along with an unreachable missing-size guard and a duplicated PDF filter.
- **Trade-off to watch**: the inlined payload re-rides with the accumulated run state on every later step invocation (~7 on the notification path). Within Inngest's 32MiB run-state limit, but it trades 3 S3 GETs for ~7 state transfers. If step latency regresses on a large-but-under-budget PDF, drop the constant to ~1MB — it's the only knob.
- **Pre-existing, flagged not fixed**: `keyFromDownloadUrl` (`src/lib/s3.ts`) prefix-matches against the *current* `S3_ENDPOINT`/`S3_BUCKET_NAME`; on mismatch it returns the whole URL as the key, GetObject 404s, and `fetchPdfAttachments` swallows it — agents then run with no attachment at all. Inlining now masks this on the small path.
- Out of scope: the `upload-attachments` retry orphan (hash dedupe reads a row not written until `save-source`, so a retry re-PUTs under a fresh UUID key) — needs content-addressed keys, separate ticket. Also `resend.emails.receiving.attachments.list`, which would batch the remaining one-at-a-time URL lookups but needs pagination handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VW-379]: https://northeastern-patch.atlassian.net/browse/VW-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF attachments can now be processed inline when they fit within the supported size limit.
  * Email classification, triage, entity extraction, and work-order processing can reuse pre-loaded inline PDF data to avoid redundant fetching.
  * Attachment handling falls back to secure, time-limited downloads when inline processing isn’t available.
* **Bug Fixes**
  * Prevents using partially downloaded PDF sets by detecting incomplete PDF availability and avoiding downstream processing when downloads fail.
* **Documentation**
  * Updated onboarding with a detailed “Email Pipeline (Resend) Setup” guide and troubleshooting steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->