### PR TITLE
[VW-366] Add ability to update version of affected assets

### DIFF
--- a/prisma/migrations/20260721131315_unsure/migration.sql
+++ b/prisma/migrations/20260721131315_unsure/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "VersionStatus" ADD VALUE 'UNSURE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,10 +195,10 @@ model Connection {
 }
 
 enum VersionStatus {
-  UNKNOWN
+  UNKNOWN             // No answer exists, nobody has looked at this device's version
   NOT_APPLICABLE
   KNOWN
-  UNSURE
+  UNSURE              // A user looked and explicitly couldn't determine the version
 }
 
 // VERS version-range schemes (https://github.com/package-url/vers-spec)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,7 @@ enum VersionStatus {
   UNKNOWN
   NOT_APPLICABLE
   KNOWN
+  UNSURE
 }
 
 // VERS version-range schemes (https://github.com/package-url/vers-spec)

--- a/scripts/seed-notifications.ts
+++ b/scripts/seed-notifications.ts
@@ -374,7 +374,8 @@ const DESERIALIZATION_MATCHINGS: Array<{
 // Assets, each bucketed into a DeviceGroup keyed by exact version.
 const DESERIALIZATION_ASSETS: Array<{
   product: string;
-  version: string;
+  version?: string;
+  versionStatus?: "UNSURE";
   ip: string;
   hostname: string;
   serialNumber: string;
@@ -453,6 +454,23 @@ const DESERIALIZATION_ASSETS: Array<{
     role: "SPECT/CT Console",
     networkSegment: "IMAGING-NUCMED",
   },
+  {
+    product: "MAGNETOM Family",
+    ip: "10.60.0.13",
+    hostname: "mri-magnetom-03",
+    serialNumber: "MAGNETOM-UNKNOWN-001",
+    role: "MRI Scanner Console",
+    networkSegment: "IMAGING-MRI",
+  },
+  {
+    product: "MAGNETOM Family",
+    versionStatus: "UNSURE",
+    ip: "10.60.0.14",
+    hostname: "mri-magnetom-04",
+    serialNumber: "MAGNETOM-UNKNOWN-001",
+    role: "MRI Scanner Console",
+    networkSegment: "IMAGING-MRI",
+  },
 ];
 
 async function upsertDeserializationMatching(spec: {
@@ -477,16 +495,22 @@ async function upsertDeserializationMatching(spec: {
   );
 }
 
-async function upsertDeviceGroupForAsset(product: string, version: string) {
+async function upsertDeviceGroupForAsset(
+  product: string,
+  version?: string,
+  versionStatus: VersionStatus = version
+    ? VersionStatus.KNOWN
+    : VersionStatus.UNKNOWN,
+) {
   const vendor = await upsertVendor(DESERIALIZATION_VENDOR);
   const productRec = await upsertProduct(product);
-  const versionRec = await upsertVersion(version);
+  const versionRec = version ? await upsertVersion(version) : null;
 
   const identity = {
     vendorId: vendor.id,
     productId: productRec.id,
-    versionId: versionRec.id,
-    versionStatus: VersionStatus.KNOWN,
+    versionId: versionRec?.id ?? null,
+    versionStatus: VersionStatus,
   };
 
   return (
@@ -562,8 +586,14 @@ async function seedDeserializationScenario(userId: string) {
     const deviceGroup = await upsertDeviceGroupForAsset(
       spec.product,
       spec.version,
+      spec.versionStatus === "UNSURE" ? VersionStatus.UNSURE : undefined,
     );
-    const { product: _product, version: _version, ...assetFields } = spec;
+    const {
+      product: _product,
+      version: _version,
+      versionStatus: _versionStatus,
+      ...assetFields
+    } = spec;
     assets.push(
       await prisma.asset.create({
         data: {

--- a/scripts/seed-notifications.ts
+++ b/scripts/seed-notifications.ts
@@ -506,16 +506,17 @@ async function upsertDeviceGroupForAsset(
   const productRec = await upsertProduct(product);
   const versionRec = version ? await upsertVersion(version) : null;
 
-  const identity = {
-    vendorId: vendor.id,
-    productId: productRec.id,
-    versionId: versionRec?.id ?? null,
-    versionStatus: VersionStatus,
-  };
+  const vendorId = vendor.id;
+  const productId = productRec.id;
+  const versionId = versionRec?.id ?? null;
 
   return (
-    (await prisma.deviceGroup.findFirst({ where: identity })) ??
-    (await prisma.deviceGroup.create({ data: identity }))
+    (await prisma.deviceGroup.findFirst({
+      where: { vendorId, productId, versionId, versionStatus },
+    })) ??
+    (await prisma.deviceGroup.create({
+      data: { vendorId, productId, versionId, versionStatus },
+    }))
   );
 }
 

--- a/scripts/seed-notifications.ts
+++ b/scripts/seed-notifications.ts
@@ -467,7 +467,7 @@ const DESERIALIZATION_ASSETS: Array<{
     versionStatus: "UNSURE",
     ip: "10.60.0.14",
     hostname: "mri-magnetom-04",
-    serialNumber: "MAGNETOM-UNKNOWN-001",
+    serialNumber: "MAGNETOM-UNSURE-001",
     role: "MRI Scanner Console",
     networkSegment: "IMAGING-MRI",
   },

--- a/src/features/assets/server/routers.ts
+++ b/src/features/assets/server/routers.ts
@@ -610,24 +610,22 @@ export const assetsRouter = createTRPCRouter({
 
       const { id, cpe, utilization, version, versionStatus, ...updateData } =
         input;
-        const current = await prisma.asset.findUniqueOrThrow({
-          where: { id },
-          select: {
-            deviceGroup: {
-              select: {
-                vendor: { select: { canonicalName: true } },
-                product: { select: { canonicalName: true } },
-              },
+      const current = await prisma.asset.findUniqueOrThrow({
+        where: { id },
+        select: {
+          deviceGroup: {
+            select: {
+              vendor: { select: { canonicalName: true } },
+              product: { select: { canonicalName: true } },
             },
           },
-        });
+        },
+      });
 
       let deviceGroupId: string | undefined;
       if (cpe) {
         deviceGroupId = (await cpeToDeviceGroup(cpe)).id;
       } else if (version || versionStatus) {
-
-
         if (current.deviceGroup.vendor && current.deviceGroup.product) {
           const target = await resolveDeviceGroup({
             vendor: current.deviceGroup.vendor.canonicalName,

--- a/src/features/assets/server/routers.ts
+++ b/src/features/assets/server/routers.ts
@@ -610,10 +610,6 @@ export const assetsRouter = createTRPCRouter({
 
       const { id, cpe, utilization, version, versionStatus, ...updateData } =
         input;
-      let deviceGroupId: string | undefined;
-      if (cpe) {
-        deviceGroupId = (await cpeToDeviceGroup(cpe)).id;
-      } else if (version || versionStatus) {
         const current = await prisma.asset.findUniqueOrThrow({
           where: { id },
           select: {
@@ -625,6 +621,12 @@ export const assetsRouter = createTRPCRouter({
             },
           },
         });
+
+      let deviceGroupId: string | undefined;
+      if (cpe) {
+        deviceGroupId = (await cpeToDeviceGroup(cpe)).id;
+      } else if (version || versionStatus) {
+
 
         if (current.deviceGroup.vendor && current.deviceGroup.product) {
           const target = await resolveDeviceGroup({

--- a/src/features/assets/server/routers.ts
+++ b/src/features/assets/server/routers.ts
@@ -18,6 +18,7 @@ import {
   findVulnerabilitiesMatchingDeviceGroups,
   processIntegrationSync,
   processIntegrationToken,
+  resolveDeviceGroup,
 } from "@/lib/router-utils";
 import { integrationResponseSchema } from "@/lib/schemas";
 import {
@@ -607,18 +608,48 @@ export const assetsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await requireOwnership(input.id, ctx.auth.user.id, "asset");
 
-      const { id, cpe, utilization, ...updateData } = input;
-      const deviceGroupUpdate = cpe
-        ? { deviceGroupId: (await cpeToDeviceGroup(cpe)).id }
-        : {};
-      return prisma.asset.update({
+      const { id, cpe, utilization, version, versionStatus, ...updateData } =
+        input;
+      let deviceGroupId: string | undefined;
+      if (cpe) {
+        deviceGroupId = (await cpeToDeviceGroup(cpe)).id;
+      } else if (version || versionStatus) {
+        const current = await prisma.asset.findUniqueOrThrow({
+          where: { id },
+          select: {
+            deviceGroup: {
+              select: {
+                vendor: { select: { canonicalName: true } },
+                product: { select: { canonicalName: true } },
+              },
+            },
+          },
+        });
+
+        if (current.deviceGroup.vendor && current.deviceGroup.product) {
+          const target = await resolveDeviceGroup({
+            vendor: current.deviceGroup.vendor.canonicalName,
+            product: current.deviceGroup.product.canonicalName,
+            version: version ?? null,
+            versionStatus: version ? "KNOWN" : (versionStatus ?? "UNKNOWN"),
+          });
+          deviceGroupId = target.id;
+        }
+      }
+      const updated = await prisma.asset.update({
         where: { id },
         data: {
-          ...deviceGroupUpdate,
+          ...(deviceGroupId ? { deviceGroupId } : {}),
           ...updateData,
           utilization: utilization as Prisma.InputJsonValue | undefined,
         },
         include: assetInclude,
       });
+      if (deviceGroupId) {
+        await prisma.deviceGroupHistory.create({
+          data: { deviceGroupId, assetId: id },
+        });
+      }
+      return updated;
     }),
 });

--- a/src/features/assets/types.ts
+++ b/src/features/assets/types.ts
@@ -44,6 +44,14 @@ export const assetInputSchema = z.object({
   location: locationSchema.optional(),
   status: assetStatusSchema.nullish(),
   utilization: assetUtilizationSchema.nullish(),
+  version: z
+    .string()
+    .trim()
+    .min(1)
+    .max(64)
+    .regex(/^[\w.\- +:|]+$/)
+    .optional(),
+  versionStatus: z.enum(["UNKNOWN", "UNSURE"]).optional(),
 });
 
 export const updateAssetSchema = assetInputSchema.partial().extend({

--- a/src/features/assets/types.ts
+++ b/src/features/assets/types.ts
@@ -44,13 +44,7 @@ export const assetInputSchema = z.object({
   location: locationSchema.optional(),
   status: assetStatusSchema.nullish(),
   utilization: assetUtilizationSchema.nullish(),
-  version: z
-    .string()
-    .trim()
-    .min(1)
-    .max(64)
-    .regex(/^[\w.\- +:|]+$/)
-    .optional(),
+  version: z.string().trim().min(1).max(64).optional(),
   versionStatus: z.enum(["UNKNOWN", "UNSURE"]).optional(),
 });
 

--- a/src/features/inbox/components/DropdownCell.tsx
+++ b/src/features/inbox/components/DropdownCell.tsx
@@ -57,18 +57,15 @@ const DropdownCell = ({
         <SelectValue>{currentDisplayLabel}</SelectValue>
       </SelectTrigger>
       <SelectContent>
+        <SelectItem value={UNSURE_VALUE} className="text-muted-foreground">
+          Not sure
+        </SelectItem>
+        <SelectSeparator />
         {options.map((o) => (
           <SelectItem key={o} value={o}>
             {o}
           </SelectItem>
         ))}
-        <SelectSeparator />
-        <SelectItem value={UNKNOWN_VALUE} className="text-muted-foreground">
-          Unknown
-        </SelectItem>
-        <SelectItem value={UNSURE_VALUE} className="text-muted-foreground">
-          Not sure
-        </SelectItem>
       </SelectContent>
     </Select>
   );

--- a/src/features/inbox/components/DropdownCell.tsx
+++ b/src/features/inbox/components/DropdownCell.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const UNKNOWN_VALUE = "Unknown";
+const UNSURE_VALUE = "Not sure";
+
+const DropdownCell = ({
+  value,
+  versionStatus,
+  options,
+  onAnswer,
+  isPending,
+}: {
+  value: string | null;
+  versionStatus: "UNKNOWN" | "UNSURE" | "KNOWN" | "NOT_APPLICABLE";
+  options: string[];
+  onAnswer: (
+    answer: { version: string } | { versionStatus: "UNSURE" | "UNKNOWN" },
+  ) => Promise<unknown>;
+  isPending?: boolean;
+}) => {
+  const [selected, setSelected] = useState(
+    versionStatus === "UNSURE" ? UNSURE_VALUE : (value ?? UNKNOWN_VALUE),
+  );
+
+  const handleDropDownValueChange = (newValue: string) => {
+    if (newValue === selected) return;
+    setSelected(newValue);
+    if (newValue === UNSURE_VALUE) onAnswer({ versionStatus: "UNSURE" });
+    else if (newValue === UNKNOWN_VALUE) onAnswer({ versionStatus: "UNKNOWN" });
+    else onAnswer({ version: newValue });
+  };
+
+  const currentDisplayLabel =
+    selected === UNKNOWN_VALUE
+      ? "Unknown"
+      : selected === UNSURE_VALUE
+        ? "Not sure"
+        : selected;
+
+  return (
+    <Select
+      value={selected}
+      disabled={isPending}
+      onValueChange={(v) => handleDropDownValueChange(v)}
+    >
+      <SelectTrigger className="h-7 text-sm w-36">
+        <SelectValue>{currentDisplayLabel}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o} value={o}>
+            {o}
+          </SelectItem>
+        ))}
+        <SelectSeparator />
+        <SelectItem value={UNKNOWN_VALUE} className="text-muted-foreground">
+          Unknown
+        </SelectItem>
+        <SelectItem value={UNSURE_VALUE} className="text-muted-foreground">
+          Not sure
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default DropdownCell;

--- a/src/features/inbox/components/DropdownCell.tsx
+++ b/src/features/inbox/components/DropdownCell.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useState } from "react";
 import {
   Select,

--- a/src/features/inbox/components/notification-affected-assets-tab.tsx
+++ b/src/features/inbox/components/notification-affected-assets-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,6 +27,12 @@ import type {
   NotificationDetailWithRelations,
   ResolvedDeviceGroupAsset,
 } from "../types";
+import DropdownCell from "./DropdownCell";
+import { displayName } from "@/lib/markdown/device-group";
+import {
+  useVersionForVendorProduct,
+  useAnswerAssetVersion,
+} from "../hooks/use-notifications";
 
 const PAGE_SIZE = 10;
 
@@ -48,6 +54,24 @@ function MatchingAssetTable({
   const [page, setPage] = useState(1);
   const [rows, setRows] = useState<ResolvedDeviceGroupAsset[]>([]);
   const appendedPages = useRef(new Set<number>());
+
+  const matching = group.deviceGroupMatching;
+  const { data: knownVersions } = useVersionForVendorProduct({
+    vendorId: matching.vendorId,
+    productId: matching.productId ?? "",
+  });
+
+  const suggestedVersion =
+    displayName(matching.version) ?? matching.versionRange;
+
+  const options = useMemo(() => {
+    const names = (knownVersions ?? []).map((v) => v.canonicalDisplayName);
+    return suggestedVersion && !names.includes(suggestedVersion)
+      ? [suggestedVersion, ...names]
+      : names;
+  }, [knownVersions, suggestedVersion]);
+
+  const answerVersion = useAnswerAssetVersion();
 
   const { data, isLoading, isFetching, isError, refetch } =
     useAffectedAssetsPage({
@@ -95,7 +119,7 @@ function MatchingAssetTable({
               <TableHead>Asset ID</TableHead>
               <TableHead>IP Address</TableHead>
               <TableHead>Location</TableHead>
-              <TableHead>Version</TableHead>
+              <TableHead className="w-60">Version</TableHead>
               <TableHead>Status</TableHead>
               <TableHead className="w-10" />
             </TableRow>
@@ -117,7 +141,17 @@ function MatchingAssetTable({
                 </TableCell>
                 <TableCell>{asset.ip}</TableCell>
                 <TableCell>{parseLocation(asset.location)}</TableCell>
-                <TableCell>{asset.version ?? "—"}</TableCell>
+                <TableCell className="w-60">
+                  <DropdownCell
+                    value={asset.version}
+                    versionStatus={asset.versionStatus}
+                    options={options}
+                    onAnswer={(answer) =>
+                      answerVersion.mutateAsync({ id: asset.id, ...answer })
+                    }
+                    isPending={answerVersion.isPending}
+                  />
+                </TableCell>
                 <TableCell>{asset.status ?? "—"}</TableCell>
                 <TableCell>
                   <MoreVerticalDropdownMenu

--- a/src/features/inbox/components/notification-affected-assets-tab.tsx
+++ b/src/features/inbox/components/notification-affected-assets-tab.tsx
@@ -56,13 +56,16 @@ function MatchingAssetTable({
   const appendedPages = useRef(new Set<number>());
 
   const matching = group.deviceGroupMatching;
+  // TODO: confrim if there are unnecessary api calls where DGM with same vendor/product
+  // appears in both AFFECTED and NOT_AFFECTED, or two DGM with same vendor/product both
+  // AFFECTED but with different version range. If so, make it more efficient by 
+  // https://github.com/PATCH-UPGRADE/viper/pull/171#discussion_r3631431484
   const { data: knownVersions } = useVersionForVendorProduct({
     vendorId: matching.vendorId,
     productId: matching.productId ?? "",
   });
 
-  const suggestedVersion =
-    displayName(matching.version) ?? matching.versionRange;
+  const suggestedVersion = displayName(matching.version);
 
   const options = useMemo(() => {
     const names = (knownVersions ?? []).map((v) => v.canonicalDisplayName);

--- a/src/features/inbox/hooks/use-notifications.ts
+++ b/src/features/inbox/hooks/use-notifications.ts
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { useTRPC } from "@/trpc/client";
 import type { AffectedAssetsSummary } from "../types";
 import { useNotificationsParams } from "./use-notifications-params";
+import { getAssetRoleLabel } from "@/features/assets/utils";
 
 export const useSuspenseNotifications = () => {
   const trpc = useTRPC();
@@ -91,6 +92,53 @@ export const useUpdateNotification = () => {
       },
       onError: (error) => {
         toast.error(`Failed to save change: ${error.message}`);
+      },
+    }),
+  );
+};
+
+export const useVersionForVendorProduct = (args: {
+  vendorId: string;
+  productId: string;
+}) => {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.notifications.getVersionForVendorProduct.queryOptions(args),
+  );
+};
+
+export const useAnswerAssetVersion = () => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.assets.update.mutationOptions({
+      onSuccess: (data, variables) => {
+        const label = getAssetRoleLabel(data);
+        if ("version" in variables && variables.version) {
+          toast.success(`${label} set to version ${variables.version}`);
+        } else if (
+          "versionStatus" in variables &&
+          variables.versionStatus === "UNKNOWN"
+        ) {
+          toast.success(`${label} marked version unknown`);
+        } else if (
+          "versionStatus" in variables &&
+          variables.versionStatus === "UNSURE"
+        ) {
+          toast.success(`${label} marked version not sure`);
+        } else {
+          toast.success(`${label} updated`);
+        }
+        queryClient.invalidateQueries({
+          queryKey: [["notifications", "getOne"]],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [["notifications", "getAffectedAssetsPage"]],
+        });
+      },
+      onError: (error) => {
+        toast.error(`Failed to update version: ${error.message}`);
       },
     }),
   );

--- a/src/features/inbox/server/affected-assets.ts
+++ b/src/features/inbox/server/affected-assets.ts
@@ -47,6 +47,7 @@ export type ComputeMatchingBucketsInput = {
   totalAssetCount: number;
   /** Whether the matching is linked to the notification via NotificationDeviceGroupMapping. */
   isNotificationLinked: boolean;
+  unknownVersionAssetCount?: number;
 };
 
 /** The triage buckets a set of effective statuses places an asset into. */
@@ -75,9 +76,12 @@ export function computeMatchingBuckets(
     overrides,
     totalAssetCount,
     isNotificationLinked,
+    unknownVersionAssetCount = 0,
   } = input;
   const defaultStatuses = Object.values(matchingStatusByVuln);
   const hasAnyIssue = defaultStatuses.length > 0 || overrides.length > 0;
+
+  let result: Partial<Record<AffectedBucket, MatchingBucketResult>>;
 
   // No issues at all: a notification-linked matching renders as a plain card;
   // an issue-referenced-only matching with no issues here contributes nothing.
@@ -91,46 +95,54 @@ export function computeMatchingBuckets(
       };
     }
     return {};
-  }
+  } else {
+    const defaultBuckets = triageBucketsFor(defaultStatuses);
 
-  const defaultBuckets = triageBucketsFor(defaultStatuses);
-
-  // Each override asset's effective status set = override merged over the
-  // matching defaults, so a partial override still inherits the other vulns.
-  const overrideBuckets = overrides.map((o) => ({
-    assetId: o.assetId,
-    buckets: triageBucketsFor(
-      Object.values({ ...matchingStatusByVuln, ...o.statusByVuln }),
-    ),
-  }));
-
-  const result: Partial<Record<AffectedBucket, MatchingBucketResult>> = {};
-  for (const bucket of TRIAGE_BUCKETS) {
-    if (defaultBuckets.has(bucket)) {
-      // Every non-override asset is in this bucket; drop overrides that aren't.
-      const excludedAssetIds = overrideBuckets
-        .filter((o) => !o.buckets.has(bucket))
-        .map((o) => o.assetId);
-      const count = totalAssetCount - excludedAssetIds.length;
-      if (count > 0) {
-        result[bucket] = {
-          count,
-          filter: { kind: "allExcept", excludedAssetIds },
-        };
-      }
-    } else {
-      // Only override assets that individually land in this bucket.
-      const assetIds = overrideBuckets
-        .filter((o) => o.buckets.has(bucket))
-        .map((o) => o.assetId);
-      if (assetIds.length > 0) {
-        result[bucket] = {
-          count: assetIds.length,
-          filter: { kind: "only", assetIds },
-        };
+    // Each override asset's effective status set = override merged over the
+    // matching defaults, so a partial override still inherits the other vulns.
+    const overrideBuckets = overrides.map((o) => ({
+      assetId: o.assetId,
+      buckets: triageBucketsFor(
+        Object.values({ ...matchingStatusByVuln, ...o.statusByVuln }),
+      ),
+    }));
+    result = {};
+    for (const bucket of TRIAGE_BUCKETS) {
+      if (defaultBuckets.has(bucket)) {
+        // Every non-override asset is in this bucket; drop overrides that aren't.
+        const excludedAssetIds = overrideBuckets
+          .filter((o) => !o.buckets.has(bucket))
+          .map((o) => o.assetId);
+        const count = totalAssetCount - excludedAssetIds.length;
+        if (count > 0) {
+          result[bucket] = {
+            count,
+            filter: { kind: "allExcept", excludedAssetIds },
+          };
+        }
+      } else {
+        // Only override assets that individually land in this bucket.
+        const assetIds = overrideBuckets
+          .filter((o) => o.buckets.has(bucket))
+          .map((o) => o.assetId);
+        if (assetIds.length > 0) {
+          result[bucket] = {
+            count: assetIds.length,
+            filter: { kind: "only", assetIds },
+          };
+        }
       }
     }
   }
+
+  if (unknownVersionAssetCount > 0) {
+    const existing = result.needsInformation;
+    result.needsInformation = {
+      count: (existing?.count ?? 0) + unknownVersionAssetCount,
+      filter: existing?.filter ?? { kind: "only", assetIds: [] },
+    };
+  }
+
   return result;
 }
 

--- a/src/features/inbox/server/routers.ts
+++ b/src/features/inbox/server/routers.ts
@@ -11,6 +11,7 @@ import prisma from "@/lib/db";
 import {
   deviceGroupWhereForMatching,
   matchingAppliesToDeviceGroup,
+  unknownVersionDeviceGroupWhere,
 } from "@/lib/device-matching";
 import { recordFieldCorrections } from "@/lib/field-correction";
 import {
@@ -91,6 +92,18 @@ async function resolvedDeviceGroupAssetCount(
   return candidates
     .filter((dg) => matchingAppliesToDeviceGroup(matching, dg))
     .reduce((sum, dg) => sum + dg._count.assets, 0);
+}
+
+async function unknownVersionAssetCount(
+  matching: MatchingIdentity,
+): Promise<number> {
+  const where = unknownVersionDeviceGroupWhere(matching);
+  if (!where) return 0;
+  const groups = await prisma.deviceGroup.findMany({
+    where,
+    select: { _count: { select: { assets: true } } },
+  });
+  return groups.reduce((sum, dg) => sum + dg._count.assets, 0);
 }
 
 /** Ids of the concrete device groups a matching resolves to (for paginated asset queries). */
@@ -364,11 +377,17 @@ export const notificationsRouter = createTRPCRouter({
 
       // One COUNT per display matching
       const countByMatchingId = new Map<string, number>();
+      const unknownCountByMatchingId = new Map<string, number>();
+
       await Promise.all(
         contexts.map(async (c) => {
           countByMatchingId.set(
             c.matchingId,
             await resolvedDeviceGroupAssetCount(c.deviceGroupMatching),
+          );
+          unknownCountByMatchingId.set(
+            c.matchingId,
+            await unknownVersionAssetCount(c.deviceGroupMatching),
           );
         }),
       );
@@ -383,6 +402,8 @@ export const notificationsRouter = createTRPCRouter({
           overrides: c.overrides,
           totalAssetCount: countByMatchingId.get(c.matchingId) ?? 0,
           isNotificationLinked: c.isNotificationLinked,
+          unknownVersionAssetCount:
+            unknownCountByMatchingId.get(c.matchingId) ?? 0,
         }),
       }));
       const affectedAssets = buildAffectedAssetsSummary(groups);
@@ -454,30 +475,60 @@ export const notificationsRouter = createTRPCRouter({
       const totalAssetCount = await resolvedDeviceGroupAssetCount(
         ctx.deviceGroupMatching,
       );
+
+      const unknownCount = await unknownVersionAssetCount(
+        ctx.deviceGroupMatching,
+      );
+
       const buckets = computeMatchingBuckets({
         matchingStatusByVuln: ctx.matchingStatusByVuln,
         overrides: ctx.overrides,
         totalAssetCount,
         isNotificationLinked: ctx.isNotificationLinked,
+        unknownVersionAssetCount: unknownCount,
       });
       const result = buckets[bucket];
       if (!result) {
         return createPaginatedResponse<ResolvedDeviceGroupAsset>([], emptyMeta);
       }
 
-      const deviceGroupIds = await resolveMatchedDeviceGroupIds(
+      const matchedIds = await resolveMatchedDeviceGroupIds(
         ctx.deviceGroupMatching,
       );
+      const unknowWhere = unknownVersionDeviceGroupWhere(
+        ctx.deviceGroupMatching,
+      );
+      const unknownIds = unknowWhere
+        ? (
+            await prisma.deviceGroup.findMany({
+              where: unknowWhere,
+              select: { id: true },
+            })
+          ).map((g) => g.id)
+        : [];
+
       const idFilter =
         result.filter.kind === "only"
           ? { in: result.filter.assetIds }
           : result.filter.excludedAssetIds.length > 0
             ? { notIn: result.filter.excludedAssetIds }
             : undefined;
-      const where = {
-        deviceGroupId: { in: deviceGroupIds },
-        ...(idFilter ? { id: idFilter } : {}),
-      };
+
+      const where =
+        bucket === "needsInformation" && unknownIds.length > 0
+          ? {
+              OR: [
+                {
+                  deviceGroupId: { in: matchedIds },
+                  ...(idFilter ? { id: idFilter } : {}),
+                },
+                { deviceGroupId: { in: unknownIds } },
+              ],
+            }
+          : {
+              deviceGroupId: { in: matchedIds },
+              ...(idFilter ? { id: idFilter } : {}),
+            };
 
       // Asset-level override notes for this matching, one joined string per asset.
       // Only keep notes whose vuln status maps to the bucket being paged, so an
@@ -513,7 +564,10 @@ export const notificationsRouter = createTRPCRouter({
           location: true,
           status: true,
           deviceGroup: {
-            select: { version: { select: { canonicalName: true } } },
+            select: {
+              versionStatus: true,
+              version: { select: { canonicalName: true } },
+            },
           },
         },
         orderBy: { id: "asc" },
@@ -526,6 +580,7 @@ export const notificationsRouter = createTRPCRouter({
         location: a.location,
         status: a.status,
         version: a.deviceGroup.version?.canonicalName ?? null,
+        versionStatus: a.deviceGroup.versionStatus,
         statusNotes: noteByAsset.get(a.id) ?? null,
       }));
       return createPaginatedResponse(items, meta);
@@ -611,6 +666,20 @@ export const notificationsRouter = createTRPCRouter({
         });
 
         return notification;
+      });
+    }),
+
+  getVersionForVendorProduct: protectedProcedure
+    .input(z.object({ vendorId: z.string(), productId: z.string() }))
+    .query(async ({ input }) => {
+      return prisma.version.findMany({
+        where: {
+          deviceGroups: {
+            some: { vendorId: input.vendorId, productId: input.productId },
+          },
+        },
+        select: { canonicalDisplayName: true },
+        orderBy: { canonicalDisplayName: "asc" },
       });
     }),
 });

--- a/src/features/inbox/types.ts
+++ b/src/features/inbox/types.ts
@@ -4,6 +4,7 @@ import {
   type AssetStatus,
   type Prisma,
   TicketCategory,
+  VersionStatus,
 } from "@/generated/prisma";
 
 export const notificationInclude = {
@@ -81,6 +82,7 @@ export type ResolvedDeviceGroupAsset = {
   hostname: string | null;
   location: unknown;
   version: string | null;
+  versionStatus: VersionStatus;
   status: AssetStatus | null;
   statusNotes: string | null;
 };

--- a/src/lib/device-matching.ts
+++ b/src/lib/device-matching.ts
@@ -1,5 +1,5 @@
 import semver from "semver";
-import type { Prisma } from "@/generated/prisma";
+import { VersionStatus, type Prisma } from "@/generated/prisma";
 
 // ============================================================================
 // VERS version-range support
@@ -174,6 +174,22 @@ export function deviceGroupWhereForMatching(
   return {
     vendorId: matching.vendorId,
     ...(matching.productId !== null ? { productId: matching.productId } : {}),
+  };
+}
+
+/**
+ * Prisma `where` selecting device groups whose reversion is still (UNKNOWN or UNSURE)
+ */
+export function unknownVersionDeviceGroupWhere(
+  matching: MatchingLike,
+): Prisma.DeviceGroupWhereInput | null {
+  if (matching.versionId === null && matching.versionRange === null)
+    return null;
+
+  return {
+    vendorId: matching.vendorId,
+    ...(matching.productId !== null ? { productId: matching.productId } : {}),
+    versionStatus: { in: [VersionStatus.UNKNOWN, VersionStatus.UNSURE] },
   };
 }
 


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-366

## Summary
- added a DropdownCell to the Affect Assets table, allowing users to update the version directly. It also supports the new Unsure value
- Assets are updated dynamically and moved to the another bucket when the version changes, and a toast message informs the user of the change

https://github.com/user-attachments/assets/2bcc97a9-36fe-40e4-91f8-1de2dfeaba09




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recording uncertain or unknown asset versions via `versionStatus` (including “UNSURE”).
  * Added interactive version selection for affected assets with suggested versions and “Unknown”/“Not sure” options.
  * Asset updates now derive device-group version information (from existing vendor/product plus incoming version details) and record device-group history when applicable.
  * Notifications now include assets tied to unknown-version device groups in the “Needs information” bucket.
  * Added version lookups for vendor/product to power per-asset version suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->