### PR TITLE
[VW-388] Question Agent API, Create Note, Generate Followup questions (2/3)

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -8,6 +8,7 @@ import { extractArtifactNotesFn } from "@/inngest/functions/extract-artifact-not
 import { manageMemoriesFn } from "@/inngest/functions/manage-memories";
 import { processInboxEmail } from "@/inngest/functions/process-inbox-email";
 import { purgeExpiredTokensFn } from "@/inngest/functions/purge-expired-user-tokens";
+import { reevaluateIssueOnAnswer } from "@/inngest/functions/reevaluate-issue-on-answer";
 import {
   resolveAllEntityFilters,
   resolveEntityFilterFn,
@@ -30,5 +31,6 @@ export const { GET, POST, PUT } = serve({
     resolveAllEntityFilters,
     resolveEntityFilterFn,
     extractArtifactNotesFn,
+    reevaluateIssueOnAnswer
   ],
 });

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -31,6 +31,6 @@ export const { GET, POST, PUT } = serve({
     resolveAllEntityFilters,
     resolveEntityFilterFn,
     extractArtifactNotesFn,
-    reevaluateIssueOnAnswer
+    reevaluateIssueOnAnswer,
   ],
 });

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -105,13 +105,13 @@ export async function gatherQuestionContext(
       },
     },
   });
-
+  console.log("gatherQuestionContext notification ", notification);
   if (!notification) return null;
 
   const vulnerabilities = notification.vulnerabilities.map(
     (m) => m.vulnerability,
   );
-
+  console.log("gatherQuestionContext vulnerabilities ", vulnerabilities);
   if (vulnerabilities.length === 0) return null;
 
   const matchingsById = new Map<string, MatchingWithRefs>();
@@ -119,7 +119,7 @@ export async function gatherQuestionContext(
     for (const dgm of v.deviceGroupMatchings) matchingsById.set(dgm.id, dgm);
   }
   const matchings = [...matchingsById.values()];
-
+  console.log("gatherQuestionContext matchings ", matchings);
   const candidateGroups =
     matchings.length > 0
       ? await prisma.deviceGroup.findMany({
@@ -154,9 +154,11 @@ export async function gatherQuestionContext(
     statusNotes: string | null;
   };
   const issueRenders: IssueRender[] = [];
-
+  console.log("gatherQuestionContext-----------------------------");
   for (const v of vulnerabilities) {
+    console.log("gatherQuestionContext v ", v);
     for (const issue of v.issues) {
+      console.log("gatherQuestionContext issue ", issue);
       if (!issue.deviceGroupMatchingId) continue;
       const matching = matchingsById.get(issue.deviceGroupMatchingId);
 
@@ -177,7 +179,7 @@ export async function gatherQuestionContext(
       });
     }
   }
-
+  console.log("gatherQuestionContext issues ", issues);
   if (issues.length === 0) return null;
 
   const assetIds = [
@@ -188,12 +190,13 @@ export async function gatherQuestionContext(
     deviceGroupMatchingIds: matchings.map((m) => m.id),
     assetIds,
   });
-
+  console.log("gatherQuestionContext notes ", notes);
   const markdown = renderQuestionPrompt({
     vulnerabilities,
     issueRenders,
     notes,
   });
+  console.log("gatherQuestionContext markdown ", markdown);
   return { notificationId, markdown, issues };
 }
 
