### PR TITLE
[VW-352] MitigationPlan gets created by agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Run mprocs:
 mprocs
 ```
 
+Alternatively, use docker: `docker compose -f compose.dev.yml up`
+* Note: I had to increase my Docker Desktop memory limit to get ts to compile
+
 ## Database Seeding
 
 The project includes a seed script to populate the database with sample data for development and testing.

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -20,8 +20,11 @@ services:
     build:
       context: .
       dockerfile: docker/viper-dev/Dockerfile
+    stdin_open: true
+    tty: true
     env_file: .env
     environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/viper
       - INNGEST_DEV=1
       - INNGEST_BASE_URL=http://inngest:8288
       - PRISMA_CLIENT_ENGINE_TYPE=binary
@@ -58,8 +61,8 @@ services:
     env_file: .env
     ports:
       - "5555:5555"
-    profiles:
-      - dev
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/viper
     command: ["npx", "prisma", "studio", "--browser", "none"]
     depends_on:
       postgres:

--- a/prisma/migrations/20260720182855_add_mitigation_plans/migration.sql
+++ b/prisma/migrations/20260720182855_add_mitigation_plans/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "PlanTagEnum" AS ENUM ('NETWORK_SEGMENTATION', 'DEVICE_UPDATE', 'FIRMWARE_UPDATE', 'VENDOR_FIX', 'NEEDS_VENDOR', 'CONFIG_CHANGE', 'ACCESS_CONTROL', 'MONITORING', 'COMPENSATING_CONTROL', 'DECOMMISSION');
+
+-- AlterTable
+ALTER TABLE "work_order_ticket" ADD COLUMN     "isDraft" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "mitigationPlanId" TEXT;
+
+-- CreateTable
+CREATE TABLE "mitigation_plan" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "compareLine" TEXT,
+    "tags" "PlanTagEnum"[],
+    "cards" JSONB NOT NULL DEFAULT '{}',
+    "notificationId" TEXT NOT NULL,
+    "isAccepted" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mitigation_plan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "mitigation_plan_notificationId_idx" ON "mitigation_plan"("notificationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mitigation_plan_notificationId_order_key" ON "mitigation_plan"("notificationId", "order");
+
+-- CreateIndex
+CREATE INDEX "work_order_ticket_mitigationPlanId_idx" ON "work_order_ticket"("mitigationPlanId");
+
+-- AddForeignKey
+ALTER TABLE "work_order_ticket" ADD CONSTRAINT "work_order_ticket_mitigationPlanId_fkey" FOREIGN KEY ("mitigationPlanId") REFERENCES "mitigation_plan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mitigation_plan" ADD CONSTRAINT "mitigation_plan_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "notification"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260721194524_work_order_notification_and_priority/migration.sql
+++ b/prisma/migrations/20260721194524_work_order_notification_and_priority/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "work_order_ticket" ADD COLUMN     "notificationId" TEXT,
+ADD COLUMN     "priority" "Priority" NOT NULL DEFAULT 'Unsorted',
+ADD COLUMN     "priorityReasonWhy" TEXT;
+
+-- CreateIndex
+CREATE INDEX "work_order_ticket_notificationId_idx" ON "work_order_ticket"("notificationId");
+
+-- AddForeignKey
+ALTER TABLE "work_order_ticket" ADD CONSTRAINT "work_order_ticket_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "notification"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1077,6 +1077,9 @@ model WorkOrderTicket {
   status      TicketStatus   @default(TO_DO)
   category    TicketCategory @default(OTHER)
 
+  priority          Priority @default(Unsorted)
+  priorityReasonWhy String?  @db.Text
+
   sourceLabel String?
   sources NotificationSource[]
 
@@ -1085,6 +1088,9 @@ model WorkOrderTicket {
   isDraft Boolean @default(false)
   mitigationPlanId String?
   mitigationPlan   MitigationPlan? @relation(fields: [mitigationPlanId], references: [id], onDelete: Cascade)
+
+  notificationId String?
+  notification   Notification? @relation(fields: [notificationId], references: [id], onDelete: SetNull)
 
   suggestedAssignee String?
 
@@ -1123,6 +1129,7 @@ model WorkOrderTicket {
   @@index([creatorId])
   @@index([parentId])
   @@index([mitigationPlanId])
+  @@index([notificationId])
   @@map("work_order_ticket")
 }
 
@@ -1262,6 +1269,7 @@ model Notification {
   remediations    NotificationRemediationMapping[]
   matchFeedback   MatchFeedback[]
   mitigationPlans MitigationPlan[]
+  workOrderTickets WorkOrderTicket[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1030,6 +1030,21 @@ enum TicketCategory {
   OTHER
 }
 
+// Closed set of mitigation-plan tags the createMitigationPlans agent chooses
+// from. Human labels are rendered client-side.
+enum PlanTagEnum {
+  NETWORK_SEGMENTATION
+  DEVICE_UPDATE
+  FIRMWARE_UPDATE
+  VENDOR_FIX
+  NEEDS_VENDOR
+  CONFIG_CHANGE
+  ACCESS_CONTROL
+  MONITORING
+  COMPENSATING_CONTROL
+  DECOMMISSION
+}
+
 model Department {
   id          String         @id @default(cuid())
   name        String         @unique
@@ -1067,6 +1082,10 @@ model WorkOrderTicket {
 
   body String? @db.Text
 
+  isDraft Boolean @default(false)
+  mitigationPlanId String?
+  mitigationPlan   MitigationPlan? @relation(fields: [mitigationPlanId], references: [id], onDelete: Cascade)
+
   suggestedAssignee String?
 
   departments Department[] @relation("WorkOrderTicketDepartments")
@@ -1103,6 +1122,7 @@ model WorkOrderTicket {
   @@index([assigneeId])
   @@index([creatorId])
   @@index([parentId])
+  @@index([mitigationPlanId])
   @@map("work_order_ticket")
 }
 
@@ -1241,12 +1261,37 @@ model Notification {
   vulnerabilities NotificationVulnerabilityMapping[]
   remediations    NotificationRemediationMapping[]
   matchFeedback   MatchFeedback[]
+  mitigationPlans MitigationPlan[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([type])
   @@map("notification")
+}
+
+model MitigationPlan {
+  id          String        @id @default(cuid())
+  title       String
+  summary     String        @db.Text
+  compareLine String?       @db.Text // short blurb comparing this plan to the others
+  tags        PlanTagEnum[]
+  cards       Json          @default("{}") // { effort, downtime, residual_risk, coverage, timeline }
+
+  notificationId String
+  notification   Notification @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+
+  isAccepted Boolean @default(false)
+  order      Int // 0-based; order 0 is the recommended plan
+
+  workOrders WorkOrderTicket[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([notificationId, order])
+  @@index([notificationId])
+  @@map("mitigation_plan")
 }
 
 model NotificationSource {

--- a/src/features/inbox/agent/mitigation/index.ts
+++ b/src/features/inbox/agent/mitigation/index.ts
@@ -21,10 +21,10 @@ Each plan is a coherent strategy for reducing the risk from this notification, m
 RULES:
 - Order the plans best-first: the FIRST plan is the one you recommend. Typically 1-3 plans.
 - Plans must be genuinely different strategies (e.g. contain-now-via-network vs. patch-every-device), not slight variations. Give each a "compareLine" that says how it trades off against the others.
-- Ground EVERY field in the provided notification and hospital context. Never invent device counts, CVSS/EPSS numbers, care areas, downtime figures, or remediations — use only what the context states. If the context is thin, keep the cards qualitative rather than fabricating numbers.
+- Ground EVERY field in the provided notification and hospital context. Never invent device counts, CVSS/EPSS numbers, care areas, downtime figures, or remediations — use only what the context states. If the context is thin, keep the cards qualitative rather than fabricating numbers, or report "Uncertain"
 - Prefer plans that map to the linked remediations and affected device groups. Factor VEX determinations in: assets marked NOT_AFFECTED do not need remediating.
 - cards: fill effort, downtime, residual_risk, coverage, and timeline for each plan as short at-a-glance strings.
-- workOrders: each plan lists the concrete work orders that would be created if it is accepted. Title is action-oriented; shortDescription is a one-line chip; detailedDescription is the full instruction.
+- workOrders: each plan lists the concrete work orders that would be created if it is accepted. shortDescription is action-oriented, a title; detailedDescription is the full instruction.
 - If there is not enough information to responsibly propose any plan, return an empty plans array. Do not force a plan.`;
 
 function buildTextPrompt(input: {

--- a/src/features/inbox/agent/mitigation/index.ts
+++ b/src/features/inbox/agent/mitigation/index.ts
@@ -5,11 +5,16 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { tool } from "@langchain/core/tools";
+import { z } from "zod";
 import { buildUserMessage } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { fetchPdfAttachments } from "../../utils";
-import { gatherTriageContext } from "../triage/context";
-import { type MitigationPlansResult, mitigationPlansSchema } from "./schema";
+import { gatherTriageContext, type LinkableIds } from "../triage/context";
+import {
+  buildMitigationPlansSchema,
+  type MitigationPlanItem,
+  type MitigationPlansResult,
+} from "./schema";
 
 const MODEL = "claude-sonnet-4-6";
 const TOOL_NAME = "record_mitigation_plans";
@@ -25,6 +30,10 @@ RULES:
 - Prefer plans that map to the linked remediations and affected device groups. Factor VEX determinations in: assets marked NOT_AFFECTED do not need remediating.
 - cards: fill effort, downtime, residual_risk, coverage, and timeline for each plan as short at-a-glance strings.
 - workOrders: each plan lists the concrete work orders that would be created if it is accepted. shortDescription is action-oriented, a title; detailedDescription is the full instruction.
+- LINKING: every work order names the vulnerabilities, remediations, and device groups IT specifically addresses, using the exact ids shown inline in the hospital context (e.g. "(id: …)" on a vulnerability heading, the id on a remediation heading, "(id: …)" on a device group line). Never invent an id.
+- Link narrowly. A work order that firewalls one device group must NOT list the other groups, and one that applies a single vendor patch must NOT list every remediation. Different work orders in a plan usually target different device groups. Leave a list empty rather than padding it.
+- Each device group line states how many hospital assets it resolves to. A group with 0 assets is a product the hospital does not appear to own — do not attach work orders to it unless the work is explicitly about confirming inventory.
+- For each device group a work order touches, give a one-line reasonWhy and set confidence: Matched only with strong evidence, otherwise NeedsReview.
 - If there is not enough information to responsibly propose any plan, return an empty plans array. Do not force a plan.`;
 
 function buildTextPrompt(input: {
@@ -49,7 +58,7 @@ ${input.contextMarkdown}`;
 export async function createMitigationPlans(
   sourceId: string,
   notificationId: string,
-): Promise<MitigationPlansResult> {
+): Promise<MitigationPlansResult & { linkableIds: LinkableIds }> {
   const [source, notification, pdfAttachments, context] = await Promise.all([
     prisma.notificationSource.findUnique({
       where: { id: sourceId },
@@ -60,14 +69,17 @@ export async function createMitigationPlans(
       select: { type: true, title: true, summary: true },
     }),
     fetchPdfAttachments(sourceId),
-    gatherTriageContext(notificationId),
+    gatherTriageContext(notificationId, { includeIds: true }),
   ]);
+
+  const { linkableIds } = context;
+  const schema = buildMitigationPlansSchema(linkableIds);
 
   const recordTool = tool(async () => "ok", {
     name: TOOL_NAME,
     description:
       "Record the ordered mitigation plans (first = recommended). Pass an empty plans array if there isn't enough information to propose any.",
-    schema: mitigationPlansSchema,
+    schema,
   });
 
   // Extended thinking requires tool_choice "auto" (no forcing), so we bind the
@@ -91,9 +103,23 @@ export async function createMitigationPlans(
     buildUserMessage(textPrompt, pdfAttachments),
   ]);
 
+  // Fail loud and retry if model has invalid output
   const call = res.tool_calls?.find((c) => c.name === TOOL_NAME);
-  if (!call) return { plans: [] };
+  if (!call) {
+    throw new Error(
+      `Mitigation agent never called ${TOOL_NAME} for notification ${notificationId}`,
+    );
+  }
 
-  const parsed = mitigationPlansSchema.safeParse(call.args);
-  return parsed.success ? parsed.data : { plans: [] };
+  const parsed = schema.safeParse(call.args);
+  if (!parsed.success) {
+    throw new Error(
+      `Mitigation agent returned invalid ${TOOL_NAME} args for notification ${notificationId}: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+
+  return {
+    plans: parsed.data.plans as MitigationPlanItem[],
+    linkableIds,
+  };
 }

--- a/src/features/inbox/agent/mitigation/index.ts
+++ b/src/features/inbox/agent/mitigation/index.ts
@@ -1,0 +1,99 @@
+// Mitigation-planning agent: given a notification with linked vulnerabilities
+// and the resolved hospital context, propose an ordered set of mitigation plans
+// (recommended first) — or none if there isn't enough information to act on.
+
+import "server-only";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { tool } from "@langchain/core/tools";
+import { buildUserMessage } from "@/lib/agent-messages";
+import prisma from "@/lib/db";
+import { fetchPdfAttachments } from "../../utils";
+import { gatherTriageContext } from "../triage/context";
+import { type MitigationPlansResult, mitigationPlansSchema } from "./schema";
+
+const MODEL = "claude-sonnet-4-6";
+const TOOL_NAME = "record_mitigation_plans";
+
+const SYSTEM_PROMPT = `You are a mitigation-planning agent for a hospital cybersecurity platform. Given a security notification and the resolved hospital context (linked vulnerabilities, remediations, VEX determinations, affected device groups, care areas, and clinical workflows), propose a small set of distinct mitigation plans for the hospital to choose between.
+
+Each plan is a coherent strategy for reducing the risk from this notification, made up of concrete work orders.
+
+RULES:
+- Order the plans best-first: the FIRST plan is the one you recommend. Typically 1-3 plans.
+- Plans must be genuinely different strategies (e.g. contain-now-via-network vs. patch-every-device), not slight variations. Give each a "compareLine" that says how it trades off against the others.
+- Ground EVERY field in the provided notification and hospital context. Never invent device counts, CVSS/EPSS numbers, care areas, downtime figures, or remediations — use only what the context states. If the context is thin, keep the cards qualitative rather than fabricating numbers.
+- Prefer plans that map to the linked remediations and affected device groups. Factor VEX determinations in: assets marked NOT_AFFECTED do not need remediating.
+- cards: fill effort, downtime, residual_risk, coverage, and timeline for each plan as short at-a-glance strings.
+- workOrders: each plan lists the concrete work orders that would be created if it is accepted. Title is action-oriented; shortDescription is a one-line chip; detailedDescription is the full instruction.
+- If there is not enough information to responsibly propose any plan, return an empty plans array. Do not force a plan.`;
+
+function buildTextPrompt(input: {
+  notificationType: string;
+  notificationTitle: string | null;
+  notificationSummary: string | null;
+  markdown: string | null;
+  contextMarkdown: string;
+}): string {
+  return `--- NOTIFICATION ---
+Type: ${input.notificationType}
+Title: ${input.notificationTitle ?? "(untitled)"}
+Summary: ${input.notificationSummary ?? "(none)"}
+
+--- FULL NOTIFICATION BODY ---
+${input.markdown ?? "(no body)"}
+
+--- RESOLVED HOSPITAL CONTEXT ---
+${input.contextMarkdown}`;
+}
+
+export async function createMitigationPlans(
+  sourceId: string,
+  notificationId: string,
+): Promise<MitigationPlansResult> {
+  const [source, notification, pdfAttachments, context] = await Promise.all([
+    prisma.notificationSource.findUnique({
+      where: { id: sourceId },
+      select: { markdown: true },
+    }),
+    prisma.notification.findUnique({
+      where: { id: notificationId },
+      select: { type: true, title: true, summary: true },
+    }),
+    fetchPdfAttachments(sourceId),
+    gatherTriageContext(notificationId),
+  ]);
+
+  const recordTool = tool(async () => "ok", {
+    name: TOOL_NAME,
+    description:
+      "Record the ordered mitigation plans (first = recommended). Pass an empty plans array if there isn't enough information to propose any.",
+    schema: mitigationPlansSchema,
+  });
+
+  // Extended thinking requires tool_choice "auto" (no forcing), so we bind the
+  // single tool and read the call args instead of using withStructuredOutput.
+  const model = new ChatAnthropic({
+    model: MODEL,
+    maxTokens: 8000,
+    thinking: { type: "enabled", budget_tokens: 4000 },
+  }).bindTools([recordTool]);
+
+  const textPrompt = buildTextPrompt({
+    notificationType: notification?.type ?? "Other",
+    notificationTitle: notification?.title ?? null,
+    notificationSummary: notification?.summary ?? null,
+    markdown: source?.markdown ?? null,
+    contextMarkdown: context.markdown,
+  });
+
+  const res = await model.invoke([
+    { role: "system", content: SYSTEM_PROMPT },
+    buildUserMessage(textPrompt, pdfAttachments),
+  ]);
+
+  const call = res.tool_calls?.find((c) => c.name === TOOL_NAME);
+  if (!call) return { plans: [] };
+
+  const parsed = mitigationPlansSchema.safeParse(call.args);
+  return parsed.success ? parsed.data : { plans: [] };
+}

--- a/src/features/inbox/agent/mitigation/persist.ts
+++ b/src/features/inbox/agent/mitigation/persist.ts
@@ -30,6 +30,7 @@ export async function persistMitigationPlans(
   const { plans } = await createMitigationPlans(sourceId, notificationId);
   if (plans.length === 0) return { plans: 0 };
 
+  // TODO: (HEY!) don't just connect every single vulnerability, remediation, dg
   const [automation, vulnMappings, remMappings, dgMappings] = await Promise.all(
     [
       getAutomationUser(),

--- a/src/features/inbox/agent/mitigation/persist.ts
+++ b/src/features/inbox/agent/mitigation/persist.ts
@@ -1,12 +1,15 @@
 import "server-only";
 import { getAutomationUser } from "@/lib/automation-user";
 import prisma from "@/lib/db";
+import { existingIds, keepValidIds } from "../../utils";
 import { createMitigationPlans } from ".";
+import type { PlanWorkOrder } from "./schema";
 
 // Run the mitigation-planning agent for a notification and persist its output:
 // one MitigationPlan per plan (order 0 = recommended) plus its draft work orders
-// (isDraft=true), each wired to the notification's linked vulns/remediations/
-// device groups so an accepted plan yields fully-linked tickets.
+// (isDraft=true). Each work order is wired to only the vulnerabilities,
+// remediations, and device groups the agent named for THAT work order, so an
+// accepted plan yields tickets that are actually scoped to their own work.
 export async function persistMitigationPlans(
   sourceId: string,
   notificationId: string,
@@ -30,31 +33,43 @@ export async function persistMitigationPlans(
   const { plans } = await createMitigationPlans(sourceId, notificationId);
   if (plans.length === 0) return { plans: 0 };
 
-  // TODO: (HEY!) don't just connect every single vulnerability, remediation, dg
-  const [automation, vulnMappings, remMappings, dgMappings] = await Promise.all(
-    [
-      getAutomationUser(),
-      prisma.notificationVulnerabilityMapping.findMany({
-        where: { notificationId },
-        select: { vulnerabilityId: true },
-      }),
-      prisma.notificationRemediationMapping.findMany({
-        where: { notificationId, confidence: { not: "Rejected" } },
-        select: { remediationId: true },
-      }),
-      prisma.notificationDeviceGroupMapping.findMany({
-        where: { notificationId, confidence: { not: "Rejected" } },
-        select: { deviceGroupMatchingId: true },
-      }),
-    ],
-  );
+  const [automation, valid] = await Promise.all([
+    getAutomationUser(),
+    resolveValidIds(plans.flatMap((p) => p.workOrders)),
+  ]);
 
-  const vulnConnect = vulnMappings.map((m) => ({ id: m.vulnerabilityId }));
-  const remConnect = remMappings.map((m) => ({ id: m.remediationId }));
-  const deviceGroupCreate = dgMappings.map((m) => ({
-    deviceGroupMatchingId: m.deviceGroupMatchingId,
-    confidence: "NeedsReview" as const,
-  }));
+  let dropped = 0;
+  const linksFor = (w: PlanWorkOrder) => {
+    const vulnerabilityIds = keepValidIds(
+      w.vulnerabilityIds,
+      valid.vulnerability,
+    );
+    const remediationIds = keepValidIds(w.remediationIds, valid.remediation);
+    const deviceGroupIds = keepValidIds(
+      w.deviceGroups.map((d) => d.id),
+      valid.deviceGroupMatching,
+    );
+    dropped +=
+      w.vulnerabilityIds.length -
+      vulnerabilityIds.length +
+      (w.remediationIds.length - remediationIds.length) +
+      (w.deviceGroups.length - deviceGroupIds.length);
+
+    return {
+      vulnerabilities: { connect: vulnerabilityIds.map((id) => ({ id })) },
+      remediations: { connect: remediationIds.map((id) => ({ id })) },
+      deviceGroups: {
+        create: deviceGroupIds.map((id) => {
+          const d = w.deviceGroups.find((g) => g.id === id);
+          return {
+            deviceGroupMatchingId: id,
+            confidence: d?.confidence ?? ("NeedsReview" as const),
+            reasonWhy: d?.reasonWhy ?? null,
+          };
+        }),
+      },
+    };
+  };
 
   for (const [order, plan] of plans.entries()) {
     await prisma.mitigationPlan.create({
@@ -72,14 +87,38 @@ export async function persistMitigationPlans(
             body: w.detailedDescription,
             isDraft: true,
             creatorId: automation.id,
-            vulnerabilities: { connect: vulnConnect },
-            remediations: { connect: remConnect },
-            deviceGroups: { create: deviceGroupCreate },
+            notificationId,
+            ...linksFor(w),
           })),
         },
       },
     });
   }
 
-  return { plans: plans.length };
+  if (dropped > 0) {
+    console.warn(
+      `persistMitigationPlans: dropped ${dropped} unknown/duplicate entity id(s) for notification ${notificationId}`,
+    );
+  }
+
+  return { plans: plans.length, droppedLinks: dropped };
+}
+
+/** Which of the ids the agent named still exist, per entity type. */
+async function resolveValidIds(workOrders: PlanWorkOrder[]) {
+  const [vulnerability, remediation, deviceGroupMatching] = await Promise.all([
+    existingIds(
+      (args) => prisma.vulnerability.findMany(args),
+      workOrders.flatMap((w) => w.vulnerabilityIds),
+    ),
+    existingIds(
+      (args) => prisma.remediation.findMany(args),
+      workOrders.flatMap((w) => w.remediationIds),
+    ),
+    existingIds(
+      (args) => prisma.deviceGroupMatching.findMany(args),
+      workOrders.flatMap((w) => w.deviceGroups.map((d) => d.id)),
+    ),
+  ]);
+  return { vulnerability, remediation, deviceGroupMatching };
 }

--- a/src/features/inbox/agent/mitigation/persist.ts
+++ b/src/features/inbox/agent/mitigation/persist.ts
@@ -1,0 +1,84 @@
+import "server-only";
+import { getAutomationUser } from "@/lib/automation-user";
+import prisma from "@/lib/db";
+import { createMitigationPlans } from ".";
+
+// Run the mitigation-planning agent for a notification and persist its output:
+// one MitigationPlan per plan (order 0 = recommended) plus its draft work orders
+// (isDraft=true), each wired to the notification's linked vulns/remediations/
+// device groups so an accepted plan yields fully-linked tickets.
+export async function persistMitigationPlans(
+  sourceId: string,
+  notificationId: string,
+) {
+  // Never clobber a plan a human already accepted (its work orders are now real).
+  const acceptedCount = await prisma.mitigationPlan.count({
+    where: { notificationId, isAccepted: true },
+  });
+  if (acceptedCount > 0) return { skipped: "accepted-exists" as const };
+
+  const vulnCount = await prisma.notificationVulnerabilityMapping.count({
+    where: { notificationId },
+  });
+  if (vulnCount === 0) return { skipped: "no-vulnerabilities" as const };
+
+  // Clear any stale, un-accepted plans first (cascades their draft work orders).
+  await prisma.mitigationPlan.deleteMany({
+    where: { notificationId, isAccepted: false },
+  });
+
+  const { plans } = await createMitigationPlans(sourceId, notificationId);
+  if (plans.length === 0) return { plans: 0 };
+
+  const [automation, vulnMappings, remMappings, dgMappings] = await Promise.all(
+    [
+      getAutomationUser(),
+      prisma.notificationVulnerabilityMapping.findMany({
+        where: { notificationId },
+        select: { vulnerabilityId: true },
+      }),
+      prisma.notificationRemediationMapping.findMany({
+        where: { notificationId, confidence: { not: "Rejected" } },
+        select: { remediationId: true },
+      }),
+      prisma.notificationDeviceGroupMapping.findMany({
+        where: { notificationId, confidence: { not: "Rejected" } },
+        select: { deviceGroupMatchingId: true },
+      }),
+    ],
+  );
+
+  const vulnConnect = vulnMappings.map((m) => ({ id: m.vulnerabilityId }));
+  const remConnect = remMappings.map((m) => ({ id: m.remediationId }));
+  const deviceGroupCreate = dgMappings.map((m) => ({
+    deviceGroupMatchingId: m.deviceGroupMatchingId,
+    confidence: "NeedsReview" as const,
+  }));
+
+  for (const [order, plan] of plans.entries()) {
+    await prisma.mitigationPlan.create({
+      data: {
+        notificationId,
+        order,
+        title: plan.title,
+        summary: plan.summary,
+        compareLine: plan.compareLine,
+        tags: plan.tags,
+        cards: plan.cards,
+        workOrders: {
+          create: plan.workOrders.map((w) => ({
+            summary: w.shortDescription,
+            body: w.detailedDescription,
+            isDraft: true,
+            creatorId: automation.id,
+            vulnerabilities: { connect: vulnConnect },
+            remediations: { connect: remConnect },
+            deviceGroups: { create: deviceGroupCreate },
+          })),
+        },
+      },
+    });
+  }
+
+  return { plans: plans.length };
+}

--- a/src/features/inbox/agent/mitigation/schema.test.ts
+++ b/src/features/inbox/agent/mitigation/schema.test.ts
@@ -1,9 +1,17 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { mitigationPlansSchema } from "./schema";
+import { buildMitigationPlansSchema } from "./schema";
+
+const ids = {
+  vulnerabilityIds: ["vuln_1", "vuln_2"],
+  remediationIds: ["rem_1"],
+  deviceGroupMatchingIds: ["dgm_1", "dgm_2"],
+};
+
+const schema = buildMitigationPlansSchema(ids);
 
 const goldenPlan = {
-  shortDescription: "Contain now, patch on schedule",
+  title: "Contain now, patch on schedule",
   summary:
     "Block the attack path at the network today with zero downtime, then schedule firmware updates for the permanent fix.",
   compareLine: "Attack path closed immediately; vulnerable code removed later.",
@@ -20,23 +28,48 @@ const goldenPlan = {
       shortDescription: "Block TCP 32912/32914 at the imaging VLAN boundary",
       detailedDescription:
         "Add deny rules for TCP 32912 and 32914 inbound to the imaging VLAN.",
+      vulnerabilityIds: ["vuln_1"],
+      remediationIds: [],
+      deviceGroups: [
+        {
+          id: "dgm_1",
+          confidence: "Matched",
+          reasonWhy: "These are the scanners exposed on the imaging VLAN.",
+        },
+      ],
     },
   ],
 };
 
-describe("mitigationPlansSchema", () => {
+const withWorkOrder = (workOrder: Record<string, unknown>) => ({
+  plans: [{ ...goldenPlan, workOrders: [workOrder] }],
+});
+
+describe("buildMitigationPlansSchema", () => {
   it("accepts a well-formed, ordered plan list", () => {
-    const parsed = mitigationPlansSchema.safeParse({ plans: [goldenPlan] });
+    const parsed = schema.safeParse({ plans: [goldenPlan] });
     expect(parsed.success).toBe(true);
   });
 
   it("accepts an empty plan list (agent declined to propose any)", () => {
-    const parsed = mitigationPlansSchema.safeParse({ plans: [] });
+    const parsed = schema.safeParse({ plans: [] });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a work order that links nothing", () => {
+    const parsed = schema.safeParse(
+      withWorkOrder({
+        ...goldenPlan.workOrders[0],
+        vulnerabilityIds: [],
+        remediationIds: [],
+        deviceGroups: [],
+      }),
+    );
     expect(parsed.success).toBe(true);
   });
 
   it("rejects an unknown tag", () => {
-    const parsed = mitigationPlansSchema.safeParse({
+    const parsed = schema.safeParse({
       plans: [{ ...goldenPlan, tags: ["NOT_A_REAL_TAG"] }],
     });
     expect(parsed.success).toBe(false);
@@ -49,9 +82,61 @@ describe("mitigationPlansSchema", () => {
       coverage: goldenPlan.cards.coverage,
       timeline: goldenPlan.cards.timeline,
     };
-    const parsed = mitigationPlansSchema.safeParse({
+    const parsed = schema.safeParse({
       plans: [{ ...goldenPlan, cards: partialCards }],
     });
     expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a vulnerability id outside the catalog", () => {
+    const parsed = schema.safeParse(
+      withWorkOrder({
+        ...goldenPlan.workOrders[0],
+        vulnerabilityIds: ["vuln_hallucinated"],
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a device group id outside the catalog", () => {
+    const parsed = schema.safeParse(
+      withWorkOrder({
+        ...goldenPlan.workOrders[0],
+        deviceGroups: [
+          { id: "dgm_nope", confidence: "Matched", reasonWhy: "invented" },
+        ],
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("allows no ids at all when the context resolved none", () => {
+    const emptySchema = buildMitigationPlansSchema({
+      vulnerabilityIds: [],
+      remediationIds: [],
+      deviceGroupMatchingIds: [],
+    });
+    const workOrder = {
+      shortDescription: "Ask the vendor for an advisory",
+      detailedDescription: "No hospital entities resolved yet.",
+      vulnerabilityIds: [],
+      remediationIds: [],
+      deviceGroups: [],
+    };
+    expect(
+      emptySchema.safeParse({
+        plans: [{ ...goldenPlan, workOrders: [workOrder] }],
+      }).success,
+    ).toBe(true);
+    expect(
+      emptySchema.safeParse({
+        plans: [
+          {
+            ...goldenPlan,
+            workOrders: [{ ...workOrder, vulnerabilityIds: ["vuln_1"] }],
+          },
+        ],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/src/features/inbox/agent/mitigation/schema.test.ts
+++ b/src/features/inbox/agent/mitigation/schema.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { mitigationPlansSchema } from "./schema";
+
+const goldenPlan = {
+  shortDescription: "Contain now, patch on schedule",
+  summary:
+    "Block the attack path at the network today with zero downtime, then schedule firmware updates for the permanent fix.",
+  compareLine: "Attack path closed immediately; vulnerable code removed later.",
+  tags: ["NETWORK_SEGMENTATION", "VENDOR_FIX", "NEEDS_VENDOR"],
+  cards: {
+    effort: "2 tickets · ~14 hrs total",
+    downtime: "None to contain",
+    residual_risk: "Low",
+    coverage: "6 of 6 assets",
+    timeline: "Contained today · patched in ~2 weeks",
+  },
+  workOrders: [
+    {
+      shortDescription: "Block TCP 32912/32914 at the imaging VLAN boundary",
+      detailedDescription:
+        "Add deny rules for TCP 32912 and 32914 inbound to the imaging VLAN.",
+    },
+  ],
+};
+
+describe("mitigationPlansSchema", () => {
+  it("accepts a well-formed, ordered plan list", () => {
+    const parsed = mitigationPlansSchema.safeParse({ plans: [goldenPlan] });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts an empty plan list (agent declined to propose any)", () => {
+    const parsed = mitigationPlansSchema.safeParse({ plans: [] });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects an unknown tag", () => {
+    const parsed = mitigationPlansSchema.safeParse({
+      plans: [{ ...goldenPlan, tags: ["NOT_A_REAL_TAG"] }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a plan missing a required card", () => {
+    const partialCards = {
+      effort: goldenPlan.cards.effort,
+      downtime: goldenPlan.cards.downtime,
+      coverage: goldenPlan.cards.coverage,
+      timeline: goldenPlan.cards.timeline,
+    };
+    const parsed = mitigationPlansSchema.safeParse({
+      plans: [{ ...goldenPlan, cards: partialCards }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/features/inbox/agent/mitigation/schema.ts
+++ b/src/features/inbox/agent/mitigation/schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { PlanTagEnum } from "@/generated/prisma";
+
+// At-a-glance metrics rendered as the plan's cards. Stored verbatim as JSON on
+// MitigationPlan.cards.
+export const planCardsSchema = z.object({
+  effort: z.string().describe("e.g. '2 tickets · ~14 hrs total'"),
+  downtime: z.string().describe("expected downtime, e.g. 'None to contain'"),
+  residual_risk: z
+    .string()
+    .describe("risk remaining after this plan, e.g. 'Low'"),
+  coverage: z
+    .string()
+    .describe("how much exposure this closes, e.g. '6 of 6 assets'"),
+  timeline: z.string().describe("when it lands, e.g. 'Contained today'"),
+});
+
+export const planWorkOrderSchema = z.object({
+  shortDescription: z.string().describe("concise, action-oriented work-order title"),
+  detailedDescription: z
+    .string()
+    .describe("full description of the work to perform"),
+});
+
+export const mitigationPlanItemSchema = z.object({
+  title: z.string(),
+  summary: z.string().describe("what this plan does, in plain terms"),
+  compareLine: z
+    .string()
+    .describe("short blurb comparing this plan to the other plans"),
+  tags: z.array(z.enum(PlanTagEnum)),
+  cards: planCardsSchema,
+  workOrders: z
+    .array(planWorkOrderSchema)
+    .describe("the work orders that would be created if this plan is accepted"),
+});
+
+export const mitigationPlansSchema = z.object({
+  plans: z
+    .array(mitigationPlanItemSchema)
+    .describe(
+      "ordered mitigation plans, best/recommended first; empty if there isn't enough information to propose any",
+    ),
+});
+
+export type MitigationPlanItem = z.infer<typeof mitigationPlanItemSchema>;
+export type MitigationPlansResult = z.infer<typeof mitigationPlansSchema>;

--- a/src/features/inbox/agent/mitigation/schema.ts
+++ b/src/features/inbox/agent/mitigation/schema.ts
@@ -20,6 +20,7 @@ export const planWorkOrderSchema = z.object({
   detailedDescription: z
     .string()
     .describe("full description of the work to perform"),
+  // TODO: (HEY!) need a way to link device groups, assets, remediations, and vulnerabilities here
 });
 
 export const mitigationPlanItemSchema = z.object({

--- a/src/features/inbox/agent/mitigation/schema.ts
+++ b/src/features/inbox/agent/mitigation/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { LinkableIds } from "@/features/inbox/agent/triage/context";
 import { PlanTagEnum } from "@/generated/prisma";
 
 // At-a-glance metrics rendered as the plan's cards. Stored verbatim as JSON on
@@ -15,34 +16,101 @@ export const planCardsSchema = z.object({
   timeline: z.string().describe("when it lands, e.g. 'Contained today'"),
 });
 
-export const planWorkOrderSchema = z.object({
-  shortDescription: z.string().describe("concise, action-oriented work-order title"),
-  detailedDescription: z
-    .string()
-    .describe("full description of the work to perform"),
-  // TODO: (HEY!) need a way to link device groups, assets, remediations, and vulnerabilities here
-});
+/**
+ * Only allow the model to select an id in `ids`, otherwise never allow an entry
+ */
+function idArray(ids: string[], description: string) {
+  const inner =
+    ids.length > 0 ? z.enum(ids as [string, ...string[]]) : z.never();
+  return z.array(inner).describe(description);
+}
 
-export const mitigationPlanItemSchema = z.object({
-  title: z.string(),
-  summary: z.string().describe("what this plan does, in plain terms"),
-  compareLine: z
-    .string()
-    .describe("short blurb comparing this plan to the other plans"),
-  tags: z.array(z.enum(PlanTagEnum)),
-  cards: planCardsSchema,
-  workOrders: z
-    .array(planWorkOrderSchema)
-    .describe("the work orders that would be created if this plan is accepted"),
-});
-
-export const mitigationPlansSchema = z.object({
-  plans: z
-    .array(mitigationPlanItemSchema)
-    .describe(
-      "ordered mitigation plans, best/recommended first; empty if there isn't enough information to propose any",
+/**
+ * Bake valid ID's into the schema we give the model itself...
+ */
+export function buildMitigationPlansSchema(ids: LinkableIds) {
+  const planWorkOrderSchema = z.object({
+    shortDescription: z
+      .string()
+      .describe("concise, action-oriented work-order title"),
+    detailedDescription: z
+      .string()
+      .describe("full description of the work to perform"),
+    vulnerabilityIds: idArray(
+      ids.vulnerabilityIds,
+      "ids of ONLY the vulnerabilities this specific work order addresses; empty if none",
     ),
-});
+    remediationIds: idArray(
+      ids.remediationIds,
+      "ids of ONLY the remediations this specific work order applies; empty if none",
+    ),
+    deviceGroups: z
+      .array(
+        z.object({
+          id:
+            ids.deviceGroupMatchingIds.length > 0
+              ? z.enum(ids.deviceGroupMatchingIds as [string, ...string[]])
+              : z.never(),
+          confidence: z
+            .enum(["NeedsReview", "Matched"])
+            .describe(
+              "Matched = strong evidence this work order targets this device group; NeedsReview = plausible but a human should verify.",
+            ),
+          reasonWhy: z
+            .string()
+            .describe("one line on why this work order targets this group"),
+        }),
+      )
+      .describe(
+        "ONLY the device groups this specific work order touches; empty if none",
+      ),
+  });
 
-export type MitigationPlanItem = z.infer<typeof mitigationPlanItemSchema>;
-export type MitigationPlansResult = z.infer<typeof mitigationPlansSchema>;
+  const mitigationPlanItemSchema = z.object({
+    title: z.string(),
+    summary: z.string().describe("what this plan does, in plain terms"),
+    compareLine: z
+      .string()
+      .describe("short blurb comparing this plan to the other plans"),
+    tags: z.array(z.enum(PlanTagEnum)),
+    cards: planCardsSchema,
+    workOrders: z
+      .array(planWorkOrderSchema)
+      .describe(
+        "the work orders that would be created if this plan is accepted",
+      ),
+  });
+
+  return z.object({
+    plans: z
+      .array(mitigationPlanItemSchema)
+      .describe(
+        "ordered mitigation plans, best/recommended first; empty if there isn't enough information to propose any",
+      ),
+  });
+}
+
+export type PlanCards = z.infer<typeof planCardsSchema>;
+
+export type PlanWorkOrder = {
+  shortDescription: string;
+  detailedDescription: string;
+  vulnerabilityIds: string[];
+  remediationIds: string[];
+  deviceGroups: Array<{
+    id: string;
+    confidence: "NeedsReview" | "Matched";
+    reasonWhy: string;
+  }>;
+};
+
+export type MitigationPlanItem = {
+  title: string;
+  summary: string;
+  compareLine: string;
+  tags: PlanTagEnum[];
+  cards: PlanCards;
+  workOrders: PlanWorkOrder[];
+};
+
+export type MitigationPlansResult = { plans: MitigationPlanItem[] };

--- a/src/features/inbox/agent/triage/context.ts
+++ b/src/features/inbox/agent/triage/context.ts
@@ -19,10 +19,23 @@ import {
   workflowClinicalSummary,
 } from "@/lib/markdown";
 
+export type LinkableIds = {
+  vulnerabilityIds: string[];
+  remediationIds: string[];
+  deviceGroupMatchingIds: string[];
+};
+
 export type TriageContext = {
   notificationId: string;
   markdown: string;
   affectedAssetIds: string[];
+  linkableIds: LinkableIds;
+};
+
+const EMPTY_LINKABLE_IDS: LinkableIds = {
+  vulnerabilityIds: [],
+  remediationIds: [],
+  deviceGroupMatchingIds: [],
 };
 
 // Unlike the VEX agent's gatherVexContext, this unions notification- and
@@ -30,6 +43,7 @@ export type TriageContext = {
 // without linked vulns/assets still triage on a degraded context.
 export async function gatherTriageContext(
   notificationId: string,
+  opts: { includeIds?: boolean } = {},
 ): Promise<TriageContext> {
   const notification = await prisma.notification.findUnique({
     where: { id: notificationId },
@@ -77,7 +91,12 @@ export async function gatherTriageContext(
   });
 
   if (!notification) {
-    return { notificationId, markdown: "", affectedAssetIds: [] };
+    return {
+      notificationId,
+      markdown: "",
+      affectedAssetIds: [],
+      linkableIds: EMPTY_LINKABLE_IDS,
+    };
   }
 
   const vulnerabilities = notification.vulnerabilities.map(
@@ -193,21 +212,44 @@ export async function gatherTriageContext(
     })),
   );
 
+  // One line per matching (the entity an agent links against), with the device
+  // groups and assets it actually resolves to. Only rendered under includeIds.
+  const matchingSummaries: MatchingSummary[] = matchings.map((m) => {
+    const resolved = groups.filter((g) => matchingAppliesToDeviceGroup(m, g));
+    return {
+      id: m.id,
+      label: deviceGroupMatchingLabel(m),
+      groupCount: resolved.length,
+      assetCount: resolved.reduce((sum, g) => sum + g.assets.length, 0),
+    };
+  });
+
   const markdown = renderTriagePrompt({
     vulnerabilities: vulnInputs,
     vexIssues,
     remediations,
     groups,
+    matchingSummaries,
     affectedAssets,
     notes,
     noteLabels,
+    includeIds: opts.includeIds ?? false,
     workflowsMarkdown:
       affectedAssetIds.length > 0
         ? workflowClinicalSummary(workflows, affectedAssetIds)
         : null,
   });
 
-  return { notificationId, markdown, affectedAssetIds };
+  return {
+    notificationId,
+    markdown,
+    affectedAssetIds,
+    linkableIds: {
+      vulnerabilityIds: vulnerabilities.map((v) => v.id),
+      remediationIds: remediations.map((r) => r.id),
+      deviceGroupMatchingIds: matchings.map((m) => m.id),
+    },
+  };
 }
 
 type AffectedAsset = {
@@ -239,11 +281,20 @@ type GroupForRender = {
   assets: unknown[];
 };
 
+type MatchingSummary = {
+  id: string;
+  label: string;
+  groupCount: number;
+  assetCount: number;
+};
+
 type RenderArgs = {
   vulnerabilities: VulnerabilityForMarkdown[];
   vexIssues: VexIssue[];
   remediations: RemediationForMarkdown[];
   groups: GroupForRender[];
+  matchingSummaries: MatchingSummary[];
+  includeIds: boolean;
   affectedAssets: AffectedAsset[];
   notes: Array<{
     text: string;
@@ -278,6 +329,7 @@ function renderTriagePrompt(args: RenderArgs): string {
             vulnerabilityToMarkdown(v, {
               includeAssets: false,
               includeRemediations: false,
+              includeId: args.includeIds,
             }),
           )
           .join("\n\n"),
@@ -313,7 +365,19 @@ function renderTriagePrompt(args: RenderArgs): string {
     );
   }
 
-  if (args.groups.length > 0) {
+  // With ids on, list the device-group *matchings* — those are what an agent
+  // links against — rolled up to the groups and assets each one resolves to.
+  if (args.includeIds && args.matchingSummaries.length > 0) {
+    sections.push(
+      "## Affected device groups\n\n" +
+        args.matchingSummaries
+          .map(
+            (m) =>
+              `- **${m.label}** (id: ${m.id}) — ${m.groupCount} device group${m.groupCount === 1 ? "" : "s"}, ${m.assetCount} asset${m.assetCount === 1 ? "" : "s"}`,
+          )
+          .join("\n"),
+    );
+  } else if (args.groups.length > 0) {
     sections.push(
       "## Affected device groups\n\n" +
         args.groups

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -345,6 +345,8 @@ function renderVexPrompt(args: {
 
 // ─── System prompt ───────────────────────────────────────────────────────────
 
+export const VEX_TOOL_NAME = "update_and_create_issues";
+
 export const SYSTEM_PROMPT = `You are an issue triage analyst for a hospital cybersecurity platform. A security notification references one or more vulnerabilities, and the platform has already opened one baseline Issue per (vulnerability × affected device group). Your job is to sort each issue into the correct exploitability status using ONLY the evidence provided.
 
 Statuses:
@@ -361,4 +363,4 @@ Rules:
 - If only one asset is an exception (e.g. one asset is not network-reachable) and the rest of the group is still affected, OMIT the group-level "status" so the device-group issue is left unchanged, and put the exception in "assets". Set the group "status" only when your determination applies to the whole group.
 - Ground every decision in the provided sources, vulnerability descriptions, remediations, and notes. Never invent facts or numbers.
 - Set confidence to Matched only with strong evidence; otherwise NeedsReview.
-- Call the record_vex_determinations tool exactly once with your determinations. Omit issues you are not changing.`;
+- Call the ${VEX_TOOL_NAME} tool exactly once with your determinations. Omit issues you are not changing; pass {} if nothing changes. You must always call it — never answer in prose.`;

--- a/src/features/inbox/agent/vex/index.ts
+++ b/src/features/inbox/agent/vex/index.ts
@@ -6,7 +6,13 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { tool } from "@langchain/core/tools";
-import { gatherVexContext, SYSTEM_PROMPT, type VexContext } from "./context";
+import { z } from "zod";
+import {
+  gatherVexContext,
+  SYSTEM_PROMPT,
+  VEX_TOOL_NAME,
+  type VexContext,
+} from "./context";
 import { applyVexDeterminations, type VexApplySummary } from "./process_output";
 import { buildVexSchema, type VexResult } from "./tools";
 
@@ -18,9 +24,8 @@ export async function sortVulnerabilities(
   const issueIds = context.issues.map((i) => i.issueId);
   const schema = buildVexSchema(issueIds);
 
-  const TOOL_NAME = "update_and_create_issues";
   const recordTool = tool(async () => "ok", {
-    name: TOOL_NAME,
+    name: VEX_TOOL_NAME,
     description:
       "Record the issue status determination for each issue, keyed by id. Omit issues that are unchanged.",
     schema,
@@ -39,11 +44,22 @@ export async function sortVulnerabilities(
     { role: "user", content: context.markdown },
   ]);
 
-  const call = res.tool_calls?.find((c) => c.name === TOOL_NAME);
-  if (!call) return {};
+  // Fail loud
+  const call = res.tool_calls?.find((c) => c.name === VEX_TOOL_NAME);
+  if (!call) {
+    throw new Error(
+      `VEX agent never called ${VEX_TOOL_NAME} for notification ${context.notificationId}`,
+    );
+  }
 
   const parsed = schema.safeParse(call.args);
-  return parsed.success ? (parsed.data as VexResult) : {};
+  if (!parsed.success) {
+    throw new Error(
+      `VEX agent returned invalid ${VEX_TOOL_NAME} args for notification ${context.notificationId}: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+
+  return parsed.data as VexResult;
 }
 
 /**

--- a/src/features/inbox/utils.ts
+++ b/src/features/inbox/utils.ts
@@ -3,7 +3,7 @@ import prisma from "@/lib/db";
 import { normalizeName } from "@/lib/router-utils";
 import { downloadBufferFromS3, keyFromDownloadUrl } from "@/lib/s3";
 
-const isPdf = (a: {
+export const isPdf = (a: {
   filename?: string | null;
   contentType?: string | null;
 }): boolean =>
@@ -92,6 +92,29 @@ export async function fetchPdfAttachments(
   );
 
   return results.filter((a) => a !== null);
+}
+
+export function keepValidIds(
+  ids: string[],
+  valid: ReadonlySet<string>,
+): string[] {
+  return [...new Set(ids)].filter((id) => valid.has(id));
+}
+
+/** Ids of the given set that exist in the table, as a Set for membership tests. */
+export async function existingIds<T extends { id: string }>(
+  findMany: (args: {
+    where: { id: { in: string[] } };
+    select: { id: true };
+  }) => Promise<T[]>,
+  ids: string[],
+): Promise<Set<string>> {
+  if (ids.length === 0) return new Set();
+  const rows = await findMany({
+    where: { id: { in: [...new Set(ids)] } },
+    select: { id: true },
+  });
+  return new Set(rows.map((r) => r.id));
 }
 
 // Similiar to resolveDeviceGroup except it doesn't create. From

--- a/src/features/mitigation/server/routers.ts
+++ b/src/features/mitigation/server/routers.ts
@@ -1,0 +1,71 @@
+import "server-only";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import prisma from "@/lib/db";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+
+// Draft work orders proposed by a plan, in the shape the plan UI renders.
+const planWorkOrderSelect = {
+  id: true,
+  summary: true,
+  sourceLabel: true,
+  body: true,
+  category: true,
+  status: true,
+  isDraft: true,
+} as const;
+
+const mitigationPlanInclude = {
+  workOrders: {
+    select: planWorkOrderSelect,
+    orderBy: { createdAt: "asc" },
+  },
+} as const;
+
+export const mitigationRouter = createTRPCRouter({
+  // All mitigation plans for a notification, ordered (order 0 = recommended),
+  // each with its (draft or promoted) work orders.
+  getForNotification: protectedProcedure
+    .input(z.object({ notificationId: z.string() }))
+    .query(({ input }) =>
+      prisma.mitigationPlan.findMany({
+        where: { notificationId: input.notificationId },
+        include: mitigationPlanInclude,
+        orderBy: { order: "asc" },
+      }),
+    ),
+
+  // Accept a plan: mark it accepted (and every other plan for the notification
+  // un-accepted — only one may be accepted), and promote its draft work orders
+  // into real tickets by clearing isDraft.
+  accept: protectedProcedure
+    .input(z.object({ planId: z.string() }))
+    .mutation(async ({ input }) => {
+      const plan = await prisma.mitigationPlan.findUnique({
+        where: { id: input.planId },
+        select: { id: true, notificationId: true },
+      });
+      if (!plan) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Plan not found" });
+      }
+
+      return prisma.$transaction(async (tx) => {
+        await tx.mitigationPlan.updateMany({
+          where: { notificationId: plan.notificationId },
+          data: { isAccepted: false },
+        });
+        await tx.mitigationPlan.update({
+          where: { id: plan.id },
+          data: { isAccepted: true },
+        });
+        await tx.workOrderTicket.updateMany({
+          where: { mitigationPlanId: plan.id },
+          data: { isDraft: false },
+        });
+        return tx.mitigationPlan.findUniqueOrThrow({
+          where: { id: plan.id },
+          include: mitigationPlanInclude,
+        });
+      });
+    }),
+});

--- a/src/features/tracking/server/routers.test.ts
+++ b/src/features/tracking/server/routers.test.ts
@@ -415,8 +415,8 @@ describe("trackingRouter.getMany — my-department tab", () => {
     });
 
     const where = mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where;
-    // AND[0] is parentId filter, AND[1] is the tab filter, AND[2] is search
-    expect(where.AND[1]).toEqual({
+    // AND[0] parentId, AND[1] isDraft filter, AND[2] tab filter, AND[3] search
+    expect(where.AND[2]).toEqual({
       departments: { some: { id: "dept-A" } },
     });
   });
@@ -437,7 +437,7 @@ describe("trackingRouter.getMany — my-department tab", () => {
     });
 
     const where = mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where;
-    expect(where.AND[1]).toEqual({ id: "__no_department__" });
+    expect(where.AND[2]).toEqual({ id: "__no_department__" });
   });
 });
 
@@ -529,8 +529,8 @@ describe("trackingRouter.list", () => {
     expect(mockPrisma.workOrderTicket.count).toHaveBeenCalledTimes(1);
     expect(mockPrisma.workOrderTicket.findMany).toHaveBeenCalledTimes(1);
     const findManyArg = mockPrisma.workOrderTicket.findMany.mock.calls[0][0];
-    // Only the (empty) search filter ends up in the AND list
-    expect(findManyArg.where.AND).toEqual([{}]);
+    // The isDraft filter and the (empty) search filter end up in the AND list
+    expect(findManyArg.where.AND).toEqual([{ isDraft: false }, {}]);
   });
 
   it("filters by departmentIds via m2m `some` + `in`", async () => {
@@ -1112,6 +1112,7 @@ describe("trackingRouter.listAttachableChildren", () => {
     expect(arg.where).toEqual({
       id: { not: "p1" },
       children: { none: {} },
+      isDraft: false,
     });
     expect(arg.select.parent).toEqual({
       select: { id: true, summary: true },

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -194,7 +194,12 @@ export const trackingRouter = createTRPCRouter({
       }
 
       const where: Prisma.WorkOrderTicketWhereInput = {
-        AND: [{ parentId: null }, parentTabWhere, createSearchFilter(search)],
+        AND: [
+          { parentId: null },
+          { isDraft: false },
+          parentTabWhere,
+          createSearchFilter(search),
+        ],
       };
 
       const totalCount = await prisma.workOrderTicket.count({ where });
@@ -314,6 +319,7 @@ export const trackingRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       const { search, departmentIds, assigneeIds } = input;
       const filters: Prisma.WorkOrderTicketWhereInput[] = [
+        { isDraft: false },
         createSearchFilter(search),
       ];
 
@@ -574,6 +580,7 @@ export const trackingRouter = createTRPCRouter({
         where: {
           id: { not: input.parentId },
           children: { none: {} },
+          isDraft: false,
         },
         select: {
           id: true,

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -156,10 +156,9 @@ export const processInboxEmail = inngest.createFunction(
     // 5. Persist NotificationSource + NotificationAttachment
     const sourceId = await step.run("save-source", async () => {
       // DEV: uncomment to reset duplicate so you can replay the same email webhook
-      // TODO cassidy
-      await prisma.notificationSource.deleteMany({
-        where: { externalId: emailId },
-      });
+      // await prisma.notificationSource.deleteMany({
+      //  where: { externalId: emailId },
+      // });
 
       try {
         const source = await prisma.notificationSource.create({

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -55,7 +55,7 @@ export const processInboxEmail = inngest.createFunction(
 
     // 3. Triage: is this relevant at all, and if so is it an informational
     // Notification or an actionable Work Order?
-    const { kind } = await step.run("classify-email", async () => {
+    const { kind } = await step.run("classify-email-kind", async () => {
       const pdfAttachments = await fetchPdfAttachmentsFromResend(
         emailId,
         email.attachments ?? [],
@@ -78,6 +78,7 @@ export const processInboxEmail = inngest.createFunction(
     const uploadedAttachments = await step.run(
       "upload-attachments",
       async () => {
+        console.log("HEY", email)
         if (!email.attachments?.length) return [];
 
         const { Resend } = await import("resend");
@@ -98,7 +99,11 @@ export const processInboxEmail = inngest.createFunction(
 
             const res = await fetch(attData.download_url);
             if (!res.ok) {
+              const responseText = await res.text();
+              console.log('heyo', res.status, responseText)
               console.warn(`Failed to download attachment ${att.id}`);
+              // TODO: (HEY!) This should probably be blocking -- the attachment, in most cases
+              // I've seen, is where all of the information comes from
               return null;
             }
 
@@ -144,9 +149,10 @@ export const processInboxEmail = inngest.createFunction(
     // 5. Persist NotificationSource + NotificationAttachment
     const sourceId = await step.run("save-source", async () => {
       // DEV: uncomment to reset duplicate so you can replay the same email webhook
-      //await prisma.notificationSource.deleteMany({
-      //  where: { externalId: emailId },
-      //});
+      // TODO cassidy
+      await prisma.notificationSource.deleteMany({
+        where: { externalId: emailId },
+      });
 
       try {
         const source = await prisma.notificationSource.create({

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -12,7 +12,7 @@ import { matchAndLinkEntities } from "@/features/inbox/agent/match";
 import { persistMitigationPlans } from "@/features/inbox/agent/mitigation/persist";
 import { triageNotification } from "@/features/inbox/agent/triage";
 import { sortNotificationVulnerabilities } from "@/features/inbox/agent/vex";
-import { fetchPdfAttachmentsFromResend } from "@/features/inbox/utils";
+import { fetchPdfAttachmentsFromResend, isPdf } from "@/features/inbox/utils";
 import { Prisma } from "@/generated/prisma";
 import { getAutomationUser } from "@/lib/automation-user";
 import prisma from "@/lib/db";
@@ -78,7 +78,6 @@ export const processInboxEmail = inngest.createFunction(
     const uploadedAttachments = await step.run(
       "upload-attachments",
       async () => {
-        console.log("HEY", email)
         if (!email.attachments?.length) return [];
 
         const { Resend } = await import("resend");
@@ -99,11 +98,19 @@ export const processInboxEmail = inngest.createFunction(
 
             const res = await fetch(attData.download_url);
             if (!res.ok) {
-              const responseText = await res.text();
-              console.log('heyo', res.status, responseText)
-              console.warn(`Failed to download attachment ${att.id}`);
-              // TODO: (HEY!) This should probably be blocking -- the attachment, in most cases
-              // I've seen, is where all of the information comes from
+              const detail = `${res.status} ${await res.text()}`;
+              // If there's a pdf that we can't download, just throw an error
+              // Chances are all relevant context is there
+              if (
+                isPdf({ filename: att.filename, contentType: att.content_type })
+              ) {
+                throw new Error(
+                  `Failed to download PDF attachment ${att.id}: ${detail}`,
+                );
+              }
+              console.warn(
+                `Failed to download attachment ${att.id}: ${detail}`,
+              );
               return null;
             }
 

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -9,6 +9,7 @@ import { classifyEmailKind } from "@/features/inbox/agent/classify-kind";
 import { extractEntities } from "@/features/inbox/agent/extract";
 import { extractWorkOrder } from "@/features/inbox/agent/extract-work-order";
 import { matchAndLinkEntities } from "@/features/inbox/agent/match";
+import { persistMitigationPlans } from "@/features/inbox/agent/mitigation/persist";
 import { triageNotification } from "@/features/inbox/agent/triage";
 import { sortNotificationVulnerabilities } from "@/features/inbox/agent/vex";
 import { fetchPdfAttachmentsFromResend } from "@/features/inbox/utils";
@@ -354,6 +355,22 @@ export const processInboxEmail = inngest.createFunction(
       });
     }
 
-    return { sourceId, notificationId, emailId, linkSummary, vexSummary };
+    // 12. Mitigation plans: if the notification has linked vulnerabilities,
+    // propose ordered remediation plans and materialize each as a plan plus its
+    // draft work orders (isDraft=true; accepting a plan promotes them).
+    const mitigationSummary = notificationId
+      ? await step.run("create-mitigation-plans", () =>
+          persistMitigationPlans(sourceId, notificationId),
+        )
+      : null;
+
+    return {
+      sourceId,
+      notificationId,
+      emailId,
+      linkSummary,
+      vexSummary,
+      mitigationSummary,
+    };
   },
 );

--- a/src/lib/agent-messages.ts
+++ b/src/lib/agent-messages.ts
@@ -14,12 +14,12 @@ export type PdfAttachment = {
  * which ride along as Anthropic `document` blocks so the model reads them
  * beside the text rather than in a separate call.
  */
+// https://github.com/anthropics/skills/blob/main/skills/claude-api/SKILL.md#document--file-input-quick-reference
 export function buildUserMessage(
   text: string,
   pdfAttachments: PdfAttachment[] = [],
 ): HumanMessage {
   const content = [
-    { type: "text" as const, text },
     ...pdfAttachments.map((pdf) => ({
       type: "document",
       source: {
@@ -29,6 +29,7 @@ export function buildUserMessage(
       },
       title: pdf.filename ?? "attachment.pdf",
     })),
+    { type: "text" as const, text },
   ];
 
   // biome-ignore lint/suspicious/noExplicitAny: LangChain's content type doesn't model Anthropic document blocks

--- a/src/lib/markdown/remediation.ts
+++ b/src/lib/markdown/remediation.ts
@@ -2,7 +2,7 @@
 // these fields is compatible.
 
 import { deviceGroupMatchingsSummary } from "./device-group";
-import { type CanonicalRef, shortId } from "./shared";
+import type { CanonicalRef } from "./shared";
 
 type DeviceGroupMatchingForMarkdown = {
   vendor?: CanonicalRef;
@@ -36,7 +36,7 @@ export interface RemediationForMarkdown {
 export function remediationToMarkdown(r: RemediationForMarkdown): string {
   const cveRef =
     r.vulnerability?.cveId ?? r.vulnerabilityId ?? "no linked vuln";
-  const lines = [`### Remediation rem-${shortId(r.id)} → ${cveRef}`];
+  const lines = [`### Remediation ${r.id} → ${cveRef}`];
 
   const remediationMatchings = r.deviceGroupMatchings ?? [];
   if (remediationMatchings.length > 0) {
@@ -55,7 +55,7 @@ export function remediationToMarkdown(r: RemediationForMarkdown): string {
       const label =
         ir.issue.asset.hostname ?? ir.issue.asset.ip ?? ir.issue.asset.id;
       lines.push(
-        `  - ${label} (${shortId(ir.issue.asset.id)}) — issue status: ${ir.issue.status}`,
+        `  - ${label} (${ir.issue.asset.id}) — issue status: ${ir.issue.status}`,
       );
     }
   }

--- a/src/lib/markdown/vulnerability.ts
+++ b/src/lib/markdown/vulnerability.ts
@@ -32,13 +32,18 @@ export interface VulnerabilityForMarkdown {
 
 export function vulnerabilityToMarkdown(
   v: VulnerabilityForMarkdown,
-  opts: { includeAssets?: boolean; includeRemediations?: boolean } = {
+  opts: {
+    includeAssets?: boolean;
+    includeRemediations?: boolean;
+    includeId?: boolean;
+  } = {
     includeAssets: true,
     includeRemediations: true,
   },
 ): string {
+  const idRef = opts.includeId && v.cveId ? ` (id: ${v.id})` : "";
   const lines = [
-    `### ${v.cveId ?? v.id} — ${v.severity}${v.priority ? `, priority: ${v.priority}` : ""}`,
+    `### ${v.cveId ?? v.id}${idRef} — ${v.severity}${v.priority ? `, priority: ${v.priority}` : ""}`,
     `- **CVSS Score**: ${v.cvssScore ?? "N/A"}`,
     `- **CVSS Vector**: ${v.cvssVector ?? "N/A"}`,
     `- **EPSS**: ${v.epss != null ? `${(v.epss * 100).toFixed(2)}%` : "N/A"}`,

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -8,6 +8,7 @@ import { deviceGroupsRouter } from "@/features/device-groups/server/routers";
 import { notificationsRouter } from "@/features/inbox/server/routers";
 import { integrationsRouter } from "@/features/integrations/server/routers";
 import { issuesRouter } from "@/features/issues/server/routers";
+import { mitigationRouter } from "@/features/mitigation/server/routers";
 import { networkRouter } from "@/features/network/server/router";
 import { remediationsRouter } from "@/features/remediations/server/routers";
 import { tagColorsRouter } from "@/features/tag-colors/server/routers";
@@ -27,6 +28,7 @@ export const appRouter = createTRPCRouter({
   deviceArtifacts: deviceArtifactsRouter,
   user: userRouter,
   issues: issuesRouter,
+  mitigation: mitigationRouter,
   integrations: integrationsRouter,
   deviceGroups: deviceGroupsRouter,
   webhooks: webhooksRouter,


### PR DESCRIPTION
* New MitigationPlan model, which gets created by an agent after triage step
* WorkOrderTickets can now be linked to a Notification, have priority

Misc fixes:
* Dev docker compose didn't work for me, so some small fixes for that.
* Made VEX agent fail loud, instead of silently succeeding, if the produced schema is invalid
* Put VEX agent return tool name in prompt itself (previous tool name was incorrect)
* Throw an error if there's a PDF that fails to download, since the rest of the pipeline at this point is probably useless
* Swap order of "document" and "text" in `buildUserMessage`, according to best practices in Anthropic docs (actually, their claude API skill, but I linked the github for that)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-generated mitigation plans for inbox notifications, including linked work orders and supporting context.
  * Added options to review and accept a recommended mitigation plan, promoting its draft work orders.
  * Added priority, draft status, notification links, and mitigation-plan associations to work orders.
  * Added Docker Compose startup guidance and improved local development configuration.

* **Bug Fixes**
  * Draft work orders are now excluded from standard tracking lists and attachment selection.
  * PDF attachment download failures now report clearer errors and stop processing when necessary.
  * VEX analysis now validates required tool responses more strictly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->