### PR TITLE
[VW-0] Making Playwright imports Dynamic

### DIFF
--- a/src/features/integrations/teamplay-fleet/capture.ts
+++ b/src/features/integrations/teamplay-fleet/capture.ts
@@ -1,6 +1,3 @@
-import sparticuzChromium from "@sparticuz/chromium";
-import { chromium } from "playwright-core";
-
 export interface SessionLoginConfig {
   welcomeUrl: string;
   cookieBannerAcceptSelector?: string; // there is a cookie setting overlay on the very first login
@@ -20,8 +17,11 @@ export interface CapturedSession {
 }
 
 async function launchBrowser() {
-  // production use. Tt is a known issue that playwright-core doesn't work with vercel in deployed environment.
+  const { chromium } = await import("playwright-core");
+
+  // production use. It is a known issue that playwright-core doesn't work with vercel in deployed environment.
   if (process.env.VERCEL) {
+    const { default: sparticuzChromium } = await import("@sparticuz/chromium");
     return chromium.launch({
       executablePath: await sparticuzChromium.executablePath(),
       args: sparticuzChromium.args,


### PR DESCRIPTION
Was getting the following 500 error on vercel deployments
<img width="610" height="261" alt="image" src="https://github.com/user-attachments/assets/69c9377d-081a-4733-b43f-5270951541ba" />

Moving (playwright-core, @sparticuz/chromium) to a dynamic import in `launchBrowser()` resolves this 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser launching reliability across different deployment environments.
  * Enhanced compatibility for hosted deployments using the Vercel platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->