@@ -206,58 +209,68 @@ Omit any issue you don't have a good, specific question for.`;
 export async function gatherQuestionContextForIssue(
   issueId: string,
   notificationId: string,
-  priorQnA: { title: string; answer: string | null}[],
+  priorQnA: { title: string; answer: string | null }[],
 ): Promise<QuestionContext | null> {
   const issue = await prisma.issue.findUnique({
     where: { id: issueId },
     include: { vulnerability: true },
   });
 
-  if(!issue || !issue.deviceGroupMatchingId) return null;
+  if (!issue || !issue.deviceGroupMatchingId) return null;
 
   const matching = await prisma.deviceGroupMatching.findUnique({
     where: { id: issue.deviceGroupMatchingId },
     include: {
-      vendor: { select: { canonicalDisplayName: true }},
-      product: { select: { canonicalDisplayName: true}},
-      version: { select: { canonicalDisplayName: true }},
+      vendor: { select: { canonicalDisplayName: true } },
+      product: { select: { canonicalDisplayName: true } },
+      version: { select: { canonicalDisplayName: true } },
     },
   });
 
-  if(!matching) return null;
+  if (!matching) return null;
 
   const candidateGroups = await prisma.deviceGroup.findMany({
     where: deviceGroupWhereForMatching(matching),
-    select: { id: true, assets: { select: {id: true}}}
+    select: { id: true, assets: { select: { id: true } } },
   });
 
-  const groups = candidateGroups.filter((g) => matchingAppliesToDeviceGroup(matching, g));
-  const assetIds = [...new Set(groups.flatMap((g) => g.assets.map((a)=> a.id)))];
+  const groups = candidateGroups.filter((g) =>
+    matchingAppliesToDeviceGroup(matching, g),
+  );
+  const assetIds = [
+    ...new Set(groups.flatMap((g) => g.assets.map((a) => a.id))),
+  ];
 
   const notes = await getRelevantNotes({
     vulnerabilityIds: [issue.vulnerabilityId],
     deviceGroupMatchingIds: [matching.id],
-    assetIds
+    assetIds,
   });
 
-  const priorQnAText = priorQnA.map((q) => renderQnA(q.title, q.answer)).join("\n\n");
+  const priorQnAText = priorQnA
+    .map((q) => renderQnA(q.title, q.answer))
+    .join("\n\n");
 
-  const markdown = renderQuestionPrompt({
-    vulnerabilities:[issue.vulnerability],
-    issueRenders:[{
-      issueId: issue.id,
-      cve: issue.vulnerability.cveId ?? issue.vulnerability.id,
-      matching,
-      assetCount: groups.reduce((n, g) => n + g.assets.length, 0),
-      statusNotes: issue.statusNotes
-    }],
-    notes,
-  }) + "\n\n## Already asked and answered - do not repeat this, ask something more specific\n\n" + priorQnAText;
+  const markdown =
+    renderQuestionPrompt({
+      vulnerabilities: [issue.vulnerability],
+      issueRenders: [
+        {
+          issueId: issue.id,
+          cve: issue.vulnerability.cveId ?? issue.vulnerability.id,
+          matching,
+          assetCount: groups.reduce((n, g) => n + g.assets.length, 0),
+          statusNotes: issue.statusNotes,
+        },
+      ],
+      notes,
+    }) +
+    "\n\n## Already asked and answered - do not repeat this, ask something more specific\n\n" +
+    priorQnAText;
 
   return {
     notificationId,
     markdown,
-    issues: [{ issueId: issue.id, vulnerabilityId: issue.vulnerability.id}]
-  }
-
+    issues: [{ issueId: issue.id, vulnerabilityId: issue.vulnerability.id }],
+  };
 }

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -231,7 +231,14 @@ export async function gatherQuestionContextForIssue(
 
   const candidateGroups = await prisma.deviceGroup.findMany({
     where: deviceGroupWhereForMatching(matching),
-    select: { id: true, assets: { select: { id: true } } },
+    select: {
+      id: true,
+      vendorId: true,
+      productId: true,
+      versionId: true,
+      version: { select: { canonicalName: true } },
+      assets: { select: { id: true } },
+    },
   });
 
   const groups = candidateGroups.filter((g) =>

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -7,6 +7,7 @@ import {
   matchingAppliesToDeviceGroup,
 } from "@/lib/device-matching";
 import { deviceGroupMatchingLabel, type NoteRow } from "@/lib/markdown";
+import { renderQnA } from "@/lib/markdown/note";
 
 export type QuestionIssueContext = { issueId: string; vulnerabilityId: string };
 
@@ -201,3 +202,62 @@ export async function gatherQuestionContext(
 export const SYSTEM_PROMPT = `You are drafting clarifying questions for a hospital security engineer, for vulnerability issues a triage agent already marked "under investigation" because it lacked enough information to decide if the vulnerability is exploitable.
 For each issue, use the stated reason it's under investigation to write ONE specific, answerable question - never a vague "please provide more information." Include 2-6 short suggested answers a user could pick instead of typing. Ground every question in the evidence given; never invent facts about the device or vulnerability.
 Omit any issue you don't have a good, specific question for.`;
+
+export async function gatherQuestionContextForIssue(
+  issueId: string,
+  notificationId: string,
+  priorQnA: { title: string; answer: string | null}[],
+): Promise<QuestionContext | null> {
+  const issue = await prisma.issue.findUnique({
+    where: { id: issueId },
+    include: { vulnerability: true },
+  });
+
+  if(!issue || !issue.deviceGroupMatchingId) return null;
+
+  const matching = await prisma.deviceGroupMatching.findUnique({
+    where: { id: issue.deviceGroupMatchingId },
+    include: {
+      vendor: { select: { canonicalDisplayName: true }},
+      product: { select: { canonicalDisplayName: true}},
+      version: { select: { canonicalDisplayName: true }},
+    },
+  });
+
+  if(!matching) return null;
+
+  const candidateGroups = await prisma.deviceGroup.findMany({
+    where: deviceGroupWhereForMatching(matching),
+    select: { id: true, assets: { select: {id: true}}}
+  });
+
+  const groups = candidateGroups.filter((g) => matchingAppliesToDeviceGroup(matching, g));
+  const assetIds = [...new Set(groups.flatMap((g) => g.assets.map((a)=> a.id)))];
+
+  const notes = await getRelevantNotes({
+    vulnerabilityIds: [issue.vulnerabilityId],
+    deviceGroupMatchingIds: [matching.id],
+    assetIds
+  });
+
+  const priorQnAText = priorQnA.map((q) => renderQnA(q.title, q.answer)).join("\n\n");
+
+  const markdown = renderQuestionPrompt({
+    vulnerabilities:[issue.vulnerability],
+    issueRenders:[{
+      issueId: issue.id,
+      cve: issue.vulnerability.cveId ?? issue.vulnerability.id,
+      matching,
+      assetCount: groups.reduce((n, g) => n + g.assets.length, 0),
+      statusNotes: issue.statusNotes
+    }],
+    notes,
+  }) + "\n\n## Already asked and answered - do not repeat this, ask something more specific\n\n" + priorQnAText;
+
+  return {
+    notificationId,
+    markdown,
+    issues: [{ issueId: issue.id, vulnerabilityId: issue.vulnerability.id}]
+  }
+
+}

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -105,13 +105,13 @@ export async function gatherQuestionContext(
       },
     },
   });
-  console.log("gatherQuestionContext notification ", notification);
+
   if (!notification) return null;
 
   const vulnerabilities = notification.vulnerabilities.map(
     (m) => m.vulnerability,
   );
-  console.log("gatherQuestionContext vulnerabilities ", vulnerabilities);
+
   if (vulnerabilities.length === 0) return null;
 
   const matchingsById = new Map<string, MatchingWithRefs>();
