### PR TITLE
[VW-0] Add missing postgres docker compose command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run mprocs:
 mprocs
 ```
 
-Alternatively, use docker for everything (app included): `docker compose -f compose.dev.yml up`
+Alternatively, use docker: `docker compose -f compose.dev.yml up`
 * Note: I had to increase my Docker Desktop memory limit to get ts to compile
 
 ## Database Seeding

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Check out the documentation under the `docs` folder and also `CLAUDE.md`.
 
 Follow the guide in `.env.example` to create a `.env` file.
 
+Start Postgres (needed before running migrations/seeding, or `mprocs`):
+
+```
+docker compose -f compose.dev.yml up -d postgres
+```
+
 Install `mprocs` to run the multiple services:
 
 ```
@@ -33,7 +39,7 @@ Run mprocs:
 mprocs
 ```
 
-Alternatively, use docker: `docker compose -f compose.dev.yml up`
+Alternatively, use docker for everything (app included): `docker compose -f compose.dev.yml up`
 * Note: I had to increase my Docker Desktop memory limit to get ts to compile
 
 ## Database Seeding


### PR DESCRIPTION
README's Getting Started section didn't document `docker compose -f compose.dev.yml up -d postgres` for starting just the DB before running migrations/seeding/mprocs. Adds it as a step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clear setup step for starting Postgres before running migrations, seeding, or development services.
  * Included the command needed to start Postgres in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->