### PR TITLE
[VW-0] created collapsible card component

### DIFF
--- a/src/components/ui/collapsible-card.tsx
+++ b/src/components/ui/collapsible-card.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 
-
 function CollapsibleCard({
   className,
   ...props

--- a/src/components/ui/collapsible-card.tsx
+++ b/src/components/ui/collapsible-card.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { ChevronDownIcon } from "lucide-react";
+import type * as React from "react";
+
+import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+
+function CollapsibleCard({
+  className,
+  ...props
+}: React.ComponentProps<typeof Collapsible>) {
+  return (
+    <Card className={cn("gap-0", className)}>
+      <Collapsible data-slot="collapsible-card" {...props} />
+    </Card>
+  );
+}
+
+function CollapsibleCardTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof CollapsibleTrigger>) {
+  return (
+    <CardTitle>
+      <CollapsibleTrigger
+        data-slot="collapsible-card-trigger"
+        className={cn(
+          "group flex w-full cursor-pointer items-center gap-2 rounded-md px-6 text-left outline-none",
+          "focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          className,
+        )}
+        {...props}
+      >
+        <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=closed]:-rotate-90" />
+        {children}
+      </CollapsibleTrigger>
+    </CardTitle>
+  );
+}
+
+function CollapsibleCardContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof CollapsibleContent>) {
+  return (
+    <CollapsibleContent
+      data-slot="collapsible-card-content"
+      className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down"
+      {...props}
+    >
+      <CardContent className={cn("pt-4", className)}>{children}</CardContent>
+    </CollapsibleContent>
+  );
+}
+
+export { CollapsibleCard, CollapsibleCardTrigger, CollapsibleCardContent };

--- a/src/features/inbox/components/notification-overview-tab.tsx
+++ b/src/features/inbox/components/notification-overview-tab.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { format } from "date-fns";
-import {
-  ChevronDownIcon,
-  ExternalLinkIcon,
-  HeartIcon,
-  MailIcon,
-  Unlink,
-} from "lucide-react";
+import { ExternalLinkIcon, HeartIcon, MailIcon, Unlink } from "lucide-react";
 import { Fragment, type ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { TlpBadge } from "@/components/tlp-badge";
@@ -15,10 +9,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+  CollapsibleCard,
+  CollapsibleCardContent,
+  CollapsibleCardTrigger,
+} from "@/components/ui/collapsible-card";
 import {
   Dialog,
   DialogContent,
@@ -241,45 +235,42 @@ export function NotificationOverviewTab({
     <>
       {/* Hospital Impact */}
       {hasImpact && impact && (
-        <Card>
-          <Collapsible defaultOpen>
-            <CollapsibleTrigger className="group flex w-full items-center gap-2 px-6 text-left">
-              <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
-              <HeartIcon className="size-4" />
-              <span className="font-semibold">Hospital Impact</span>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="px-6 pt-4">
-              <div className="flex flex-col gap-4">
-                {impact.byline && (
-                  <p className="font-semibold leading-snug">{impact.byline}</p>
-                )}
-                {impact.impactStatement && (
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {impact.impactStatement}
+        <CollapsibleCard defaultOpen>
+          <CollapsibleCardTrigger>
+            <HeartIcon className="size-4" />
+            Hospital Impact
+          </CollapsibleCardTrigger>
+          <CollapsibleCardContent>
+            <div className="flex flex-col gap-4">
+              {impact.byline && (
+                <p className="font-semibold leading-snug">{impact.byline}</p>
+              )}
+              {impact.impactStatement && (
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {impact.impactStatement}
+                </p>
+              )}
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Care Areas
                   </p>
-                )}
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <div className="rounded-lg border p-3">
-                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Care Areas
-                    </p>
-                    <p className="mt-1 text-sm font-medium">
-                      {impact.careAreas || "—"}
-                    </p>
-                  </div>
-                  <div className="rounded-lg border p-3">
-                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Likelihood
-                    </p>
-                    <p className="mt-1 text-sm font-medium">
-                      {impact.likelihood || "—"}
-                    </p>
-                  </div>
+                  <p className="mt-1 text-sm font-medium">
+                    {impact.careAreas || "—"}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Likelihood
+                  </p>
+                  <p className="mt-1 text-sm font-medium">
+                    {impact.likelihood || "—"}
+                  </p>
                 </div>
               </div>
-            </CollapsibleContent>
-          </Collapsible>
-        </Card>
+            </div>
+          </CollapsibleCardContent>
+        </CollapsibleCard>
       )}
 
       {/* Summary */}


### PR DESCRIPTION
Created reusable component for collapsible card, and applied it to existing hospital impact card

<img width="1968" height="774" alt="image" src="https://github.com/user-attachments/assets/f4110dfa-1432-451e-a816-7e3c28cb2267" />
<img width="1920" height="132" alt="image" src="https://github.com/user-attachments/assets/a11d1916-1fd4-41ca-80fe-30597ed3994a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable collapsible cards with animated expand and collapse behavior.
  * Updated the Hospital Impact section with a consistent card-style collapsible layout.

* **Style**
  * Improved visual consistency and interaction cues with card styling and rotating chevron indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->