@@ -119,7 +119,7 @@ export async function gatherQuestionContext(
     for (const dgm of v.deviceGroupMatchings) matchingsById.set(dgm.id, dgm);
   }
   const matchings = [...matchingsById.values()];
-  console.log("gatherQuestionContext matchings ", matchings);
+
   const candidateGroups =
     matchings.length > 0
       ? await prisma.deviceGroup.findMany({
@@ -154,11 +154,9 @@ export async function gatherQuestionContext(
     statusNotes: string | null;
   };
   const issueRenders: IssueRender[] = [];
-  console.log("gatherQuestionContext-----------------------------");
+
   for (const v of vulnerabilities) {
-    console.log("gatherQuestionContext v ", v);
     for (const issue of v.issues) {
-      console.log("gatherQuestionContext issue ", issue);
       if (!issue.deviceGroupMatchingId) continue;
       const matching = matchingsById.get(issue.deviceGroupMatchingId);
 
@@ -179,7 +177,7 @@ export async function gatherQuestionContext(
       });
     }
   }
-  console.log("gatherQuestionContext issues ", issues);
+
   if (issues.length === 0) return null;
 
   const assetIds = [
@@ -190,13 +188,13 @@ export async function gatherQuestionContext(
     deviceGroupMatchingIds: matchings.map((m) => m.id),
     assetIds,
   });
-  console.log("gatherQuestionContext notes ", notes);
+
   const markdown = renderQuestionPrompt({
     vulnerabilities,
     issueRenders,
     notes,
   });
-  console.log("gatherQuestionContext markdown ", markdown);
+
   return { notificationId, markdown, issues };
 }
 

--- a/src/features/inbox/agent/question/index.ts
+++ b/src/features/inbox/agent/question/index.ts
@@ -36,12 +36,12 @@ export async function generateQuestionForNotification(
   notificationId: string,
 ): Promise<(QuestionApplySummary & { issues: number }) | null> {
   const context = await gatherQuestionContext(notificationId);
-  console.log("context ", context);
+
   if (!context) return null;
   const result = await draftQuestion(context);
-  console.log("result ", result);
+
   const summary = await applyQuestionWrites(context, result);
-  console.log("summary ", summary);
+
   return { ...summary, issues: context.issues.length };
 }
 

--- a/src/features/inbox/agent/question/index.ts
+++ b/src/features/inbox/agent/question/index.ts
@@ -1,17 +1,17 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
+import prisma from "@/lib/db";
 import {
   gatherQuestionContext,
+  gatherQuestionContextForIssue,
   type QuestionContext,
   SYSTEM_PROMPT,
-  gatherQuestionContextForIssue
 } from "./context";
 import {
   applyQuestionWrites,
   type QuestionApplySummary,
 } from "./process_output";
 import { buildQuestionSchema, type QuestionResult } from "./schema";
-import prisma from "@/lib/db";
 
 const MODEL = "claude-haiku-4-5-20251001";
 
