### PR TITLE
[VW-396] Seed script for testing the inbox agents against a real advisory

### DIFF
--- a/docs/email-pipeline-setup.md
+++ b/docs/email-pipeline-setup.md
@@ -100,23 +100,17 @@ The pipeline makes several Anthropic calls (relevance triage, classification, en
 
 ## 7. Prepare the hospital environment (optional)
 
-To exercise the VEX, triage and mitigation agents, the platform needs assets, device groups and vulnerabilities the incoming advisory can actually link to. `scripts/seed-advisory-environment.ts` sets that up for two real Siemens Healthineers advisories:
-
 ```bash
 npx tsx scripts/seed-advisory-environment.ts
 ```
 
-It **deletes every notification** and both advisory vulnerabilities, then rebuilds the substrate: device groups, assets, remediations, and notes that give the VEX agent grounds to mark some assets `NOT_AFFECTED` while their siblings stay `AFFECTED`. It never creates a notification — that has to come from the pipeline, which is the point.
-
-The script prints a summary and exits non-zero if the environment came out unusable. It requires `npm run db:seed` to have run first (it needs `user@example.com`) and refuses to run against a non-local `DATABASE_URL`.
-
-Don't run it alongside `scripts/seed-notifications.ts` — that script creates notifications for the same two advisories, which is exactly the state this one clears.
+Seeds the assets, device groups and vulnerabilities for two Siemens Healthineers advisories so the VEX, triage and mitigation agents have something real to link to. **Wipes all notifications** — it's local-only and creates no notification itself.
 
 ## 8. Send a test email
 
 From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
 
-If you seeded the environment in step 7, send one of the two advisories it covers — Siemens Healthineers **SSA-016040** (syngo.plaza VB30E, CVE-2024-52334) or the **syngo deserialization** advisory (CVE-2022-29875). Anything else will still create a notification, but it will have nothing to link to and the VEX step will be skipped.
+If you ran step 7, send one of the advisories it covers — Siemens **SSA-016040** (CVE-2024-52334) or the **syngo deserialization** advisory (CVE-2022-29875) — otherwise there is nothing to link to and the VEX step is skipped.
 
 Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
 

--- a/docs/email-pipeline-setup.md
+++ b/docs/email-pipeline-setup.md
@@ -98,13 +98,29 @@ curl -s -o /dev/null -w "%{http_code}\n" -X POST \
 
 The pipeline makes several Anthropic calls (relevance triage, classification, entity extraction, hospital-impact triage), so `ANTHROPIC_API_KEY` must be set in `.env` or the run fails partway through.
 
-## 7. Send a test email
+## 7. Prepare the hospital environment (optional)
+
+To exercise the VEX, triage and mitigation agents, the platform needs assets, device groups and vulnerabilities the incoming advisory can actually link to. `scripts/seed-advisory-environment.ts` sets that up for two real Siemens Healthineers advisories:
+
+```bash
+npx tsx scripts/seed-advisory-environment.ts
+```
+
+It **deletes every notification** and both advisory vulnerabilities, then rebuilds the substrate: device groups, assets, remediations, and notes that give the VEX agent grounds to mark some assets `NOT_AFFECTED` while their siblings stay `AFFECTED`. It never creates a notification — that has to come from the pipeline, which is the point.
+
+The script prints a summary and exits non-zero if the environment came out unusable. It requires `npm run db:seed` to have run first (it needs `user@example.com`) and refuses to run against a non-local `DATABASE_URL`.
+
+Don't run it alongside `scripts/seed-notifications.ts` — that script creates notifications for the same two advisories, which is exactly the state this one clears.
+
+## 8. Send a test email
 
 From your **personal** account, email your `@…resend.app` address. Attach a PDF if you want to exercise attachment handling.
 
+If you seeded the environment in step 7, send one of the two advisories it covers — Siemens Healthineers **SSA-016040** (syngo.plaza VB30E, CVE-2024-52334) or the **syngo deserialization** advisory (CVE-2022-29875). Anything else will still create a notification, but it will have nothing to link to and the VEX step will be skipped.
+
 Write it like a genuine security advisory. The first agent in the chain decides whether the email is relevant at all, and drops marketing, newsletters and meeting invites as `not_relevant` before anything else runs — a "test test test" email will be correctly ignored.
 
-## 8. Watch it run
+## 9. Watch it run
 
 Resend POSTs to `/api/email`, which enqueues an Inngest event.
 
@@ -126,4 +142,5 @@ Note the webhook payload is **metadata only** — no body, no attachment bytes. 
 | Webhook never arrives | Tunnel died, so its URL changed | Restart it, update the webhook URL |
 | Gmail bounces with "Message blocked" | Workspace blocks `*.resend.app` | Send from a personal account (step 1) |
 | Run returns `{skipped: true, reason: "duplicate"}` | That email was already processed — `externalId` is unique | Send a new email |
-| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory (step 7) |
+| Run returns `{skipped: true}` | Triage judged the email `not_relevant` | Write a realistic advisory (step 8) |
+| `sort-vulnerabilities` returns `{vexSkipped: true}` | The notification linked no vulnerability, so there is nothing to sort | Seed the environment and send a matching advisory (step 7) |

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -1,3 +1,9 @@
+import {
+  type AssetStatus,
+  ScopeTargetModel,
+  Severity,
+  VersionStatus,
+} from "@/generated/prisma";
 import prisma from "../src/lib/db";
 
 const SEED_USER_EMAIL = "user@example.com";
@@ -5,6 +11,129 @@ const SEED_USER_EMAIL = "user@example.com";
 const SYNGO_PLAZA_CVE = "CVE-2024-52334";
 const DESERIALIZATION_CVE = "CVE-2022-29875";
 const ADVISORY_CVES = [SYNGO_PLAZA_CVE, DESERIALIZATION_CVE];
+
+const VENDOR = "Siemens Healthineers";
+
+type AssetSpec = {
+  ip: string;
+  hostname: string;
+  serialNumber: string;
+  role: string;
+  networkSegment: string;
+  location: { facility: string; building: string; floor: string; room: string };
+};
+
+// Duplicated from scripts/seed-notifications.ts rather than imported: that module
+// calls main() at import time, so importing anything from it would run the other seed.
+function upsertVendor(name: string) {
+  const canonicalName = name.trim().toLowerCase();
+  return prisma.vendor.upsert({
+    where: { canonicalName },
+    update: {},
+    create: { canonicalName, canonicalDisplayName: name, hasCpe: true },
+  });
+}
+
+function upsertProduct(name: string) {
+  const canonicalName = name.trim().toLowerCase();
+  return prisma.product.upsert({
+    where: { canonicalName },
+    update: {},
+    create: { canonicalName, canonicalDisplayName: name, hasCpe: true },
+  });
+}
+
+function upsertVersion(name: string) {
+  const canonicalName = name.trim().toLowerCase();
+  return prisma.version.upsert({
+    where: { canonicalName },
+    update: {},
+    create: { canonicalName, canonicalDisplayName: name, hasCpe: true },
+  });
+}
+
+async function upsertMatching(spec: {
+  product: string;
+  version?: string;
+  versionRange?: string;
+}) {
+  const vendor = await upsertVendor(VENDOR);
+  const product = await upsertProduct(spec.product);
+  const version = spec.version ? await upsertVersion(spec.version) : null;
+
+  const identity = {
+    vendorId: vendor.id,
+    productId: product.id,
+    versionId: version?.id ?? null,
+    versionRange: spec.versionRange ?? null,
+  };
+
+  return (
+    (await prisma.deviceGroupMatching.findFirst({ where: identity })) ??
+    (await prisma.deviceGroupMatching.create({ data: identity }))
+  );
+}
+
+async function upsertDeviceGroup(
+  product: string,
+  version: string | null,
+  versionStatus: VersionStatus = version
+    ? VersionStatus.KNOWN
+    : VersionStatus.UNKNOWN,
+) {
+  const vendor = await upsertVendor(VENDOR);
+  const productRec = await upsertProduct(product);
+  const versionRec = version ? await upsertVersion(version) : null;
+
+  const identity = {
+    vendorId: vendor.id,
+    productId: productRec.id,
+    versionId: versionRec?.id ?? null,
+    versionStatus,
+  };
+
+  return (
+    (await prisma.deviceGroup.findFirst({ where: identity })) ??
+    (await prisma.deviceGroup.create({ data: identity }))
+  );
+}
+
+async function upsertAsset(
+  spec: AssetSpec,
+  deviceGroupId: string,
+  userId: string,
+) {
+  const existing = await prisma.asset.findFirst({
+    where: { serialNumber: spec.serialNumber },
+  });
+  if (existing) return existing;
+
+  return prisma.asset.create({
+    data: {
+      ...spec,
+      upstreamApi: "https://example.com/placeholder",
+      status: "Active" as AssetStatus,
+      deviceGroupId,
+      userId,
+    },
+  });
+}
+
+async function upsertAssetNote(userId: string, assetId: string, text: string) {
+  const existing = await prisma.note.findFirst({
+    where: { targetModel: ScopeTargetModel.ASSET, instanceId: assetId },
+  });
+  if (existing) return existing;
+
+  return prisma.note.create({
+    data: {
+      userId,
+      text,
+      targetModel: ScopeTargetModel.ASSET,
+      instanceId: assetId,
+    },
+  });
+}
 
 function assertLocalDatabase() {
   const raw = process.env.DATABASE_URL;
@@ -39,6 +168,124 @@ async function resetInboxEnvironment() {
   console.log(
     `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${vulnerabilities.count} vulnerability(ies)`,
   );
+}
+
+const SYNGO_PLAZA_PRODUCT = "syngo.plaza";
+const SYNGO_PLAZA_VERSION = "VB30E";
+
+const SYNGO_PLAZA_ASSETS: AssetSpec[] = [
+  {
+    ip: "10.50.0.11",
+    hostname: "pacs-syngo-01",
+    serialNumber: "SYNGO-PLZ-VB30E-001",
+    role: "PACS Workstation",
+    networkSegment: "RADIOLOGY-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "2",
+      room: "Reading Room A",
+    },
+  },
+  {
+    ip: "10.50.0.12",
+    hostname: "pacs-syngo-02",
+    serialNumber: "SYNGO-PLZ-VB30E-002",
+    role: "PACS Workstation",
+    networkSegment: "RADIOLOGY-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "2",
+      room: "Reading Room B",
+    },
+  },
+  {
+    ip: "10.50.0.13",
+    hostname: "pacs-syngo-03",
+    serialNumber: "SYNGO-PLZ-VB30E-003",
+    role: "PACS Workstation",
+    networkSegment: "RADIOLOGY-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "2",
+      room: "Mammography Reading",
+    },
+  },
+];
+
+const SYNGO_PLAZA_EXCEPTION_NOTE =
+  "pacs-syngo-03 was updated to VB30E_HF07 during the 2026-02 maintenance window by the Siemens field engineer (service ticket CS-88214). The CMDB record still reads VB30E because the inventory sync has not re-scanned this host; the installed build on disk is VB30E_HF07.";
+
+async function seedSyngoPlazaEnvironment(userId: string) {
+  console.log("\n🌱 syngo.plaza VB30E environment (SSA-016040)...");
+
+  const matching = await upsertMatching({
+    product: SYNGO_PLAZA_PRODUCT,
+    version: SYNGO_PLAZA_VERSION,
+  });
+
+  const deviceGroup = await upsertDeviceGroup(
+    SYNGO_PLAZA_PRODUCT,
+    SYNGO_PLAZA_VERSION,
+  );
+
+  const assets = [];
+  for (const spec of SYNGO_PLAZA_ASSETS) {
+    assets.push(await upsertAsset(spec, deviceGroup.id, userId));
+  }
+
+  const vulnerability = await prisma.vulnerability.create({
+    data: {
+      cveId: SYNGO_PLAZA_CVE,
+      severity: Severity.Medium,
+      cvssScore: 5.3,
+      cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      description:
+        "syngo.plaza VB30E contains an insecure password encryption vulnerability that could allow an attacker to extract original passwords and might gain unauthorized access.",
+      narrative:
+        "The affected application does not encrypt passwords properly. An attacker who can read the stored credential material can recover the original passwords and use them to authenticate as a legitimate user.",
+      impact:
+        "Unauthorized access to the syngo.plaza PACS system used to display, process, and report on diagnostic images, including mammographic images.",
+      userId,
+      sarif: {
+        version: "2.1.0",
+        runs: [
+          {
+            tool: { driver: { name: "Siemens Healthineers PSIRT" } },
+            results: [
+              {
+                ruleId: SYNGO_PLAZA_CVE,
+                level: "warning",
+                message: {
+                  text: "Insecure password encryption in syngo.plaza VB30E (SSA-016040)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      // Inline connect is required: the vulnerabilityExtension opens one baseline
+      // Issue per matching linked at create time. Linking later creates none.
+      deviceGroupMatchings: { connect: { id: matching.id } },
+    },
+  });
+
+  await prisma.remediation.create({
+    data: {
+      description: "Update to VB30E_HF07 or later version",
+      narrative:
+        "Siemens Healthineers has released hot fix HF07 for syngo.plaza VB30E. Apply the hot fix during the next maintenance window to remediate the insecure password encryption.",
+      vulnerabilityId: vulnerability.id,
+      userId,
+      deviceGroupMatchings: { connect: { id: matching.id } },
+    },
+  });
+
+  await upsertAssetNote(userId, assets[2].id, SYNGO_PLAZA_EXCEPTION_NOTE);
+
+  console.log(`  ✅ ${assets.length} assets, 1 matching, 1 vulnerability`);
 }
 
 async function printEnvironmentSummary() {
@@ -101,8 +348,9 @@ async function main() {
   console.log("🚀 Preparing advisory test environment\n");
   assertLocalDatabase();
 
-  await getSeedUser();
+  const user = await getSeedUser();
   await resetInboxEnvironment();
+  await seedSyngoPlazaEnvironment(user.id);
   await printEnvironmentSummary();
 
   console.log("\n✨ Done.");

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -155,7 +155,15 @@ function assertLocalDatabase() {
 }
 
 async function getSeedUser() {
-  return prisma.user.findUniqueOrThrow({ where: { email: SEED_USER_EMAIL } });
+  const user = await prisma.user.findUnique({
+    where: { email: SEED_USER_EMAIL },
+  });
+  if (!user) {
+    throw new Error(
+      `No ${SEED_USER_EMAIL} in this database — run "npm run db:seed" first, then re-run this script.`,
+    );
+  }
+  return user;
 }
 
 function seededSerials() {

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -12,8 +12,6 @@ const SYNGO_PLAZA_CVE = "CVE-2024-52334";
 const DESERIALIZATION_CVE = "CVE-2022-29875";
 const ADVISORY_CVES = [SYNGO_PLAZA_CVE, DESERIALIZATION_CVE];
 
-// The two assets VEX is expected to except. Everything else must stay AFFECTED,
-// so these are the only seeded assets allowed to carry a note.
 const SYNGO_PLAZA_EXCEPTION_SERIAL = "SYNGO-PLZ-VB30E-003";
 const DESERIALIZATION_EXCEPTION_SERIAL = "MAGNETOM-VA30A-001";
 const EXCEPTION_SERIALS = [
@@ -32,8 +30,6 @@ type AssetSpec = {
   location: { facility: string; building: string; floor: string; room: string };
 };
 
-// Duplicated from scripts/seed-notifications.ts rather than imported: that module
-// calls main() at import time, so importing anything from it would run the other seed.
 function upsertVendor(name: string) {
   const canonicalName = name.trim().toLowerCase();
   return prisma.vendor.upsert({
@@ -110,9 +106,6 @@ async function upsertAsset(
     where: { serialNumber: spec.serialNumber },
   });
 
-  // Serial is the identity; everything else is reconciled to the spec. Without
-  // this, editing a version or hostname here leaves the existing row untouched —
-  // silently stranding the asset in its old device group or old name.
   if (existing) {
     return prisma.asset.update({
       where: { id: existing.id },
@@ -179,9 +172,6 @@ async function seededAssetIds() {
   return assets.map((asset) => asset.id);
 }
 
-// Deleting the two vulnerabilities is what clears their Issues (Issue.vulnerabilityId
-// is onDelete: Cascade). Without it, a previous run's VEX determinations survive and
-// the next run measures them instead of its own.
 async function resetInboxEnvironment() {
   const notifications = await prisma.notification.deleteMany({});
   const orphanSources = await prisma.notificationSource.deleteMany({
@@ -190,18 +180,12 @@ async function resetInboxEnvironment() {
   const draftTickets = await prisma.workOrderTicket.deleteMany({
     where: { isDraft: true },
   });
-  // Before the vulnerabilities, not after: Remediation.vulnerabilityId is SetNull,
-  // so deleting the vulnerability first would strand these as orphans that
-  // searchRemediation still offers the match agent as candidates.
   const remediations = await prisma.remediation.deleteMany({
     where: { vulnerability: { cveId: { in: ADVISORY_CVES } } },
   });
   const vulnerabilities = await prisma.vulnerability.deleteMany({
     where: { cveId: { in: ADVISORY_CVES } },
   });
-  // Any note on a seeded asset reaches VEX through getRelevantNotes({ assetIds }).
-  // seed-notifications.ts leaves one on pacs-syngo-02, and answering a Question
-  // leaves one too — either would except an asset this scenario needs AFFECTED.
   const notes = await prisma.note.deleteMany({
     where: {
       targetModel: ScopeTargetModel.ASSET,
@@ -310,8 +294,7 @@ async function seedSyngoPlazaEnvironment(userId: string) {
           },
         ],
       },
-      // Inline connect is required: the vulnerabilityExtension opens one baseline
-      // Issue per matching linked at create time. Linking later creates none.
+      // Must be inline: the extension opens baseline Issues only for matchings linked in this create.
       deviceGroupMatchings: { connect: { id: matching.id } },
     },
   });
@@ -359,8 +342,7 @@ const DESERIALIZATION_MATCHINGS: Array<{
   },
   { product: "MAMMOMAT Revelation", version: "VC20" },
   { product: "NAEOTOM Alpha", version: "VA40" },
-  // "All versions < VA30 SP5 or VA40 SP2" — SP5 and SP2 are the fixes, so the
-  // affected set is the builds below them on each track, not the fix itself.
+  // VA30 SP5 / VA40 SP2 are the fixes, so the affected set is the builds below them.
   ...SOMATOM_PRODUCTS.map((product) => ({
     product,
     versionRange: SOMATOM_AFFECTED_RANGE,
@@ -552,8 +534,7 @@ const DESERIALIZATION_EXCEPTION_NOTE =
 async function seedDeserializationEnvironment(userId: string) {
   console.log("\n🌱 syngo deserialization environment (SSA-220609)...");
 
-  // Sequential: several products share a canonical version ("VA30 SP5", "VB22"),
-  // and concurrent upserts of the same Version race on its unique key.
+  // Sequential, not Promise.all: products share canonical versions and race on the unique key.
   const matchings = [];
   for (const spec of DESERIALIZATION_MATCHINGS) {
     matchings.push(await upsertMatching(spec));
@@ -671,8 +652,6 @@ async function printEnvironmentSummary() {
     }
   }
 
-  // The exception notes are the whole mechanism: exactly these assets carry one,
-  // and no other seeded asset does, or VEX excepts a host meant to stay AFFECTED.
   const notedAssets = await prisma.asset.findMany({
     where: { serialNumber: { in: seededSerials() } },
     select: { id: true, hostname: true, serialNumber: true },

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -288,6 +288,290 @@ async function seedSyngoPlazaEnvironment(userId: string) {
   console.log(`  ✅ ${assets.length} assets, 1 matching, 1 vulnerability`);
 }
 
+const DESERIALIZATION_MATCHINGS: Array<{
+  product: string;
+  version?: string;
+  versionRange?: string;
+}> = [
+  { product: "Biograph Horizon PET/CT Systems", version: "VJ30" },
+  {
+    product: "MAGNETOM Family",
+    versionRange: "vers:generic/VA10B|VA12M|VA12S|VA20A|VA30A|VA31A",
+  },
+  { product: "MAMMOMAT Revelation", version: "VC20" },
+  { product: "NAEOTOM Alpha", version: "VA40" },
+  { product: "SOMATOM go.All", version: "VA30 SP5" },
+  { product: "SOMATOM go.Now", version: "VA30 SP5" },
+  { product: "SOMATOM go.Open Pro", version: "VA30 SP5" },
+  { product: "SOMATOM go.Sim", version: "VA30 SP5" },
+  { product: "SOMATOM go.Top", version: "VA30 SP5" },
+  { product: "SOMATOM go.Up", version: "VA30 SP5" },
+  { product: "SOMATOM X.cite", version: "VA30 SP5" },
+  { product: "SOMATOM X.creed", version: "VA30 SP5" },
+  { product: "Symbia E/S", version: "VB22" },
+  { product: "Symbia Evo", version: "VB22" },
+  { product: "Symbia Intevo", version: "VB22" },
+  { product: "Symbia T", version: "VB22" },
+  { product: "Symbia.net", version: "VB22" },
+  {
+    product: "syngo.via",
+    versionRange: "vers:generic/VB10|VB20|VB30|VB40|VB50|VB60",
+  },
+];
+
+const DESERIALIZATION_ASSETS: Array<
+  AssetSpec & { product: string; version: string }
+> = [
+  {
+    product: "MAGNETOM Family",
+    version: "VA10B",
+    ip: "10.60.0.11",
+    hostname: "mri-magnetom-01",
+    serialNumber: "MAGNETOM-VA10B-001",
+    role: "MRI Scanner Console",
+    networkSegment: "IMAGING-MRI",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "1",
+      room: "MRI Suite 1",
+    },
+  },
+  {
+    product: "MAGNETOM Family",
+    version: "VA12S",
+    ip: "10.60.0.12",
+    hostname: "mri-magnetom-02",
+    serialNumber: "MAGNETOM-VA12S-001",
+    role: "MRI Scanner Console",
+    networkSegment: "IMAGING-MRI",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "1",
+      room: "MRI Suite 2",
+    },
+  },
+  {
+    product: "MAGNETOM Family",
+    version: "VA30A",
+    ip: "10.60.0.13",
+    hostname: "mri-magnetom-03",
+    serialNumber: "MAGNETOM-VA30A-001",
+    role: "MRI Scanner Console",
+    networkSegment: "IMAGING-MRI-ISOLATED",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "1",
+      room: "MRI Suite 3",
+    },
+  },
+  {
+    product: "syngo.via",
+    version: "VB50",
+    ip: "10.60.1.11",
+    hostname: "syngovia-01",
+    serialNumber: "SYNGOVIA-VB50-001",
+    role: "Imaging Workstation",
+    networkSegment: "IMAGING-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "2",
+      room: "Reading Room C",
+    },
+  },
+  {
+    product: "syngo.via",
+    version: "VB60",
+    ip: "10.60.1.12",
+    hostname: "syngovia-02",
+    serialNumber: "SYNGOVIA-VB60-001",
+    role: "Imaging Workstation",
+    networkSegment: "IMAGING-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "2",
+      room: "Reading Room D",
+    },
+  },
+  {
+    product: "Symbia Intevo",
+    version: "VB22",
+    ip: "10.60.2.11",
+    hostname: "symbia-intevo-01",
+    serialNumber: "SYMBIA-INTEVO-VB22-001",
+    role: "SPECT/CT Console",
+    networkSegment: "IMAGING-NUCMED",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "B1",
+      room: "Nuclear Medicine 1",
+    },
+  },
+  {
+    product: "Symbia E/S",
+    version: "VB22",
+    ip: "10.60.2.12",
+    hostname: "symbia-es-01",
+    serialNumber: "SYMBIA-ES-VB22-001",
+    role: "SPECT Console",
+    networkSegment: "IMAGING-NUCMED",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "B1",
+      room: "Nuclear Medicine 2",
+    },
+  },
+  {
+    product: "SOMATOM go.Top",
+    version: "VA30 SP5",
+    ip: "10.60.3.11",
+    hostname: "ct-somatom-gotop-01",
+    serialNumber: "SOMATOM-GOTOP-VA30-001",
+    role: "CT Scanner Console",
+    networkSegment: "IMAGING-CT",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "1",
+      room: "CT Suite 1",
+    },
+  },
+  {
+    product: "NAEOTOM Alpha",
+    version: "VA40",
+    ip: "10.60.3.12",
+    hostname: "ct-naeotom-01",
+    serialNumber: "NAEOTOM-VA40-001",
+    role: "Photon-Counting CT Console",
+    networkSegment: "IMAGING-CT",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "1",
+      room: "CT Suite 2",
+    },
+  },
+  {
+    product: "Biograph Horizon PET/CT Systems",
+    version: "VJ30",
+    ip: "10.60.4.11",
+    hostname: "pet-biograph-01",
+    serialNumber: "BIOGRAPH-VJ30-001",
+    role: "PET/CT Console",
+    networkSegment: "IMAGING-NUCMED",
+    location: {
+      facility: "Main Hospital",
+      building: "Imaging Pavilion",
+      floor: "B1",
+      room: "PET/CT Suite",
+    },
+  },
+  {
+    product: "MAMMOMAT Revelation",
+    version: "VC20",
+    ip: "10.60.5.11",
+    hostname: "mammo-revelation-01",
+    serialNumber: "MAMMOMAT-VC20-001",
+    role: "Mammography System",
+    networkSegment: "IMAGING-MAMMO",
+    location: {
+      facility: "Women's Health Center",
+      building: "Main",
+      floor: "1",
+      room: "Mammography 1",
+    },
+  },
+];
+
+const DESERIALIZATION_EXCEPTION_NOTE =
+  "mri-magnetom-03 is deployed in Siemens 'workstation mode' — the syngo client and server run on the same host, and ports 32912/tcp and 32914/tcp are closed for all inbound traffic on the host Windows firewall. The IMAGING-MRI-ISOLATED segment additionally blocks both ports at the boundary firewall, permitting only the service VPN jump host. Verified during the 2026-Q1 segmentation audit.";
+
+async function seedDeserializationEnvironment(userId: string) {
+  console.log("\n🌱 syngo deserialization environment (SSA-220609)...");
+
+  // Sequential: several products share a canonical version ("VA30 SP5", "VB22"),
+  // and concurrent upserts of the same Version race on its unique key.
+  const matchings = [];
+  for (const spec of DESERIALIZATION_MATCHINGS) {
+    matchings.push(await upsertMatching(spec));
+  }
+
+  const assets = [];
+  for (const spec of DESERIALIZATION_ASSETS) {
+    const { product, version, ...assetFields } = spec;
+    const deviceGroup = await upsertDeviceGroup(product, version);
+    assets.push(await upsertAsset(assetFields, deviceGroup.id, userId));
+  }
+
+  const vulnerability = await prisma.vulnerability.create({
+    data: {
+      cveId: DESERIALIZATION_CVE,
+      severity: Severity.Critical,
+      cvssScore: 9.8,
+      cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+      description:
+        "The application deserialises untrusted data without sufficient validations, which could result in an arbitrary deserialization. This could allow an unauthenticated attacker to execute code in the affected system if ports 32912/tcp or 32914/tcp are reachable.",
+      narrative:
+        "An unauthenticated attacker who can reach ports 32912/tcp or 32914/tcp on an affected system can send a crafted serialized payload. Because the application deserializes untrusted data without validation (CWE-502), the payload is instantiated and can execute arbitrary code under the syngo platform's privileges.",
+      impact:
+        "Remote code execution on imaging systems (MRI, CT, PET/CT, SPECT/CT, mammography) and the syngo.via viewing and reporting platform, potentially disrupting diagnostic imaging workflows across radiology and nuclear medicine.",
+      userId,
+      sarif: {
+        version: "2.1.0",
+        runs: [
+          {
+            tool: { driver: { name: "Siemens Healthineers PSIRT" } },
+            results: [
+              {
+                ruleId: DESERIALIZATION_CVE,
+                level: "error",
+                message: {
+                  text: "Deserialization of untrusted data in Siemens Healthineers syngo platform (SSA-220609)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      deviceGroupMatchings: { connect: matchings.map((m) => ({ id: m.id })) },
+    },
+  });
+
+  await prisma.remediation.create({
+    data: {
+      description:
+        "Update to the fixed version for each affected product, or block ports 32912/tcp and 32914/tcp at an external firewall",
+      narrative:
+        "Siemens Healthineers provides fixes for all affected versions. Where a fix cannot yet be applied, block ports 32912/tcp and 32914/tcp at an external firewall and, for workstation-mode installations, close both ports for inbound traffic on the host Windows firewall.",
+      vulnerabilityId: vulnerability.id,
+      userId,
+      deviceGroupMatchings: { connect: matchings.map((m) => ({ id: m.id })) },
+    },
+  });
+
+  const exceptionAsset = assets.find(
+    (a) => a.serialNumber === "MAGNETOM-VA30A-001",
+  );
+  if (!exceptionAsset) {
+    throw new Error("Expected MAGNETOM-VA30A-001 to exist after seeding.");
+  }
+  await upsertAssetNote(
+    userId,
+    exceptionAsset.id,
+    DESERIALIZATION_EXCEPTION_NOTE,
+  );
+
+  console.log(
+    `  ✅ ${assets.length} assets, ${matchings.length} matchings, 1 vulnerability`,
+  );
+}
+
 async function printEnvironmentSummary() {
   const failures: string[] = [];
 
@@ -351,6 +635,7 @@ async function main() {
   const user = await getSeedUser();
   await resetInboxEnvironment();
   await seedSyngoPlazaEnvironment(user.id);
+  await seedDeserializationEnvironment(user.id);
   await printEnvironmentSummary();
 
   console.log("\n✨ Done.");

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -161,12 +161,18 @@ async function resetInboxEnvironment() {
   const draftTickets = await prisma.workOrderTicket.deleteMany({
     where: { isDraft: true },
   });
+  // Before the vulnerabilities, not after: Remediation.vulnerabilityId is SetNull,
+  // so deleting the vulnerability first would strand these as orphans that
+  // searchRemediation still offers the match agent as candidates.
+  const remediations = await prisma.remediation.deleteMany({
+    where: { vulnerability: { cveId: { in: ADVISORY_CVES } } },
+  });
   const vulnerabilities = await prisma.vulnerability.deleteMany({
     where: { cveId: { in: ADVISORY_CVES } },
   });
 
   console.log(
-    `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${vulnerabilities.count} vulnerability(ies)`,
+    `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${remediations.count} remediation(s), ${vulnerabilities.count} vulnerability(ies)`,
   );
 }
 

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -4,6 +4,10 @@ import {
   Severity,
   VersionStatus,
 } from "@/generated/prisma";
+import {
+  deviceGroupWhereForMatching,
+  matchingAppliesToDeviceGroup,
+} from "@/lib/device-matching";
 import prisma from "../src/lib/db";
 
 const SEED_USER_EMAIL = "user@example.com";
@@ -18,6 +22,10 @@ const EXCEPTION_SERIALS = [
   SYNGO_PLAZA_EXCEPTION_SERIAL,
   DESERIALIZATION_EXCEPTION_SERIAL,
 ];
+
+// Hosts on a fixed/newer build: the advisory must not reach them at all, so the
+// affected-asset list is a real subset of the fleet rather than everything we own.
+const OUT_OF_SCOPE_SERIALS = ["SYNGO-PLZ-VB30E-HF07-001", "SYNGOVIA-VB70-001"];
 
 const VENDOR = "Siemens Healthineers";
 
@@ -180,6 +188,38 @@ async function seededAssetIds() {
   return assets.map((asset) => asset.id);
 }
 
+type MatchingRow = {
+  vendorId: string;
+  productId: string | null;
+  versionId: string | null;
+  versionRange: string | null;
+};
+
+async function assetsInScopeOf(matchings: MatchingRow[]) {
+  const byId = new Map<
+    string,
+    { hostname: string | null; serialNumber: string | null }
+  >();
+
+  for (const matching of matchings) {
+    const groups = await prisma.deviceGroup.findMany({
+      where: deviceGroupWhereForMatching(matching),
+      include: {
+        version: true,
+        assets: { select: { id: true, hostname: true, serialNumber: true } },
+      },
+    });
+    for (const group of groups) {
+      if (!matchingAppliesToDeviceGroup(matching, group)) continue;
+      for (const asset of group.assets) byId.set(asset.id, asset);
+    }
+  }
+
+  return [...byId.values()].sort((a, b) =>
+    (a.hostname ?? "").localeCompare(b.hostname ?? ""),
+  );
+}
+
 async function resetInboxEnvironment() {
   const notifications = await prisma.notification.deleteMany({});
   const orphanSources = await prisma.notificationSource.deleteMany({
@@ -209,8 +249,9 @@ async function resetInboxEnvironment() {
 const SYNGO_PLAZA_PRODUCT = "syngo.plaza";
 const SYNGO_PLAZA_VERSION = "VB30E";
 
-const SYNGO_PLAZA_ASSETS: AssetSpec[] = [
+const SYNGO_PLAZA_ASSETS: Array<AssetSpec & { version: string }> = [
   {
+    version: SYNGO_PLAZA_VERSION,
     ip: "10.50.0.11",
     hostname: "pacs-syngo-01",
     serialNumber: "SYNGO-PLZ-VB30E-001",
@@ -224,6 +265,7 @@ const SYNGO_PLAZA_ASSETS: AssetSpec[] = [
     },
   },
   {
+    version: SYNGO_PLAZA_VERSION,
     ip: "10.50.0.12",
     hostname: "pacs-syngo-02",
     serialNumber: "SYNGO-PLZ-VB30E-002",
@@ -237,6 +279,7 @@ const SYNGO_PLAZA_ASSETS: AssetSpec[] = [
     },
   },
   {
+    version: SYNGO_PLAZA_VERSION,
     ip: "10.50.0.13",
     hostname: "pacs-syngo-03",
     serialNumber: "SYNGO-PLZ-VB30E-003",
@@ -247,6 +290,20 @@ const SYNGO_PLAZA_ASSETS: AssetSpec[] = [
       building: "Diagnostic Pavilion",
       floor: "2",
       room: "Mammography Reading",
+    },
+  },
+  {
+    version: "VB30E_HF07",
+    ip: "10.50.0.14",
+    hostname: "pacs-syngo-04",
+    serialNumber: "SYNGO-PLZ-VB30E-HF07-001",
+    role: "PACS Workstation",
+    networkSegment: "RADIOLOGY-PACS",
+    location: {
+      facility: "Main Hospital",
+      building: "Diagnostic Pavilion",
+      floor: "3",
+      room: "Reading Room C",
     },
   },
 ];
@@ -262,14 +319,11 @@ async function seedSyngoPlazaEnvironment(userId: string) {
     version: SYNGO_PLAZA_VERSION,
   });
 
-  const deviceGroup = await upsertDeviceGroup(
-    SYNGO_PLAZA_PRODUCT,
-    SYNGO_PLAZA_VERSION,
-  );
-
   const assets = [];
   for (const spec of SYNGO_PLAZA_ASSETS) {
-    assets.push(await upsertAsset(spec, deviceGroup.id, userId));
+    const { version, ...assetFields } = spec;
+    const deviceGroup = await upsertDeviceGroup(SYNGO_PLAZA_PRODUCT, version);
+    assets.push(await upsertAsset(assetFields, deviceGroup.id, userId));
   }
 
   const vulnerability = await prisma.vulnerability.create({
@@ -324,42 +378,16 @@ async function seedSyngoPlazaEnvironment(userId: string) {
   console.log(`  ✅ ${assets.length} assets, 1 matching, 1 vulnerability`);
 }
 
-const SOMATOM_PRODUCTS = [
-  "SOMATOM go.All",
-  "SOMATOM go.Now",
-  "SOMATOM go.Open Pro",
-  "SOMATOM go.Sim",
-  "SOMATOM go.Top",
-  "SOMATOM go.Up",
-  "SOMATOM X.cite",
-  "SOMATOM X.creed",
-];
-
-const SOMATOM_AFFECTED_RANGE =
-  "vers:generic/VA20|VA30|VA30 SP1|VA30 SP2|VA30 SP3|VA30 SP4|VA40|VA40 SP1";
-
+// The advisory lists 18 products; these are the ones this hospital owns.
 const DESERIALIZATION_MATCHINGS: Array<{
   product: string;
   version?: string;
   versionRange?: string;
 }> = [
-  { product: "Biograph Horizon PET/CT Systems", version: "VJ30" },
   {
     product: "MAGNETOM Family",
     versionRange: "vers:generic/VA10B|VA12M|VA12S|VA20A|VA30A|VA31A",
   },
-  { product: "MAMMOMAT Revelation", version: "VC20" },
-  { product: "NAEOTOM Alpha", version: "VA40" },
-  // VA30 SP5 / VA40 SP2 are the fixes, so the affected set is the builds below them.
-  ...SOMATOM_PRODUCTS.map((product) => ({
-    product,
-    versionRange: SOMATOM_AFFECTED_RANGE,
-  })),
-  { product: "Symbia E/S", version: "VB22" },
-  { product: "Symbia Evo", version: "VB22" },
-  { product: "Symbia Intevo", version: "VB22" },
-  { product: "Symbia T", version: "VB22" },
-  { product: "Symbia.net", version: "VB22" },
   {
     product: "syngo.via",
     versionRange: "vers:generic/VB10|VB20|VB30|VB40|VB50|VB60",
@@ -431,10 +459,10 @@ const DESERIALIZATION_ASSETS: Array<
   },
   {
     product: "syngo.via",
-    version: "VB60",
+    version: "VB70",
     ip: "10.60.1.12",
-    hostname: "syngovia-04",
-    serialNumber: "SYNGOVIA-VB60-001",
+    hostname: "syngovia-07",
+    serialNumber: "SYNGOVIA-VB70-001",
     role: "Imaging Workstation",
     networkSegment: "IMAGING-PACS",
     location: {
@@ -442,96 +470,6 @@ const DESERIALIZATION_ASSETS: Array<
       building: "Diagnostic Pavilion",
       floor: "2",
       room: "Reading Room D",
-    },
-  },
-  {
-    product: "Symbia Intevo",
-    version: "VB22",
-    ip: "10.60.2.11",
-    hostname: "symbia-intevo-01",
-    serialNumber: "SYMBIA-INTEVO-VB22-001",
-    role: "SPECT/CT Console",
-    networkSegment: "IMAGING-NUCMED",
-    location: {
-      facility: "Main Hospital",
-      building: "Imaging Pavilion",
-      floor: "B1",
-      room: "Nuclear Medicine 1",
-    },
-  },
-  {
-    product: "Symbia E/S",
-    version: "VB22",
-    ip: "10.60.2.12",
-    hostname: "symbia-es-01",
-    serialNumber: "SYMBIA-ES-VB22-001",
-    role: "SPECT Console",
-    networkSegment: "IMAGING-NUCMED",
-    location: {
-      facility: "Main Hospital",
-      building: "Imaging Pavilion",
-      floor: "B1",
-      room: "Nuclear Medicine 2",
-    },
-  },
-  {
-    product: "SOMATOM go.Top",
-    version: "VA30 SP3",
-    ip: "10.60.3.11",
-    hostname: "ct-somatom-gotop-01",
-    serialNumber: "SOMATOM-GOTOP-VA30-001",
-    role: "CT Scanner Console",
-    networkSegment: "IMAGING-CT",
-    location: {
-      facility: "Main Hospital",
-      building: "Imaging Pavilion",
-      floor: "1",
-      room: "CT Suite 1",
-    },
-  },
-  {
-    product: "NAEOTOM Alpha",
-    version: "VA40",
-    ip: "10.60.3.12",
-    hostname: "ct-naeotom-01",
-    serialNumber: "NAEOTOM-VA40-001",
-    role: "Photon-Counting CT Console",
-    networkSegment: "IMAGING-CT",
-    location: {
-      facility: "Main Hospital",
-      building: "Imaging Pavilion",
-      floor: "1",
-      room: "CT Suite 2",
-    },
-  },
-  {
-    product: "Biograph Horizon PET/CT Systems",
-    version: "VJ30",
-    ip: "10.60.4.11",
-    hostname: "pet-biograph-01",
-    serialNumber: "BIOGRAPH-VJ30-001",
-    role: "PET/CT Console",
-    networkSegment: "IMAGING-NUCMED",
-    location: {
-      facility: "Main Hospital",
-      building: "Imaging Pavilion",
-      floor: "B1",
-      room: "PET/CT Suite",
-    },
-  },
-  {
-    product: "MAMMOMAT Revelation",
-    version: "VC20",
-    ip: "10.60.5.11",
-    hostname: "mammo-revelation-01",
-    serialNumber: "MAMMOMAT-VC20-001",
-    role: "Mammography System",
-    networkSegment: "IMAGING-MAMMO",
-    location: {
-      facility: "Women's Health Center",
-      building: "Main",
-      floor: "1",
-      room: "Mammography 1",
     },
   },
 ];
@@ -643,10 +581,29 @@ async function printEnvironmentSummary() {
       (issue) => issue.assetId !== null,
     ).length;
 
+    const inScope = await assetsInScopeOf(vulnerability.deviceGroupMatchings);
+
     console.log(`\n  ${cveId}`);
     console.log(`    device group matchings      ${matchings}`);
     console.log(`    baseline issues             ${baseline}`);
     console.log(`    asset-level issues          ${assetLevel}`);
+    console.log(
+      `    assets in scope             ${inScope.length}  (${inScope.map((a) => a.hostname).join(", ")})`,
+    );
+
+    for (const asset of inScope) {
+      if (OUT_OF_SCOPE_SERIALS.includes(asset.serialNumber ?? "")) {
+        failures.push(
+          `${cveId}: ${asset.hostname} runs a fixed build but the advisory still matches it — nothing is left unaffected`,
+        );
+      }
+    }
+
+    if (inScope.length === 0) {
+      failures.push(
+        `${cveId}: no assets in scope — the advisory would arrive with nothing to link to`,
+      );
+    }
 
     if (baseline !== matchings) {
       failures.push(
@@ -673,6 +630,13 @@ async function printEnvironmentSummary() {
   });
   const notedIds = new Set(notesByAsset.map((note) => note.instanceId));
 
+  const allMatchings = await prisma.deviceGroupMatching.findMany({
+    where: { vulnerabilities: { some: { cveId: { in: ADVISORY_CVES } } } },
+  });
+  const reachable = new Set(
+    (await assetsInScopeOf(allMatchings)).map((a) => a.serialNumber),
+  );
+
   console.log("\n  exception notes");
   for (const serial of EXCEPTION_SERIALS) {
     const asset = notedAssets.find((a) => a.serialNumber === serial);
@@ -680,6 +644,11 @@ async function printEnvironmentSummary() {
     console.log(`    ${asset?.hostname ?? serial}${has ? "" : "   MISSING"}`);
     if (!has) {
       failures.push(`${serial}: expected an asset-scoped note, found none`);
+    }
+    if (!reachable.has(serial)) {
+      failures.push(
+        `${serial}: carries the exception note but no advisory matching reaches it — VEX would never see it`,
+      );
     }
   }
 

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -1,0 +1,116 @@
+import prisma from "../src/lib/db";
+
+const SEED_USER_EMAIL = "user@example.com";
+
+const SYNGO_PLAZA_CVE = "CVE-2024-52334";
+const DESERIALIZATION_CVE = "CVE-2022-29875";
+const ADVISORY_CVES = [SYNGO_PLAZA_CVE, DESERIALIZATION_CVE];
+
+function assertLocalDatabase() {
+  const raw = process.env.DATABASE_URL;
+  if (!raw) throw new Error("DATABASE_URL is not set.");
+  const { hostname } = new URL(raw);
+  if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+    throw new Error(
+      `Refusing to run: DATABASE_URL points at "${hostname}". This script deletes all notifications and only runs against a local database.`,
+    );
+  }
+}
+
+async function getSeedUser() {
+  return prisma.user.findUniqueOrThrow({ where: { email: SEED_USER_EMAIL } });
+}
+
+// Deleting the two vulnerabilities is what clears their Issues (Issue.vulnerabilityId
+// is onDelete: Cascade). Without it, a previous run's VEX determinations survive and
+// the next run measures them instead of its own.
+async function resetInboxEnvironment() {
+  const notifications = await prisma.notification.deleteMany({});
+  const orphanSources = await prisma.notificationSource.deleteMany({
+    where: { notificationId: null, workOrderTicketId: null },
+  });
+  const draftTickets = await prisma.workOrderTicket.deleteMany({
+    where: { isDraft: true },
+  });
+  const vulnerabilities = await prisma.vulnerability.deleteMany({
+    where: { cveId: { in: ADVISORY_CVES } },
+  });
+
+  console.log(
+    `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${vulnerabilities.count} vulnerability(ies)`,
+  );
+}
+
+async function printEnvironmentSummary() {
+  const failures: string[] = [];
+
+  const notifications = await prisma.notification.count();
+  console.log(`\n  notifications                 ${notifications}`);
+  if (notifications !== 0) {
+    failures.push(
+      `expected 0 notifications, found ${notifications} — the pipeline must create them, not this script`,
+    );
+  }
+
+  for (const cveId of ADVISORY_CVES) {
+    const vulnerability = await prisma.vulnerability.findFirst({
+      where: { cveId },
+      include: { deviceGroupMatchings: true, issues: true },
+    });
+
+    if (!vulnerability) {
+      console.log(`\n  ${cveId}                (not seeded yet)`);
+      continue;
+    }
+
+    const matchings = vulnerability.deviceGroupMatchings.length;
+    const baseline = vulnerability.issues.filter(
+      (issue) => issue.deviceGroupMatchingId !== null,
+    ).length;
+    const assetLevel = vulnerability.issues.filter(
+      (issue) => issue.assetId !== null,
+    ).length;
+
+    console.log(`\n  ${cveId}`);
+    console.log(`    device group matchings      ${matchings}`);
+    console.log(`    baseline issues             ${baseline}`);
+    console.log(`    asset-level issues          ${assetLevel}`);
+
+    if (baseline !== matchings) {
+      failures.push(
+        `${cveId}: ${matchings} matching(s) but ${baseline} baseline issue(s) — the vulnerability must connect its matchings inline in the same create() call`,
+      );
+    }
+    if (assetLevel !== 0) {
+      failures.push(
+        `${cveId}: ${assetLevel} asset-level issue(s) present — those are the VEX agent's output and must not be seeded`,
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("\n❌ Environment is not usable:");
+    for (const failure of failures) console.error(`   - ${failure}`);
+    throw new Error("Seed produced an unusable environment.");
+  }
+
+  console.log("\n  ✅ invariants hold");
+}
+
+async function main() {
+  console.log("🚀 Preparing advisory test environment\n");
+  assertLocalDatabase();
+
+  await getSeedUser();
+  await resetInboxEnvironment();
+  await printEnvironmentSummary();
+
+  console.log("\n✨ Done.");
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -12,6 +12,15 @@ const SYNGO_PLAZA_CVE = "CVE-2024-52334";
 const DESERIALIZATION_CVE = "CVE-2022-29875";
 const ADVISORY_CVES = [SYNGO_PLAZA_CVE, DESERIALIZATION_CVE];
 
+// The two assets VEX is expected to except. Everything else must stay AFFECTED,
+// so these are the only seeded assets allowed to carry a note.
+const SYNGO_PLAZA_EXCEPTION_SERIAL = "SYNGO-PLZ-VB30E-003";
+const DESERIALIZATION_EXCEPTION_SERIAL = "MAGNETOM-VA30A-001";
+const EXCEPTION_SERIALS = [
+  SYNGO_PLAZA_EXCEPTION_SERIAL,
+  DESERIALIZATION_EXCEPTION_SERIAL,
+];
+
 const VENDOR = "Siemens Healthineers";
 
 type AssetSpec = {
@@ -74,22 +83,16 @@ async function upsertMatching(spec: {
   );
 }
 
-async function upsertDeviceGroup(
-  product: string,
-  version: string | null,
-  versionStatus: VersionStatus = version
-    ? VersionStatus.KNOWN
-    : VersionStatus.UNKNOWN,
-) {
+async function upsertDeviceGroup(product: string, version: string) {
   const vendor = await upsertVendor(VENDOR);
   const productRec = await upsertProduct(product);
-  const versionRec = version ? await upsertVersion(version) : null;
+  const versionRec = await upsertVersion(version);
 
   const identity = {
     vendorId: vendor.id,
     productId: productRec.id,
-    versionId: versionRec?.id ?? null,
-    versionStatus,
+    versionId: versionRec.id,
+    versionStatus: VersionStatus.KNOWN,
   };
 
   return (
@@ -106,7 +109,16 @@ async function upsertAsset(
   const existing = await prisma.asset.findFirst({
     where: { serialNumber: spec.serialNumber },
   });
-  if (existing) return existing;
+
+  // Serial is the identity; everything else is reconciled to the spec. Without
+  // this, editing a version or hostname here leaves the existing row untouched —
+  // silently stranding the asset in its old device group or old name.
+  if (existing) {
+    return prisma.asset.update({
+      where: { id: existing.id },
+      data: { ...spec, deviceGroupId },
+    });
+  }
 
   return prisma.asset.create({
     data: {
@@ -119,12 +131,15 @@ async function upsertAsset(
   });
 }
 
-async function upsertAssetNote(userId: string, assetId: string, text: string) {
-  const existing = await prisma.note.findFirst({
-    where: { targetModel: ScopeTargetModel.ASSET, instanceId: assetId },
-  });
-  if (existing) return existing;
+async function assetBySerial(serialNumber: string) {
+  const asset = await prisma.asset.findFirst({ where: { serialNumber } });
+  if (!asset) {
+    throw new Error(`Expected ${serialNumber} to exist after seeding.`);
+  }
+  return asset;
+}
 
+function createAssetNote(userId: string, assetId: string, text: string) {
   return prisma.note.create({
     data: {
       userId,
@@ -150,6 +165,20 @@ async function getSeedUser() {
   return prisma.user.findUniqueOrThrow({ where: { email: SEED_USER_EMAIL } });
 }
 
+function seededSerials() {
+  return [...SYNGO_PLAZA_ASSETS, ...DESERIALIZATION_ASSETS].map(
+    (spec) => spec.serialNumber,
+  );
+}
+
+async function seededAssetIds() {
+  const assets = await prisma.asset.findMany({
+    where: { serialNumber: { in: seededSerials() } },
+    select: { id: true },
+  });
+  return assets.map((asset) => asset.id);
+}
+
 // Deleting the two vulnerabilities is what clears their Issues (Issue.vulnerabilityId
 // is onDelete: Cascade). Without it, a previous run's VEX determinations survive and
 // the next run measures them instead of its own.
@@ -170,9 +199,18 @@ async function resetInboxEnvironment() {
   const vulnerabilities = await prisma.vulnerability.deleteMany({
     where: { cveId: { in: ADVISORY_CVES } },
   });
+  // Any note on a seeded asset reaches VEX through getRelevantNotes({ assetIds }).
+  // seed-notifications.ts leaves one on pacs-syngo-02, and answering a Question
+  // leaves one too — either would except an asset this scenario needs AFFECTED.
+  const notes = await prisma.note.deleteMany({
+    where: {
+      targetModel: ScopeTargetModel.ASSET,
+      instanceId: { in: await seededAssetIds() },
+    },
+  });
 
   console.log(
-    `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${remediations.count} remediation(s), ${vulnerabilities.count} vulnerability(ies)`,
+    `  🧹 removed ${notifications.count} notification(s), ${orphanSources.count} orphan source(s), ${draftTickets.count} draft ticket(s), ${remediations.count} remediation(s), ${vulnerabilities.count} vulnerability(ies), ${notes.count} asset note(s)`,
   );
 }
 
@@ -289,10 +327,25 @@ async function seedSyngoPlazaEnvironment(userId: string) {
     },
   });
 
-  await upsertAssetNote(userId, assets[2].id, SYNGO_PLAZA_EXCEPTION_NOTE);
+  const exceptionAsset = await assetBySerial(SYNGO_PLAZA_EXCEPTION_SERIAL);
+  await createAssetNote(userId, exceptionAsset.id, SYNGO_PLAZA_EXCEPTION_NOTE);
 
   console.log(`  ✅ ${assets.length} assets, 1 matching, 1 vulnerability`);
 }
+
+const SOMATOM_PRODUCTS = [
+  "SOMATOM go.All",
+  "SOMATOM go.Now",
+  "SOMATOM go.Open Pro",
+  "SOMATOM go.Sim",
+  "SOMATOM go.Top",
+  "SOMATOM go.Up",
+  "SOMATOM X.cite",
+  "SOMATOM X.creed",
+];
+
+const SOMATOM_AFFECTED_RANGE =
+  "vers:generic/VA20|VA30|VA30 SP1|VA30 SP2|VA30 SP3|VA30 SP4|VA40|VA40 SP1";
 
 const DESERIALIZATION_MATCHINGS: Array<{
   product: string;
@@ -306,14 +359,12 @@ const DESERIALIZATION_MATCHINGS: Array<{
   },
   { product: "MAMMOMAT Revelation", version: "VC20" },
   { product: "NAEOTOM Alpha", version: "VA40" },
-  { product: "SOMATOM go.All", version: "VA30 SP5" },
-  { product: "SOMATOM go.Now", version: "VA30 SP5" },
-  { product: "SOMATOM go.Open Pro", version: "VA30 SP5" },
-  { product: "SOMATOM go.Sim", version: "VA30 SP5" },
-  { product: "SOMATOM go.Top", version: "VA30 SP5" },
-  { product: "SOMATOM go.Up", version: "VA30 SP5" },
-  { product: "SOMATOM X.cite", version: "VA30 SP5" },
-  { product: "SOMATOM X.creed", version: "VA30 SP5" },
+  // "All versions < VA30 SP5 or VA40 SP2" — SP5 and SP2 are the fixes, so the
+  // affected set is the builds below them on each track, not the fix itself.
+  ...SOMATOM_PRODUCTS.map((product) => ({
+    product,
+    versionRange: SOMATOM_AFFECTED_RANGE,
+  })),
   { product: "Symbia E/S", version: "VB22" },
   { product: "Symbia Evo", version: "VB22" },
   { product: "Symbia Intevo", version: "VB22" },
@@ -362,7 +413,7 @@ const DESERIALIZATION_ASSETS: Array<
     product: "MAGNETOM Family",
     version: "VA30A",
     ip: "10.60.0.13",
-    hostname: "mri-magnetom-03",
+    hostname: "mri-magnetom-05",
     serialNumber: "MAGNETOM-VA30A-001",
     role: "MRI Scanner Console",
     networkSegment: "IMAGING-MRI-ISOLATED",
@@ -392,7 +443,7 @@ const DESERIALIZATION_ASSETS: Array<
     product: "syngo.via",
     version: "VB60",
     ip: "10.60.1.12",
-    hostname: "syngovia-02",
+    hostname: "syngovia-04",
     serialNumber: "SYNGOVIA-VB60-001",
     role: "Imaging Workstation",
     networkSegment: "IMAGING-PACS",
@@ -435,7 +486,7 @@ const DESERIALIZATION_ASSETS: Array<
   },
   {
     product: "SOMATOM go.Top",
-    version: "VA30 SP5",
+    version: "VA30 SP3",
     ip: "10.60.3.11",
     hostname: "ct-somatom-gotop-01",
     serialNumber: "SOMATOM-GOTOP-VA30-001",
@@ -496,7 +547,7 @@ const DESERIALIZATION_ASSETS: Array<
 ];
 
 const DESERIALIZATION_EXCEPTION_NOTE =
-  "mri-magnetom-03 is deployed in Siemens 'workstation mode' — the syngo client and server run on the same host, and ports 32912/tcp and 32914/tcp are closed for all inbound traffic on the host Windows firewall. The IMAGING-MRI-ISOLATED segment additionally blocks both ports at the boundary firewall, permitting only the service VPN jump host. Verified during the 2026-Q1 segmentation audit.";
+  "mri-magnetom-05 is deployed in Siemens 'workstation mode' — the syngo client and server run on the same host, and ports 32912/tcp and 32914/tcp are closed for all inbound traffic on the host Windows firewall. The IMAGING-MRI-ISOLATED segment additionally blocks both ports at the boundary firewall, permitting only the service VPN jump host. Verified during the 2026-Q1 segmentation audit.";
 
 async function seedDeserializationEnvironment(userId: string) {
   console.log("\n🌱 syngo deserialization environment (SSA-220609)...");
@@ -561,13 +612,8 @@ async function seedDeserializationEnvironment(userId: string) {
     },
   });
 
-  const exceptionAsset = assets.find(
-    (a) => a.serialNumber === "MAGNETOM-VA30A-001",
-  );
-  if (!exceptionAsset) {
-    throw new Error("Expected MAGNETOM-VA30A-001 to exist after seeding.");
-  }
-  await upsertAssetNote(
+  const exceptionAsset = await assetBySerial(DESERIALIZATION_EXCEPTION_SERIAL);
+  await createAssetNote(
     userId,
     exceptionAsset.id,
     DESERIALIZATION_EXCEPTION_NOTE,
@@ -623,6 +669,42 @@ async function printEnvironmentSummary() {
         `${cveId}: ${assetLevel} asset-level issue(s) present — those are the VEX agent's output and must not be seeded`,
       );
     }
+  }
+
+  // The exception notes are the whole mechanism: exactly these assets carry one,
+  // and no other seeded asset does, or VEX excepts a host meant to stay AFFECTED.
+  const notedAssets = await prisma.asset.findMany({
+    where: { serialNumber: { in: seededSerials() } },
+    select: { id: true, hostname: true, serialNumber: true },
+  });
+  const notesByAsset = await prisma.note.findMany({
+    where: {
+      targetModel: ScopeTargetModel.ASSET,
+      instanceId: { in: notedAssets.map((asset) => asset.id) },
+    },
+    select: { instanceId: true },
+  });
+  const notedIds = new Set(notesByAsset.map((note) => note.instanceId));
+
+  console.log("\n  exception notes");
+  for (const serial of EXCEPTION_SERIALS) {
+    const asset = notedAssets.find((a) => a.serialNumber === serial);
+    const has = asset ? notedIds.has(asset.id) : false;
+    console.log(`    ${asset?.hostname ?? serial}${has ? "" : "   MISSING"}`);
+    if (!has) {
+      failures.push(`${serial}: expected an asset-scoped note, found none`);
+    }
+  }
+
+  const unexpected = notedAssets.filter(
+    (asset) =>
+      notedIds.has(asset.id) &&
+      !EXCEPTION_SERIALS.includes(asset.serialNumber ?? ""),
+  );
+  for (const asset of unexpected) {
+    failures.push(
+      `${asset.hostname ?? asset.serialNumber}: carries a note but is meant to stay AFFECTED — VEX would except it`,
+    );
   }
 
   if (failures.length > 0) {


### PR DESCRIPTION
[VW-396](https://northeastern-patch.atlassian.net/browse/VW-396)


Adds `scripts/seed-advisory-environment.ts`, a dev script that prepares VIPER to receive one of two real Siemens Healthineers advisories by email and drive the full `processInboxEmail` chain — VEX → questions → triage → mitigation — against a hospital fleet that actually exists.

Two assets are set up to be excepted by VEX on grounds taken from the advisories themselves: `pacs-syngo-03` was hot-fixed to `VB30E_HF07` while the CMDB went stale, and `mri-magnetom-05` runs in the "workstation mode" DOC 2 describes with ports 32912/32914 closed. Everything else should stay `AFFECTED`.

Should cover all 3 cases:
- If notification seed file already seeded.
- If notification seed file haven't seeded.
- if this seed file has already seeded.

By running this script, we should aways expect to be able to test out the full flow.

## Testing

Run against a local stack (`npm run db:seed` must have run first — the script needs `user@example.com`):

```bash
npx tsx scripts/seed-advisory-environment.ts
```

The script asserts its own invariants and exits non-zero if any fail: zero notifications, one baseline `Issue` per `DeviceGroupMatching` per CVE, zero asset-level issues, and exactly two exception notes on exactly the two intended hosts.

Quick checks:

- **Clean run** — 3 syngo.plaza assets / 1 matching, 11 deserialization assets / 18 matchings; baseline issues equal matchings for both CVEs.
- **Idempotency** — three consecutive runs produce identical row counts across assets, device groups, matchings, notes, remediations, issues, and notifications.
- **Matching resolution**, using the real `matchingAppliesToDeviceGroup`: every seeded asset is reachable from its matching, including both `vers:generic/…` ranges (MAGNETOM → 3, syngo.via → 2, SOMATOM go.Top → 1).
- **Contamination** — ran `seed-notifications.ts` first to leave its note on `pacs-syngo-02`, confirmed teardown removes it and exactly the two intended notes remain. Without this, DOC 1 would return two `NOT_AFFECTED` hosts.

Results:
<img width="1282" height="162" alt="Screenshot 2026-07-29 at 3 53 39 PM" src="https://github.com/user-attachments/assets/575b9a2e-e9a2-46f7-9ee3-19e28f66ae43" />

<img width="1394" height="447" alt="Screenshot 2026-07-29 at 3 51 08 PM" src="https://github.com/user-attachments/assets/4659cce5-a21d-4b66-bcb8-e04270a71ae4" />

<img width="1278" height="1572" alt="Screenshot 2026-07-29 at 3 51 01 PM" src="https://github.com/user-attachments/assets/136b49a2-a37e-47fe-b079-b11d384d3971" />


**Note**:
- This works for [this doc]:https://drive.google.com/file/d/1St0d8Q3w6FeYzAyxCDWb5smD5_aQCu9H/view
- Not work for [this doc]:https://drive.google.com/file/d/16d-hLOfWqm6L-sG9aMnW3oADuSu5ESBE/view
^ this due to the agent can't not extract machines or fixes out of the doc. 



[VW-396]: https://northeastern-patch.atlassian.net/browse/VW-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