@@ -24,7 +24,6 @@ export async function draftQuestion(
   const model = new ChatAnthropic({
     model: MODEL,
     maxTokens: 4000,
-    thinking: { type: "enabled", budget_tokens: 2000 },
   }).withStructuredOutput(schema);
 
   return model.invoke([
@@ -37,32 +36,31 @@ export async function generateQuestionForNotification(
   notificationId: string,
 ): Promise<(QuestionApplySummary & { issues: number }) | null> {
   const context = await gatherQuestionContext(notificationId);
-
+  console.log("context ", context);
   if (!context) return null;
   const result = await draftQuestion(context);
-
+  console.log("result ", result);
   const summary = await applyQuestionWrites(context, result);
-
+  console.log("summary ", summary);
   return { ...summary, issues: context.issues.length };
-};
+}
 
 export async function generateFollowUpQuestion(
   issueId: string,
 ): Promise<(QuestionApplySummary & { issues: number }) | null> {
   const priorQuestions = await prisma.question.findMany({
-    where:{ issueId },
-    orderBy: { createdAt: "asc" }
+    where: { issueId },
+    orderBy: { createdAt: "asc" },
   });
-  if(priorQuestions.length === 0) return null;
+  if (priorQuestions.length === 0) return null;
   const context = await gatherQuestionContextForIssue(
     issueId,
     priorQuestions[0].notificationId,
     priorQuestions.map((q) => ({ title: q.title, answer: q.answer })),
   );
-  if(!context) return null;
+  if (!context) return null;
 
   const result = await draftQuestion(context);
   const summary = await applyQuestionWrites(context, result);
-  return { ...summary, issues: context.issues.length}
-
+  return { ...summary, issues: context.issues.length };
 }

--- a/src/features/inbox/agent/question/index.ts
+++ b/src/features/inbox/agent/question/index.ts
@@ -4,12 +4,14 @@ import {
   gatherQuestionContext,
   type QuestionContext,
   SYSTEM_PROMPT,
+  gatherQuestionContextForIssue
 } from "./context";
 import {
   applyQuestionWrites,
   type QuestionApplySummary,
 } from "./process_output";
 import { buildQuestionSchema, type QuestionResult } from "./schema";
+import prisma from "@/lib/db";
 
 const MODEL = "claude-haiku-4-5-20251001";
 
@@ -42,4 +44,25 @@ export async function generateQuestionForNotification(
   const summary = await applyQuestionWrites(context, result);
 
   return { ...summary, issues: context.issues.length };
+};
+
+export async function generateFollowUpQuestion(
+  issueId: string,
+): Promise<(QuestionApplySummary & { issues: number }) | null> {
+  const priorQuestions = await prisma.question.findMany({
+    where:{ issueId },
+    orderBy: { createdAt: "asc" }
+  });
+  if(priorQuestions.length === 0) return null;
+  const context = await gatherQuestionContextForIssue(
+    issueId,
+    priorQuestions[0].notificationId,
+    priorQuestions.map((q) => ({ title: q.title, answer: q.answer })),
+  );
+  if(!context) return null;
+
+  const result = await draftQuestion(context);
+  const summary = await applyQuestionWrites(context, result);
+  return { ...summary, issues: context.issues.length}
+
 }

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -461,7 +461,8 @@ function renderAnswerContext(params: {
   return (
     "## Direct answer just received \n\n" +
     `You previously flagged this as under investigation because: ${params.statusNotes} ?? "(no reason recorded)"\n\n` +
-    `You asked: "${params.title} \n\n` +
+    `You asked: "${params.title}" \n\n` +
+    `Why it was asked: ${params.reasonWhy}\n\n`+
     `The user's direct answer: "${params.answer}"`
   );
 }

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -460,9 +460,9 @@ function renderAnswerContext(params: {
 }): string {
   return (
     "## Direct answer just received \n\n" +
-    `You previously flagged this as under investigation because: ${params.statusNotes} ?? "(no reason recorded)"\n\n` +
-    `You asked: "${params.title}" \n\n` +
-    `Why it was asked: ${params.reasonWhy}\n\n`+
+    `You previously flagged this as under investigation because: ${params.statusNotes ?? "(no reason recorded)"}\n\n` +
+    `You asked: "${params.title}"\n\n` +
+    `Why it was asked: ${params.reasonWhy}\n\n` +
     `The user's direct answer: "${params.answer}"`
   );
 }

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -400,15 +400,16 @@ export async function gatherVexContextForIssue(
   for (const g of groups) {
     for (const a of g.assets) assetLabel.set(a.id, a.hostname ?? a.ip ?? a.id);
   }
-  const groupLabel = new Map(
-    groups.map((g) => [g.id, deviceGroupLabel(g)]),
-  );
+  const groupLabel = new Map(groups.map((g) => [g.id, deviceGroupLabel(g)]));
   const matchingLabel = new Map<string, string>();
   matchingLabel.set(matching.id, deviceGroupMatchingLabel(matching));
 
   const cveById = new Map<string, string>();
-  cveById.set(issue.vulnerability.id, issue.vulnerability.cveId ?? issue.vulnerability.id);
- 
+  cveById.set(
+    issue.vulnerability.id,
+    issue.vulnerability.cveId ?? issue.vulnerability.id,
+  );
+
   let markdown = renderVexPrompt({
     sources: [],
     vulnerabilities: [issue.vulnerability],

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -400,17 +400,15 @@ export async function gatherVexContextForIssue(
   for (const g of groups) {
     for (const a of g.assets) assetLabel.set(a.id, a.hostname ?? a.ip ?? a.id);
   }
-  const groupLabel = new Map(groups.map((g) => [g.id, deviceGroupLabel(g)]));
-  const matchingLabel = new Map([
-    [matching.id, deviceGroupMatchingLabel(matching)],
-  ]);
-  const cveById = new Map([
-    [
-      issue.vulnerability.id,
-      issue.vulnerability.cveId ?? issue.vulnerability.id,
-    ],
-  ]);
+  const groupLabel = new Map(
+    groups.map((g) => [g.id, deviceGroupLabel(g)]),
+  );
+  const matchingLabel = new Map<string, string>();
+  matchingLabel.set(matching.id, deviceGroupMatchingLabel(matching));
 
+  const cveById = new Map<string, string>();
+  cveById.set(issue.vulnerability.id, issue.vulnerability.cveId ?? issue.vulnerability.id);
+ 
   let markdown = renderVexPrompt({
     sources: [],
     vulnerabilities: [issue.vulnerability],

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -371,6 +371,9 @@ export async function gatherVexContextForIssue(
     select: {
       id: true,
       cpe: true,
+      vendorId: true,
+      productId: true,
+      versionId: true,
       vendor: { select: { canonicalDisplayName: true } },
       product: { select: { canonicalDisplayName: true } },
       version: { select: { canonicalName: true, canonicalDisplayName: true } },

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -343,6 +343,127 @@ function renderVexPrompt(args: {
   return sections.join("\n\n");
 }
 
+export async function gatherVexContextForIssue(
+  issueId: string,
+  notificationId: string,
+  answeredQuestion?: { title: string; reasonWhy: string; answer: string },
+): Promise<VexContext | null> {
+  const issue = await prisma.issue.findUnique({
+    where: { id: issueId },
+    include: { vulnerability: true },
+  });
+
+  if (!issue || !issue.deviceGroupMatchingId) return null;
+
+  const matching = await prisma.deviceGroupMatching.findUnique({
+    where: { id: issue.deviceGroupMatchingId },
+    include: {
+      vendor: { select: { canonicalDisplayName: true } },
+      product: { select: { canonicalDisplayName: true } },
+      version: { select: { canonicalDisplayName: true } },
+    },
+  });
+
+  if (!matching) return null;
+
+  const candiateGroups = await prisma.deviceGroup.findMany({
+    where: deviceGroupWhereForMatching(matching),
+    select: {
+      id: true,
+      cpe: true,
+      vendor: { select: { canonicalDisplayName: true } },
+      product: { select: { canonicalDisplayName: true } },
+      version: { select: { canonicalName: true, canonicalDisplayName: true } },
+      assets: { select: { id: true, hostname: true, ip: true } },
+    },
+  });
+
+  const groups = candiateGroups.filter((g) =>
+    matchingAppliesToDeviceGroup(matching, g),
+  );
+  const assetIds = [
+    ...new Set(groups.flatMap((g) => g.assets.map((a) => a.id))),
+  ];
+
+  const remediations = await prisma.remediation.findMany({
+    where: { vulnerabilityId: issue.vulnerabilityId },
+  });
+
+  const notes = await getRelevantNotes({
+    vulnerabilityIds: [issue.vulnerabilityId],
+    remediationIds: remediations.map((r) => r.id),
+    deviceGroupMatchingIds: [matching.id],
+    assetIds,
+  });
+
+  const assetLabel = new Map<string, string>();
+  for (const g of groups) {
+    for (const a of g.assets) assetLabel.set(a.id, a.hostname ?? a.ip ?? a.id);
+  }
+  const groupLabel = new Map(groups.map((g) => [g.id, deviceGroupLabel(g)]));
+  const matchingLabel = new Map([
+    [matching.id, deviceGroupMatchingLabel(matching)],
+  ]);
+  const cveById = new Map([
+    [
+      issue.vulnerability.id,
+      issue.vulnerability.cveId ?? issue.vulnerability.id,
+    ],
+  ]);
+
+  let markdown = renderVexPrompt({
+    sources: [],
+    vulnerabilities: [issue.vulnerability],
+    remediations,
+    candidateGroups: groups,
+    issueRenders: [
+      {
+        issueId: issue.id,
+        cve: issue.vulnerability.cveId ?? issue.vulnerability.id,
+        matching,
+        groups,
+        assetIds,
+        status: issue.status,
+      },
+    ],
+    notes,
+    labels: { assetLabel, groupLabel, matchingLabel, cveById },
+  });
+
+  if (answeredQuestion) {
+    markdown +=
+      "\n\n" +
+      renderAnswerContext({
+        statusNotes: issue.statusNotes,
+        title: answeredQuestion.title,
+        reasonWhy: answeredQuestion.reasonWhy,
+        answer: answeredQuestion.answer,
+      });
+  }
+
+  return {
+    notificationId,
+    markdown,
+    issues: [
+      { issueId: issue.id, vulnerabilityId: issue.vulnerabilityId, assetIds },
+    ],
+  };
+}
+
+function renderAnswerContext(params: {
+  statusNotes: string | null;
+  title: string;
+  reasonWhy: string;
+  answer: string;
+}): string {
+  return (
+    "## Direct answer just received \n\n" +
+    `You previously flagged this as under investigation because: ${params.statusNotes} ?? "(no reason recorded)"\n\n` +
+    `You asked: "${params.title} \n\n` +
+    `The user's direct answer: "${params.answer}"`
+  );
+}
+
 // ─── System prompt ───────────────────────────────────────────────────────────
 
 export const VEX_TOOL_NAME = "update_and_create_issues";

--- a/src/features/questions/hooks/use-questions.ts
+++ b/src/features/questions/hooks/use-questions.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useTRPC } from "@/trpc/client";
+
+export function useSuspenseQuestionsByNotificationId(notificationId: string) {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.questions.getManyByNotificationId.queryOptions({
+      notificationId,
+    }),
+  );
+}
+
+export function useSuspenseQuestionsByIssueId(issueId: string) {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.questions.getManyByIssueId.queryOptions({ issueId }),
+  );
+}
+
+export function useRespondToQuestion() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.questions.respond.mutationOptions({
+      onSuccess: (_data, variables) => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.questions.getManyByNotificationId.queryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.questions.getManyByIssueId.queryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.issues.getOne.queryKey(),
+        });
+        if (variables.action === "answer") toast.success("Answer submitted");
+      },
+      onError: (error) =>
+        toast.error(`Failed to respond to question: ${error.message}`),
+    }),
+  );
+}

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -1,0 +1,109 @@
+import "server-only";
+import { z } from "zod";
+import { inngest } from "@/inngest/client";
+import prisma from "@/lib/db";
+import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
+import { renderQnA } from "@/lib/markdown/note";
+
+export const questionsRouter = createTRPCRouter({
+  getManyByNotificationId: protectedProcedure
+    .input(z.object({ notificationId: z.string() }))
+    .query(({ input }) =>
+      prisma.question.findMany({
+        where: { notificationId: input.notificationId },
+        orderBy: { createdAt: "asc" },
+        include: {
+          issue: {
+            include: {
+              vulnerability: true,
+              deviceGroupMatching: true,
+              asset: true,
+            },
+          },
+        },
+      }),
+    ),
+  getManyByIssueId: protectedProcedure
+    .input(z.object({ issueId: z.string() }))
+    .query(({ input }) =>
+      prisma.question.findMany({
+        where: { issueId: input.issueId },
+        orderBy: { createdAt: "asc" },
+      }),
+    ),
+
+  respond: protectedProcedure
+    .input(
+      z.object({
+        questionId: z.string(),
+        action: z.enum(["answer", "dismiss", "unsure"]),
+        answer: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const question = await prisma.question.findUniqueOrThrow({
+        where: { id: input.questionId },
+        include: { issue: true },
+      });
+      if (question.status !== "PENDING") {
+        throw new Error(`Question is already ${question.status}`);
+      }
+      if (input.action === "answer" && !input.answer) {
+        throw new Error("answer is required");
+      }
+      const status: "ANSWERED" | "DISMISSED" | "UNSURE" =
+        input.action === "answer"
+          ? "ANSWERED"
+          : input.action === "dismiss"
+            ? "DISMISSED"
+            : "UNSURE";
+      const hasAnswerText =
+        input.action !== "dismiss" && !!input.answer?.trim();
+      if (!hasAnswerText) {
+        const updated = await prisma.question.updateMany({
+          where: { id: input.questionId },
+          data: {
+            status,
+            answeredByUserId: ctx.auth.user.id,
+            answeredAt: new Date(),
+          },
+        });
+        if (updated.count === 0) {
+          throw new Error(`Question is already resolved`);
+        }
+        return { status };
+      }
+
+      const targetModel = "DEVICE_GROUP_MATCHING" as const;
+      const instanceId = question.issue.deviceGroupMatchingId!;
+
+      await prisma.$transaction(async (tx) => {
+        const note = await tx.note.create({
+          data: {
+            text: renderQnA(question.title, input.answer!),
+            status: "SCOPED",
+            targetModel,
+            instanceId,
+            userId: ctx.auth.user.id,
+          },
+        });
+        await tx.question.update({
+          where: { id: input.questionId },
+          data: {
+            status,
+            answer: input.answer,
+            answeredByUserId: ctx.auth.user.id,
+            answeredAt: new Date(),
+            resultingNoteId: note.id,
+          },
+        });
+      });
+
+      await inngest.send({
+        name: "issue/question.answered",
+        data: { issueId: question.issueId, questionId: input.questionId },
+      });
+
+      return { status };
+    }),
+});

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -61,7 +61,7 @@ export const questionsRouter = createTRPCRouter({
         input.action !== "dismiss" && !!input.answer?.trim();
       if (!hasAnswerText) {
         const updated = await prisma.question.updateMany({
-          where: { id: input.questionId },
+          where: { id: input.questionId, status: "PENDING" },
           data: {
             status,
             answeredByUserId: ctx.auth.user.id,
@@ -88,7 +88,7 @@ export const questionsRouter = createTRPCRouter({
           },
         });
         const updated = await tx.question.updateMany({
-          where: { id: input.questionId },
+          where: { id: input.questionId, status: "PENDING" },
           data: {
             status,
             answer: input.answer,

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -2,8 +2,8 @@ import "server-only";
 import { z } from "zod";
 import { inngest } from "@/inngest/client";
 import prisma from "@/lib/db";
-import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
 import { renderQnA } from "@/lib/markdown/note";
+import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
 
 export const questionsRouter = createTRPCRouter({
   getManyByNotificationId: protectedProcedure
@@ -97,7 +97,7 @@ export const questionsRouter = createTRPCRouter({
             resultingNoteId: note.id,
           },
         });
-         if (updated.count === 0) {
+        if (updated.count === 0) {
           throw new Error(`Question is already resolved`);
         }
       });

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { inngest } from "@/inngest/client";
 import prisma from "@/lib/db";
 import { renderQnA } from "@/lib/markdown/note";
-import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
+import { createTRPCRouter,  protectedProcedure } from "@/trpc/init";
 
 export const questionsRouter = createTRPCRouter({
   getManyByNotificationId: protectedProcedure

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { inngest } from "@/inngest/client";
 import prisma from "@/lib/db";
 import { renderQnA } from "@/lib/markdown/note";
-import { createTRPCRouter,  protectedProcedure } from "@/trpc/init";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
 
 export const questionsRouter = createTRPCRouter({
   getManyByNotificationId: protectedProcedure

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -87,7 +87,7 @@ export const questionsRouter = createTRPCRouter({
             userId: ctx.auth.user.id,
           },
         });
-        await tx.question.update({
+        const updated = await tx.question.updateMany({
           where: { id: input.questionId },
           data: {
             status,
@@ -97,6 +97,9 @@ export const questionsRouter = createTRPCRouter({
             resultingNoteId: note.id,
           },
         });
+         if (updated.count === 0) {
+          throw new Error(`Question is already resolved`);
+        }
       });
 
       await inngest.send({

--- a/src/features/questions/types.ts
+++ b/src/features/questions/types.ts
@@ -1,0 +1,9 @@
+import type { Prisma } from "@/generated/prisma";
+
+export type QuestionWithIssue = Prisma.QuestionGetPayload<{
+  include: {
+    issue: {
+      include: { vulnerability: true; deviceGroupMatching: true; asset: true };
+    };
+  };
+}>;

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -397,50 +397,50 @@ export const processInboxEmail = inngest.createFunction(
       return sortNotificationVulnerabilities(notificationId);
     });
 
-    // 11. Generte questions for any Issue VEX just left UNDER_INVESTIGATION
-    const questionSummary = await step.run("generate-questions", async () => {
-      if (!notificationId || !vexSummary)
-        return { questionSkipped: true as const };
-      if ("vexSkipped" in vexSummary && vexSummary.vexSkipped)
-        return { questionSkipped: true as const };
-      return generateQuestionForNotification(notificationId);
-    });
-
-    // 12. Triage: assign priority, reason, and hospital impact
-    if (notificationId) {
-      await step.run("triage-notification", async () => {
+    // run question and mitigation steps in parallel
+    const [ questionSummary, , mitigationSummary] = await Promise.all([
+      // 11. Generte questions for any Issue VEX just left UNDER_INVESTIGATION
+      step.run("generate-questions", async () => {
+        if (!notificationId || !vexSummary)
+          return { questionSkipped: true as const };
+        if ("vexSkipped" in vexSummary && vexSummary.vexSkipped)
+          return { questionSkipped: true as const };
+        return generateQuestionForNotification(notificationId);
+      }), 
+      // 11. Triage: assign priority, reason, and hospital impact
+      step.run("triage-notification", async () => {
+        if(!notificationId) return { skipped: true as const };
+        
         const result = await triageNotification(
-          sourceId,
-          notificationId,
-          inlinedPdfs ?? undefined,
-        );
-        await prisma.notification.update({
-          where: { id: notificationId },
-          data: {
-            priority: result.priority,
-            priorityReasonWhy: result.priorityReasonWhy,
-            hospitalImpact: result.hospitalImpact,
-          },
-        });
-        return {
-          priority: result.priority,
-          priorityReasonWhy: result.priorityReasonWhy,
-        };
-      });
-    }
-
-    // 12. Mitigation plans: if the notification has linked vulnerabilities,
-    // propose ordered remediation plans and materialize each as a plan plus its
-    // draft work orders (isDraft=true; accepting a plan promotes them).
-    const mitigationSummary = notificationId
-      ? await step.run("create-mitigation-plans", () =>
-          persistMitigationPlans(
             sourceId,
             notificationId,
             inlinedPdfs ?? undefined,
-          ),
-        )
-      : null;
+          );
+          await prisma.notification.update({
+            where: { id: notificationId },
+            data: {
+              priority: result.priority,
+              priorityReasonWhy: result.priorityReasonWhy,
+              hospitalImpact: result.hospitalImpact,
+            },
+          });
+          return {
+            priority: result.priority,
+            priorityReasonWhy: result.priorityReasonWhy,
+          };
+      }),
+      // 11. Mitigation plans: if the notification has linked vulnerabilities,
+      // propose ordered remediation plans and materialize each as a plan plus its
+      // draft work orders (isDraft=true; accepting a plan promotes them).
+      step.run("create-mitigation-plans", async () => {
+        if(!notificationId) return null;
+        return persistMitigationPlans(
+            sourceId,
+            notificationId,
+            inlinedPdfs ?? undefined,
+          )
+      })
+    ]);
 
     return {
       sourceId,

--- a/src/inngest/functions/process-inbox-email.ts
+++ b/src/inngest/functions/process-inbox-email.ts
@@ -398,7 +398,7 @@ export const processInboxEmail = inngest.createFunction(
     });
 
     // run question and mitigation steps in parallel
-    const [ questionSummary, , mitigationSummary] = await Promise.all([
+    const [questionSummary, , mitigationSummary] = await Promise.all([
       // 11. Generte questions for any Issue VEX just left UNDER_INVESTIGATION
       step.run("generate-questions", async () => {
         if (!notificationId || !vexSummary)
@@ -406,40 +406,40 @@ export const processInboxEmail = inngest.createFunction(
         if ("vexSkipped" in vexSummary && vexSummary.vexSkipped)
           return { questionSkipped: true as const };
         return generateQuestionForNotification(notificationId);
-      }), 
+      }),
       // 11. Triage: assign priority, reason, and hospital impact
       step.run("triage-notification", async () => {
-        if(!notificationId) return { skipped: true as const };
-        
+        if (!notificationId) return { skipped: true as const };
+
         const result = await triageNotification(
-            sourceId,
-            notificationId,
-            inlinedPdfs ?? undefined,
-          );
-          await prisma.notification.update({
-            where: { id: notificationId },
-            data: {
-              priority: result.priority,
-              priorityReasonWhy: result.priorityReasonWhy,
-              hospitalImpact: result.hospitalImpact,
-            },
-          });
-          return {
+          sourceId,
+          notificationId,
+          inlinedPdfs ?? undefined,
+        );
+        await prisma.notification.update({
+          where: { id: notificationId },
+          data: {
             priority: result.priority,
             priorityReasonWhy: result.priorityReasonWhy,
-          };
+            hospitalImpact: result.hospitalImpact,
+          },
+        });
+        return {
+          priority: result.priority,
+          priorityReasonWhy: result.priorityReasonWhy,
+        };
       }),
       // 11. Mitigation plans: if the notification has linked vulnerabilities,
       // propose ordered remediation plans and materialize each as a plan plus its
       // draft work orders (isDraft=true; accepting a plan promotes them).
       step.run("create-mitigation-plans", async () => {
-        if(!notificationId) return null;
+        if (!notificationId) return null;
         return persistMitigationPlans(
-            sourceId,
-            notificationId,
-            inlinedPdfs ?? undefined,
-          )
-      })
+          sourceId,
+          notificationId,
+          inlinedPdfs ?? undefined,
+        );
+      }),
     ]);
 
     return {

--- a/src/inngest/functions/reevaluate-issue-on-answer.ts
+++ b/src/inngest/functions/reevaluate-issue-on-answer.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import prisma from "@/lib/db";
 import { generateFollowUpQuestion } from "@/features/inbox/agent/question";
-import {
-  gatherVexContextForIssue,
-} from "@/features/inbox/agent/vex/context";
+import { gatherVexContextForIssue } from "@/features/inbox/agent/vex/context";
 import { applyVexDeterminations } from "@/features/inbox/agent/vex/process_output";
 import { sortVulnerabilities } from "@/features/inbox/agent/vex";
 import { triageNotification } from "@/features/inbox/agent/triage";
@@ -23,11 +21,15 @@ export const reevaluateIssueOnAnswer = inngest.createFunction(
     );
 
     await step.run("resort", async () => {
-      const context = await gatherVexContextForIssue(issueId, question.notificationId, {
-        title: question.title,
-        reasonWhy: question.reasonWhy,
-        answer: question.answer!,
-      });
+      const context = await gatherVexContextForIssue(
+        issueId,
+        question.notificationId,
+        {
+          title: question.title,
+          reasonWhy: question.reasonWhy,
+          answer: question.answer!,
+        },
+      );
       if (!context) return;
       const result = await sortVulnerabilities(context);
       await applyVexDeterminations(context, result);

--- a/src/inngest/functions/reevaluate-issue-on-answer.ts
+++ b/src/inngest/functions/reevaluate-issue-on-answer.ts
@@ -1,0 +1,69 @@
+import "server-only";
+import prisma from "@/lib/db";
+import { generateFollowUpQuestion } from "@/features/inbox/agent/question";
+import {
+  gatherVexContextForIssue,
+} from "@/features/inbox/agent/vex/context";
+import { applyVexDeterminations } from "@/features/inbox/agent/vex/process_output";
+import { sortVulnerabilities } from "@/features/inbox/agent/vex";
+import { triageNotification } from "@/features/inbox/agent/triage";
+import { inngest } from "../client";
+
+const MAX_FOLLOWUP_ROUNDS = 2;
+
+export const reevaluateIssueOnAnswer = inngest.createFunction(
+  { id: "reevaluate-issue-on-answer" },
+  { event: "issue/question.answered" },
+  async ({ event, step }) => {
+    const { issueId, questionId } = event.data;
+    const question = await step.run("load-question", () =>
+      prisma.question.findUniqueOrThrow({
+        where: { id: questionId },
+      }),
+    );
+
+    await step.run("resort", async () => {
+      const context = await gatherVexContextForIssue(issueId, question.notificationId, {
+        title: question.title,
+        reasonWhy: question.reasonWhy,
+        answer: question.answer!,
+      });
+      if (!context) return;
+      const result = await sortVulnerabilities(context);
+      await applyVexDeterminations(context, result);
+    });
+
+    const updatedIssue = await step.run("read-updated-issue", () =>
+      prisma.issue.findUniqueOrThrow({ where: { id: issueId } }),
+    );
+
+    if (updatedIssue.status !== "UNDER_INVESTIGATION") {
+      await step.run("retriage-notification", async () => {
+        const source = await prisma.notificationSource.findFirst({
+          where: { notificationId: question.notificationId },
+          orderBy: { receivedAt: "desc" },
+        });
+        if (!source) return;
+        const result = await triageNotification(
+          source.id,
+          question.notificationId,
+        );
+        await prisma.notification.update({
+          where: { id: question.notificationId },
+          data: {
+            priority: result.priority,
+            priorityReasonWhy: result.priorityReasonWhy,
+            hospitalImpact: result.hospitalImpact,
+          },
+        });
+      });
+    } else {
+      const roundCount = await prisma.question.count({ where: { issueId } });
+      if (roundCount < MAX_FOLLOWUP_ROUNDS) {
+        await step.run("generate-follow-up", () =>
+          generateFollowUpQuestion(issueId),
+        );
+      }
+    }
+  },
+);

--- a/src/inngest/functions/reevaluate-issue-on-answer.ts
+++ b/src/inngest/functions/reevaluate-issue-on-answer.ts
@@ -1,10 +1,10 @@
 import "server-only";
-import prisma from "@/lib/db";
 import { generateFollowUpQuestion } from "@/features/inbox/agent/question";
+import { triageNotification } from "@/features/inbox/agent/triage";
+import { sortVulnerabilities } from "@/features/inbox/agent/vex";
 import { gatherVexContextForIssue } from "@/features/inbox/agent/vex/context";
 import { applyVexDeterminations } from "@/features/inbox/agent/vex/process_output";
-import { sortVulnerabilities } from "@/features/inbox/agent/vex";
-import { triageNotification } from "@/features/inbox/agent/triage";
+import prisma from "@/lib/db";
 import { inngest } from "../client";
 
 const MAX_FOLLOWUP_ROUNDS = 2;

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -10,6 +10,7 @@ import { integrationsRouter } from "@/features/integrations/server/routers";
 import { issuesRouter } from "@/features/issues/server/routers";
 import { mitigationRouter } from "@/features/mitigation/server/routers";
 import { networkRouter } from "@/features/network/server/router";
+import { questionsRouter } from "@/features/questions/server/routers";
 import { remediationsRouter } from "@/features/remediations/server/routers";
 import { tagColorsRouter } from "@/features/tag-colors/server/routers";
 import { trackingRouter } from "@/features/tracking/server/routers";
@@ -17,7 +18,6 @@ import { userRouter } from "@/features/user/server/routers";
 import { vulnerabilitiesRouter } from "@/features/vulnerabilities/server/routers";
 import { webhooksRouter } from "@/features/webhooks/server/routers";
 import { workflowsRouter } from "@/features/workflows/server/routers";
-import { questionsRouter } from "@/features/questions/server/routers";
 import { createTRPCRouter } from "../init";
 
 export const appRouter = createTRPCRouter({


### PR DESCRIPTION
ticket : https://northeastern-patch.atlassian.net/browse/VW-388
## Summary
- new API to handle user actions with Question
- add handling for creating note, generate followup questions, updated prompt

How to verify locally without UI
- I created a temp test script and hard code to notification with "syngo.plaza"
- confirm question was generated
- updated answer(without providing actual info) and status from local DB directly
- confirm Inngest re-run and it generates a follow up question

<img width="1591" height="763" alt="inngest_question" src="https://github.com/user-attachments/assets/5abf90a5-ea28-4bbd-a934-f611e00eb17e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reviewing, answering, dismissing, or marking issue questions as unsure.
  * Added question history views by notification and issue.
  * Added automatic follow-up questions using previous answers to avoid repetition.
  * Added automatic issue re-evaluation after an answer, including updated prioritization and triage.
  * Notification processing now performs question generation, triage, and mitigation planning concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->