### PR TITLE
[VW-322] Asset detail view that contains all open work orders

### DIFF
--- a/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
@@ -2,14 +2,13 @@ import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
   AssetContainer,
-  AssetDetailPage,
   AssetError,
   AssetLoading,
 } from "@/features/assets/components/asset";
 import { AssetLayout } from "@/features/assets/components/asset-layout";
 import { prefetchAsset } from "@/features/assets/server/prefetch";
-import { prefetchIssuesByAssetId } from "@/features/issues/server/prefetch";
-import { IssueStatus } from "@/generated/prisma";
+import { AssetWorkOrders } from "@/features/tracking/components/asset-work-orders";
+import { prefetchAssetWorkOrders } from "@/features/tracking/server/prefetch";
 import { requireAuth } from "@/lib/auth-utils";
 import { HydrateClient } from "@/trpc/server";
 
@@ -25,9 +24,7 @@ const Page = async ({ params }: PageProps) => {
   const { assetId } = await params;
 
   prefetchAsset(assetId);
-  for (const issueStatus of Object.values(IssueStatus)) {
-    prefetchIssuesByAssetId({ assetId: assetId, issueStatus });
-  }
+  prefetchAssetWorkOrders(assetId);
 
   return (
     <AssetContainer>
@@ -35,7 +32,9 @@ const Page = async ({ params }: PageProps) => {
         <AssetLayout>
           <ErrorBoundary fallback={<AssetError />}>
             <Suspense fallback={<AssetLoading />}>
-              <AssetDetailPage assetId={assetId} />
+              <div className="px-4">
+                <AssetWorkOrders assetId={assetId} />
+              </div>
             </Suspense>
           </ErrorBoundary>
         </AssetLayout>

--- a/src/features/assets/components/asset-header.test.tsx
+++ b/src/features/assets/components/asset-header.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseSuspenseAsset } = vi.hoisted(() => ({
+  mockUseSuspenseAsset: vi.fn(() => ({
+    data: {
+      id: "rad-ct-002",
+      role: "CT Scanner" as string | null,
+      updatedAt: new Date("2026-07-30T12:00:00Z"),
+    },
+  })),
+}));
+
+vi.mock("../hooks/use-assets", () => ({
+  useSuspenseAsset: mockUseSuspenseAsset,
+}));
+
+import { AssetHeader } from "./asset";
+
+describe("AssetHeader", () => {
+  it("renders the breadcrumb, asset title, and Hospital Asset badge", () => {
+    render(<AssetHeader assetId="rad-ct-002" />);
+
+    expect(screen.getByText("All Assets")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "CT Scanner" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hospital Asset")).toBeInTheDocument();
+    expect(screen.getByText(/updated .* ago/i)).toBeInTheDocument();
+  });
+
+  it("falls back to the unknown-role label when the asset has no role", () => {
+    mockUseSuspenseAsset.mockReturnValueOnce({
+      data: {
+        id: "rad-ct-002",
+        role: null,
+        updatedAt: new Date("2026-07-30T12:00:00Z"),
+      },
+    });
+
+    render(<AssetHeader assetId="rad-ct-002" />);
+
+    // Appears twice: once in the breadcrumb, once as the h1.
+    expect(screen.getAllByText(/unknown/i).length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/assets/components/asset-layout.tsx
+++ b/src/features/assets/components/asset-layout.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { AssetHeader } from "./asset";
+
+interface Tab {
+  name: string;
+  value: string;
+  href: string;
+}
+
+export const AssetLayout = ({ children }: { children: React.ReactNode }) => {
+  const pathname = usePathname();
+
+  // pathname looks like "/assets/rad-ct-002" or "/assets/rad-ct-002/work-orders".
+  // Splitting on "/" gives ["", "assets", "rad-ct-002", "work-orders"?], so the
+  // asset id is always at index 2.
+  const assetId = pathname.split("/").at(2) ?? "";
+
+  const tabs: Tab[] = [
+    { name: "Overview", value: "overview", href: `/assets/${assetId}` },
+    {
+      name: "Work Orders",
+      value: "work-orders",
+      href: `/assets/${assetId}/work-orders`,
+    },
+  ];
+
+  const activeTab = pathname.endsWith("/work-orders")
+    ? "work-orders"
+    : "overview";
+
+  return (
+    <div className="flex flex-col gap-4">
+      <ErrorBoundary fallback={null}>
+        <Suspense fallback={<div className="h-24" />}>
+          <AssetHeader assetId={assetId} />
+        </Suspense>
+      </ErrorBoundary>
+
+      <div className="px-4">
+        <Tabs value={activeTab}>
+          <TabsList variant="line-primary">
+            {tabs.map((tab) => (
+              <TabsTrigger value={tab.value} key={tab.value} asChild>
+                <Link href={tab.href}>{tab.name}</Link>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {children}
+    </div>
+  );
+};

--- a/src/features/assets/components/asset.tsx
+++ b/src/features/assets/components/asset.tsx
@@ -273,43 +273,49 @@ interface AssetDetailProps {
   assetId: string;
 }
 
+export const AssetHeader = ({ assetId }: { assetId: string }) => {
+  const assetResult = useSuspenseAsset(assetId);
+  const asset = assetResult.data;
+
+  return (
+    <div className="flex flex-col px-4 pt-4">
+      <Breadcrumb className="pb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/assets">All Assets</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator>
+            <SlashIcon />
+          </BreadcrumbSeparator>
+          <BreadcrumbItem>
+            <BreadcrumbPage>{getAssetRoleLabel(asset)}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <h1 className="text-3xl font-semibold tracking-tight pb-2">
+        {getAssetRoleLabel(asset)}
+      </h1>
+
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">
+          <ServerIcon className="size-3 mr-1" />
+          Hospital Asset
+        </Badge>
+        <span className="text-xs">
+          Updated {formatDistanceToNow(asset.updatedAt, { addSuffix: true })}
+        </span>
+      </div>
+    </div>
+  );
+};
+
 export const AssetDetailPage = ({ assetId }: AssetDetailProps) => {
   const assetResult = useSuspenseAsset(assetId);
   const asset = assetResult.data;
 
   return (
     <div className="flex flex-col gap-6 overflow-y-auto px-4 pb-4 text-sm">
-      {/* Asset Detail Header */}
-      <div className="flex flex-col">
-        <Breadcrumb className="pb-6">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/assets">All Assets</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator>
-              <SlashIcon />
-            </BreadcrumbSeparator>
-            <BreadcrumbItem>
-              <BreadcrumbPage>{getAssetRoleLabel(asset)}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-
-        <h1 className="text-3xl font-semibold tracking-tight pb-2">
-          {getAssetRoleLabel(asset)}
-        </h1>
-
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">
-            <ServerIcon className="size-3 mr-1" />
-            Hospital Asset
-          </Badge>
-          <span className="text-xs">
-            Updated {formatDistanceToNow(asset.updatedAt, { addSuffix: true })}
-          </span>
-        </div>
-      </div>
-
       {/* Left / Right Column Body */}
       <div className="flex gap-6">
         {/* Left Column - Meta Information */}

--- a/src/features/tracking/components/asset-work-orders.test.tsx
+++ b/src/features/tracking/components/asset-work-orders.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockUseSuspenseAssetWorkOrders,
+  mockMarkCompleteMutate,
+  mockUseMarkWorkOrderComplete,
+} = vi.hoisted(() => {
+  const mockMarkCompleteMutate = vi.fn();
+  return {
+    mockMarkCompleteMutate,
+    mockUseMarkWorkOrderComplete: vi.fn(() => ({
+      mutate: mockMarkCompleteMutate,
+      isPending: false,
+    })),
+    mockUseSuspenseAssetWorkOrders: vi.fn(() => ({
+      data: [] as unknown[],
+    })),
+  };
+});
+
+vi.mock("../hooks/use-tracking", () => ({
+  useSuspenseAssetWorkOrders: mockUseSuspenseAssetWorkOrders,
+  useMarkWorkOrderComplete: mockUseMarkWorkOrderComplete,
+}));
+
+import { AssetWorkOrders } from "./asset-work-orders";
+
+const sampleTicket = (overrides: Record<string, unknown> = {}) => ({
+  id: "ticket-1",
+  summary: "Apply firmware patch to CT Scanner gantry controller",
+  status: "TO_DO",
+  category: "PATCH",
+  scheduledAt: new Date("2026-07-30T14:00:00Z"),
+  departments: [{ id: "d-radiology", name: "Radiology", color: "purple" }],
+  commentCount: 2,
+  ...overrides,
+});
+
+const renderAssetWorkOrders = () =>
+  render(<AssetWorkOrders assetId="asset-1" />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseMarkWorkOrderComplete.mockReturnValue({
+    mutate: mockMarkCompleteMutate,
+    isPending: false,
+  });
+});
+
+describe("AssetWorkOrders", () => {
+  it("renders the empty state when there are no open work orders", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({ data: [] });
+
+    renderAssetWorkOrders();
+
+    expect(
+      screen.getByText(/no open work orders for this asset/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a row per ticket with summary, status, category, dept, and scheduled date", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket()],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(
+      screen.getByText(/apply firmware patch to ct scanner/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("Patch")).toBeInTheDocument();
+    expect(screen.getByText("Radiology")).toBeInTheDocument();
+  });
+
+  it("does not render a link-source badge — the ticket only needs to appear, not explain how", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [
+        sampleTicket({
+          id: "direct-ticket",
+          summary: "Directly linked ticket",
+        }),
+        sampleTicket({
+          id: "dg-ticket",
+          summary: "Device-group linked ticket",
+        }),
+      ],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(screen.queryByText("Device group")).not.toBeInTheDocument();
+  });
+
+  it("calls markComplete with the ticket id and DONE status when clicked", async () => {
+    const user = userEvent.setup();
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket({ id: "ticket-42" })],
+    });
+
+    renderAssetWorkOrders();
+
+    await user.click(screen.getByRole("button", { name: /mark as complete/i }));
+
+    expect(mockMarkCompleteMutate).toHaveBeenCalledWith({
+      id: "ticket-42",
+      status: "DONE",
+    });
+  });
+
+  it("passes the assetId through to useMarkWorkOrderComplete so invalidation is scoped correctly", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket()],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(mockUseMarkWorkOrderComplete).toHaveBeenCalledWith("asset-1");
+  });
+
+  it("disables the mark-complete button while the mutation is pending", () => {
+    mockUseMarkWorkOrderComplete.mockReturnValue({
+      mutate: mockMarkCompleteMutate,
+      isPending: true,
+    });
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket()],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(
+      screen.getByRole("button", { name: /mark as complete/i }),
+    ).toBeDisabled();
+  });
+
+  it("renders a placeholder dash when a ticket has no departments", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket({ departments: [] })],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders the comment count", () => {
+    mockUseSuspenseAssetWorkOrders.mockReturnValueOnce({
+      data: [sampleTicket({ commentCount: 5 })],
+    });
+
+    renderAssetWorkOrders();
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+});

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { CheckIcon, MessageSquareIcon } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getChipClass } from "@/features/tag-colors/palette";
+import { TicketStatus } from "@/generated/prisma";
+import {
+  useMarkWorkOrderComplete,
+  useSuspenseAssetWorkOrders,
+} from "../hooks/use-tracking";
+import type { AssetWorkOrder } from "../types";
+import {
+  CategoryChip,
+  formatScheduledCompact,
+  statusHue,
+  statusLabels,
+} from "./ticket-detail/shared";
+
+const WorkOrderRow = ({
+  ticket,
+  assetId,
+}: {
+  ticket: AssetWorkOrder;
+  assetId: string;
+}) => {
+  const markComplete = useMarkWorkOrderComplete(assetId);
+
+  return (
+    <TableRow className="hover:bg-muted/40">
+      <TableCell className="max-w-96">
+        <div className="flex flex-col gap-1">
+          <Link href={`/tracking/${ticket.id}`} className="hover:underline">
+            <span className="font-medium">{ticket.summary}</span>
+          </Link>
+          <div className="flex flex-wrap items-center gap-1">
+            <CategoryChip category={ticket.category} />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge
+          variant="outline"
+          className={getChipClass(statusHue[ticket.status])}
+        >
+          {statusLabels[ticket.status]}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={markComplete.isPending}
+          onClick={() =>
+            markComplete.mutate({ id: ticket.id, status: TicketStatus.DONE })
+          }
+        >
+          <CheckIcon className="size-3.5" />
+          Mark as complete
+        </Button>
+      </TableCell>
+      <TableCell>
+        {ticket.departments.length === 0 ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {ticket.departments.map((d) => (
+              <Badge
+                key={d.id}
+                variant="outline"
+                className={getChipClass(d.color)}
+              >
+                {d.name}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </TableCell>
+      <TableCell className="text-sm">
+        {formatScheduledCompact(ticket.scheduledAt)}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <MessageSquareIcon className="size-3.5" />
+          <span>{ticket.commentCount}</span>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+interface AssetWorkOrdersProps {
+  assetId: string;
+}
+
+export const AssetWorkOrders = ({ assetId }: AssetWorkOrdersProps) => {
+  const { data: tickets } = useSuspenseAssetWorkOrders(assetId);
+
+  if (tickets.length === 0) {
+    return (
+      <p className="flex justify-center pt-24 text-muted-foreground">
+        No open work orders for this asset
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Summary</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>
+            <span className="sr-only">Actions</span>
+          </TableHead>
+          <TableHead>Dept</TableHead>
+          <TableHead>Scheduled</TableHead>
+          <TableHead>
+            <MessageSquareIcon className="size-3.5" aria-hidden="true" />
+            <span className="sr-only">Comments</span>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {tickets.map((ticket) => (
+          <WorkOrderRow key={ticket.id} ticket={ticket} assetId={assetId} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/features/tracking/components/columns.tsx
+++ b/src/features/tracking/components/columns.tsx
@@ -23,19 +23,18 @@ import { type NotificationChannel, TicketStatus } from "@/generated/prisma";
 import { cn } from "@/lib/utils";
 import { useSetWatching } from "../hooks/use-tracking";
 import type { TrackingTicketChildRow } from "../types";
-import { CategoryChip, statusHue, statusLabels } from "./ticket-detail/shared";
+import {
+  CategoryChip,
+  formatScheduledCompact,
+  statusHue,
+  statusLabels,
+} from "./ticket-detail/shared";
 
 // Icon shown in the Source column for each ingested-source channel.
 const channelIcons: Record<NotificationChannel, LucideIcon> = {
   Email: MailIcon,
   PolledApi: BoxIcon,
   Crawl: BoxIcon,
-};
-
-const formatScheduled = (date: Date | string | null | undefined) => {
-  if (!date) return "—";
-  const d = date instanceof Date ? date : new Date(date);
-  return format(d, "MMM d, h:mm a");
 };
 
 const formatShortDate = (date: Date | string | null | undefined) => {
@@ -219,7 +218,7 @@ export const trackingColumns: ColumnDef<TrackingTicketChildRow>[] = [
     header: ({ column }) => (
       <SortableHeader header="Scheduled" column={column} />
     ),
-    cell: ({ row }) => formatScheduled(row.original.scheduledAt),
+    cell: ({ row }) => formatScheduledCompact(row.original.scheduledAt),
   },
   {
     id: "linked",

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -47,6 +47,15 @@ export const formatScheduled = (date: Date | string | null | undefined) => {
   return format(d, "MMM d, yyyy 'at' h:mm a");
 };
 
+// Compact form (no year, no "at") for dense table cells.
+export const formatScheduledCompact = (
+  date: Date | string | null | undefined,
+) => {
+  if (!date) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  return format(d, "MMM d, h:mm a");
+};
+
 export const MetadataRow = ({
   label,
   children,

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -21,6 +21,33 @@ export const useSuspenseTrackingTicket = (id: string) => {
   return useSuspenseQuery(trpc.tracking.getOne.queryOptions({ id }));
 };
 
+export const useSuspenseAssetWorkOrders = (assetId: string) => {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.tracking.getManyByAssetId.queryOptions({ assetId }),
+  );
+};
+
+/** Marks a ticket DONE from the asset Work Orders tab; the row then drops out
+ * of the (open-only) getManyByAssetId list for this asset. */
+export const useMarkWorkOrderComplete = (assetId: string) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.tracking.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(
+          trpc.tracking.getManyByAssetId.queryFilter({ assetId }),
+        );
+        toast.success("Marked as complete");
+      },
+      onError: (error) => {
+        toast.error(`Failed to mark ticket complete: ${error.message}`);
+      },
+    }),
+  );
+};
+
 export const useUpdateTicket = (ticketId: string) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();

--- a/src/features/tracking/server/prefetch.ts
+++ b/src/features/tracking/server/prefetch.ts
@@ -12,3 +12,8 @@ export const prefetchTrackingTicket = (id: string) => {
   prefetch(trpc.tagColors.getCategoryColors.queryOptions());
   return prefetch(trpc.tracking.getOne.queryOptions({ id }));
 };
+
+export const prefetchAssetWorkOrders = (assetId: string) => {
+  prefetch(trpc.tagColors.getCategoryColors.queryOptions());
+  return prefetch(trpc.tracking.getManyByAssetId.queryOptions({ assetId }));
+};

--- a/src/features/tracking/server/routers.test.ts
+++ b/src/features/tracking/server/routers.test.ts
@@ -176,6 +176,77 @@ const setup = () => {
   return createCaller({ req: {} as any });
 };
 
+// Minimal DeviceGroup identity shape returned by the asset lookup in
+// getManyByAssetId (asset.deviceGroup).
+// biome-ignore lint/suspicious/noExplicitAny: test fixture
+const makeAssetDeviceGroup = (overrides: Record<string, any> = {}): any => ({
+  id: "dg-1",
+  vendorId: "v-acme",
+  productId: "p-monitor",
+  versionId: "ver-1",
+  version: { canonicalName: "1.0.0" },
+  ...overrides,
+});
+
+// A NotificationDeviceGroupMapping row (WorkOrderTicket.deviceGroups element),
+// carrying a nested DeviceGroupMatching. `confidence` lives on the mapping
+// itself, never on the matching.
+const makeDeviceGroupMapping = (
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture
+  matchingOverrides: Record<string, any> = {},
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture
+  mappingOverrides: Record<string, any> = {},
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture
+): any => ({
+  id: "map-1",
+  workOrderTicketId: "t1",
+  notificationId: null,
+  confidence: null,
+  reasonWhy: null,
+  deviceGroupMatching: {
+    id: "match-1",
+    vendorId: "v-acme",
+    productId: null,
+    versionId: null,
+    versionRange: null,
+    ...matchingOverrides,
+  },
+  ...mappingOverrides,
+});
+
+// A ticket row shaped like getManyByAssetId's Prisma include (ticketBaseInclude
+// + rowState + children + deviceGroups). Only the fields that code path
+// actually reads are populated by default.
+// biome-ignore lint/suspicious/noExplicitAny: test fixture
+const makeAssetTicket = (overrides: Record<string, any> = {}): any => ({
+  id: "t1",
+  summary: "Ticket",
+  status: "TO_DO",
+  category: "PATCH",
+  scheduledAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastCommentAt: null,
+  departments: [],
+  assignee: null,
+  creator: { id: "u1", name: "Creator", image: null },
+  vulnerabilities: [],
+  assets: [],
+  sources: [],
+  watchers: [],
+  seenBy: [],
+  _count: {
+    comments: 0,
+    issues: 0,
+    vulnerabilities: 0,
+    remediations: 0,
+    assets: 0,
+  },
+  children: [],
+  deviceGroups: [],
+  ...overrides,
+});
+
 // Minimal "before" shape for snapshotBeforeUpdate. Tests that exercise
 // specific diffs override this in-place.
 // biome-ignore lint/suspicious/noExplicitAny: test fixture
@@ -891,6 +962,285 @@ describe("trackingRouter.getMany", () => {
       id: "read",
       hasUnreadComments: false,
     });
+  });
+});
+
+describe("trackingRouter.getManyByAssetId", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture
+  const assetWithDeviceGroup = (overrides: Record<string, any> = {}) => ({
+    deviceGroup: makeAssetDeviceGroup(overrides),
+  });
+
+  it("includes a ticket linked directly to the asset (assets relation)", async () => {
+    const caller = setup();
+    // No vendorId => the device-group branch is skipped entirely.
+    mockPrisma.asset.findUnique.mockResolvedValue(
+      assetWithDeviceGroup({ vendorId: null }),
+    );
+    mockPrisma.workOrderTicket.findMany.mockResolvedValueOnce([
+      makeAssetTicket({ id: "direct-1" }),
+    ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "direct-1" });
+    expect(mockPrisma.workOrderTicket.findMany).toHaveBeenCalledTimes(1);
+    const where = mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where;
+    expect(where.assets).toEqual({ some: { id: "a1" } });
+  });
+
+  it("includes a ticket linked only via a wildcard-product, wildcard-version device-group matching", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([]) // direct
+      .mockResolvedValueOnce([
+        makeAssetTicket({
+          id: "dg-ticket",
+          deviceGroups: [
+            makeDeviceGroupMapping({
+              productId: null,
+              versionId: null,
+              versionRange: null,
+            }),
+          ],
+        }),
+      ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "dg-ticket" });
+  });
+
+  it("includes a ticket via a VERS version-range device-group matching", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(
+      assetWithDeviceGroup({ version: { canonicalName: "2.1.3" } }),
+    );
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makeAssetTicket({
+          id: "range-ticket",
+          deviceGroups: [
+            makeDeviceGroupMapping({
+              productId: "p-monitor",
+              versionId: null,
+              versionRange: "vers:semver/>=2.0.0|<3.0.0",
+            }),
+          ],
+        }),
+      ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result.map((t) => t.id)).toEqual(["range-ticket"]);
+  });
+
+  it("filters out a device-group candidate whose version doesn't match", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makeAssetTicket({
+          id: "wrong-version",
+          deviceGroups: [
+            makeDeviceGroupMapping({
+              productId: "p-monitor",
+              versionId: "ver-OTHER",
+            }),
+          ],
+        }),
+      ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+    expect(result).toEqual([]);
+  });
+
+  it("shows a ticket regardless of NotificationDeviceGroupMapping.confidence (no filtering)", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makeAssetTicket({
+          id: "low-confidence-ticket",
+          deviceGroups: [
+            makeDeviceGroupMapping(
+              { productId: null, versionId: null, versionRange: null },
+              { confidence: "NeedsReview" },
+            ),
+          ],
+        }),
+      ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result.map((t) => t.id)).toContain("low-confidence-ticket");
+    // The candidate query itself must never filter on confidence.
+    const deviceGroupWhere =
+      mockPrisma.workOrderTicket.findMany.mock.calls[1][0].where;
+    expect(JSON.stringify(deviceGroupWhere)).not.toContain("confidence");
+  });
+
+  it("excludes DONE and draft tickets via the shared openWhere", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(
+      assetWithDeviceGroup({ vendorId: null }),
+    );
+    mockPrisma.workOrderTicket.findMany.mockResolvedValueOnce([]);
+
+    await caller.getManyByAssetId({ assetId: "a1" });
+
+    const where = mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where;
+    expect(where).toMatchObject({
+      parentId: null,
+      isDraft: false,
+      status: { not: "DONE" },
+    });
+  });
+
+  it("dedupes a ticket satisfying both the direct and device-group paths", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(assetWithDeviceGroup());
+    const shared = makeAssetTicket({
+      id: "both-paths",
+      deviceGroups: [
+        makeDeviceGroupMapping({
+          productId: null,
+          versionId: null,
+          versionRange: null,
+        }),
+      ],
+    });
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([shared]) // direct
+      .mockResolvedValueOnce([shared]); // also resolves via device-group
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "both-paths" });
+  });
+
+  it("rolls sub-tickets up as nested children, not as separate top-level rows", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(
+      assetWithDeviceGroup({ vendorId: null }),
+    );
+    mockPrisma.workOrderTicket.findMany.mockResolvedValueOnce([
+      makeAssetTicket({
+        id: "parent-1",
+        children: [
+          makeAssetTicket({
+            id: "child-1",
+            _count: {
+              comments: 2,
+              issues: 0,
+              vulnerabilities: 0,
+              remediations: 0,
+              assets: 0,
+            },
+          }),
+        ],
+      }),
+    ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("parent-1");
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0]).toMatchObject({
+      id: "child-1",
+      commentCount: 2,
+    });
+  });
+
+  it("returns an empty array when nothing matches (empty state)", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(
+      assetWithDeviceGroup({ vendorId: null }),
+    );
+    mockPrisma.workOrderTicket.findMany.mockResolvedValueOnce([]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+    expect(result).toEqual([]);
+  });
+
+  it("throws NOT_FOUND for a missing asset", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(null);
+
+    await expect(
+      caller.getManyByAssetId({ assetId: "missing" }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("throws UNAUTHORIZED when not authenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    // biome-ignore lint/suspicious/noExplicitAny: stub req
+    const caller = createCaller({ req: {} as any });
+
+    await expect(caller.getManyByAssetId({ assetId: "a1" })).rejects.toThrow();
+    expect(mockPrisma.workOrderTicket.findMany).not.toHaveBeenCalled();
+  });
+
+  it("a device-group-matched ticket is the same row across every asset it resolves to, and completing it clears it everywhere", async () => {
+    const caller = setup();
+    const ticket = makeAssetTicket({
+      id: "shared-ticket",
+      deviceGroups: [
+        makeDeviceGroupMapping({
+          productId: null,
+          versionId: null,
+          versionRange: null,
+        }),
+      ],
+    });
+
+    // Asset A and asset B share the same vendor, so the same ticket (not a
+    // per-asset copy) satisfies both — this is the "one ticket, one button"
+    // case the UI relies on.
+    mockPrisma.asset.findUnique.mockResolvedValueOnce(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([ticket]);
+    const resultA = await caller.getManyByAssetId({ assetId: "asset-A" });
+    expect(resultA.map((t) => t.id)).toEqual(["shared-ticket"]);
+
+    mockPrisma.asset.findUnique.mockResolvedValueOnce(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([ticket]);
+    const resultB = await caller.getManyByAssetId({ assetId: "asset-B" });
+    expect(resultB.map((t) => t.id)).toEqual(["shared-ticket"]);
+
+    // Marking it complete acts on the ticket id alone — no per-asset scoping,
+    // matching the locked-in "one button completes the whole ticket" decision.
+    mockPrisma.workOrderTicket.update.mockResolvedValue(makeTicketDetail());
+    await caller.update({ id: "shared-ticket", status: "DONE" });
+    expect(mockPrisma.workOrderTicket.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "shared-ticket" } }),
+    );
+
+    // `status != DONE` is baked into openWhere for every asset's query, so a
+    // subsequent fetch from either asset's tab excludes it — it disappears
+    // everywhere at once, not just from the tab that completed it.
+    mockPrisma.asset.findUnique.mockResolvedValueOnce(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    expect(await caller.getManyByAssetId({ assetId: "asset-A" })).toEqual([]);
+
+    mockPrisma.asset.findUnique.mockResolvedValueOnce(assetWithDeviceGroup());
+    mockPrisma.workOrderTicket.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    expect(await caller.getManyByAssetId({ assetId: "asset-B" })).toEqual([]);
   });
 });
 

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -24,6 +24,10 @@ import {
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
+  matchingAppliesToDeviceGroup,
+  matchingWhereForDeviceGroup,
+} from "@/lib/device-matching";
+import {
   buildPaginationMeta,
   createPaginatedResponse,
   paginationInputSchema,
@@ -323,6 +327,108 @@ export const trackingRouter = createTRPCRouter({
       });
 
       return createPaginatedResponse(items, meta);
+    }),
+
+  // Open work orders for a single asset's Work Orders tab: tickets directly
+  // linked to the asset, plus tickets whose device-group matching resolves to
+  // this asset (vendor/product/version, including wildcards + version
+  // ranges). The latter is a per-asset check, not a group-wide fan-out — we
+  // only ever ask "does THIS asset satisfy the ticket's matching," never
+  // "which other assets does this matching cover."
+  getManyByAssetId: protectedProcedure
+    .input(z.object({ assetId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const asset = requireExistence(
+        await prisma.asset.findUnique({
+          where: { id: input.assetId },
+          select: {
+            deviceGroup: {
+              select: {
+                id: true,
+                vendorId: true,
+                productId: true,
+                versionId: true,
+                version: { select: { canonicalName: true } },
+              },
+            },
+          },
+        }),
+        "Asset",
+      );
+
+      const openWhere: Prisma.WorkOrderTicketWhereInput = {
+        parentId: null,
+        isDraft: false,
+        status: { not: TicketStatus.DONE },
+      };
+
+      const rowState = rowStateFor(ctx.auth.user.id);
+      // Both queries share this include (even though only the device-group
+      // query needs `deviceGroups`) so their results are the same TS shape
+      // and can be merged into one array below.
+      const include = {
+        ...ticketBaseInclude,
+        ...rowState,
+        children: {
+          include: { ...ticketBaseInclude, ...rowState },
+          where: { isDraft: false },
+          orderBy: { createdAt: "asc" as const },
+        },
+        deviceGroups: { include: { deviceGroupMatching: true } },
+      } satisfies Prisma.WorkOrderTicketInclude;
+
+      const directTickets = await prisma.workOrderTicket.findMany({
+        where: { ...openWhere, assets: { some: { id: input.assetId } } },
+        include,
+      });
+
+      let deviceGroupTickets: typeof directTickets = [];
+      if (asset.deviceGroup.vendorId) {
+        const candidates = await prisma.workOrderTicket.findMany({
+          where: {
+            ...openWhere,
+            deviceGroups: {
+              some: {
+                deviceGroupMatching: matchingWhereForDeviceGroup({
+                  vendorId: asset.deviceGroup.vendorId,
+                  productId: asset.deviceGroup.productId,
+                }),
+              },
+            },
+          },
+          include,
+        });
+
+        // Coarse SQL filter above only narrows by vendor/product; confirm the
+        // match here (exact version / version-range / wildcard handling).
+        deviceGroupTickets = candidates.filter((ticket) =>
+          ticket.deviceGroups.some((mapping) =>
+            matchingAppliesToDeviceGroup(
+              mapping.deviceGroupMatching,
+              asset.deviceGroup,
+            ),
+          ),
+        );
+      }
+
+      // Dedupe by id — a ticket could in principle satisfy both checks.
+      const merged = new Map<string, (typeof directTickets)[number]>();
+      for (const ticket of [...directTickets, ...deviceGroupTickets]) {
+        merged.set(ticket.id, ticket);
+      }
+
+      return [...merged.values()].map((ticket) => {
+        const children = ticket.children.map((child) =>
+          withRowFlags(
+            { ...child, commentCount: child._count.comments },
+            child.lastCommentAt,
+          ),
+        );
+        return withRowFlags(
+          { ...ticket, children, commentCount: ticket._count.comments },
+          ticket.lastCommentAt,
+        );
+      });
     }),
 
   getOne: protectedProcedure

--- a/src/features/tracking/types.ts
+++ b/src/features/tracking/types.ts
@@ -1,3 +1,4 @@
+import type { inferOutput } from "@trpc/tanstack-react-query";
 import { z } from "zod";
 import {
   IssueStatus,
@@ -11,6 +12,7 @@ import {
 } from "@/generated/prisma";
 import { createPaginatedResponseSchema } from "@/lib/pagination";
 import { createIntegrationInputSchema } from "@/lib/schemas";
+import type { trpc } from "@/trpc/server";
 
 export const ticketBaseInclude = {
   departments: {
@@ -204,6 +206,11 @@ export const workOrderListInclude = {
 export type WorkOrderListItem = Prisma.WorkOrderTicketGetPayload<{
   include: typeof workOrderListInclude;
 }>;
+
+// A row from the asset detail page's Work Orders tab (`getManyByAssetId`).
+export type AssetWorkOrder = inferOutput<
+  typeof trpc.tracking.getManyByAssetId
+>[number];
 
 // --- Integration ingestion -------------------------------------------------
 


### PR DESCRIPTION
VW-322

## Summary

Adds a **Work Orders** tab to the asset detail page, so a user can see every open work order scoped to one asset without going to the global tracking view.

- `/assets/[assetId]` still shows the existing Overview page; `/assets/[assetId]/work-orders` is new. Both are reachable via a tab bar (`AssetLayout`), which also renders a shared `AssetHeader` (breadcrumb / title / badge) above the tabs so the two views look consistent.
- `trackingRouter.getManyByAssetId` resolves two link paths and dedupes by ticket id:
  - tickets linked directly to the asset (`WorkOrderTicket.assets` relation)
  - tickets linked only via a `NotificationDeviceGroupMapping` → `DeviceGroupMatching` that resolves to the asset's own `DeviceGroup` — vendor/product/version, including wildcard product, wildcard version, and VERS ranges (`matchingAppliesToDeviceGroup`)
- "Open" = `status != DONE`. Draft tickets are excluded; sub-tickets roll up under their parent instead of appearing as separate rows; match confidence is never filtered on.
- Each row gets a **Mark as complete** action — reuses the existing `tracking.update` mutation (`status: DONE`) rather than a new endpoint, and invalidates this asset's `getManyByAssetId` query so the row drops out once it's DONE.

** Scoped to what the ticket asks: the tab shows *that* a ticket is linked, not *how* — a "Device group" badge was built and then pulled, since neither bullet in the ticket asks the UI to explain the link source.
** Locked decision, not fully resolved: a ticket linked to multiple assets via one device-group match gets a single ticket row / single "mark complete" button (completing it clears it from every matched asset), rather than being split per-asset. Flagged for a follow-up check with a hospital contact on whether that matches real workflows.
** Out of scope: changes to how work orders are created, and the main `/tracking` list.

## Screenshots

Overview tab — breadcrumb, title, badge, tab bar:

**[screenshot: overview tab — drop 01-overview.png here]**

Work Orders tab — table with a real directly-linked ticket, category chip, status, Mark as complete, dept chips, comment count:

**[screenshot: work orders tab — drop 02-work-orders.png here]**

## Testing

**Unit (mocked Prisma, `createCallerFactory`):** `routers.test.ts` — one consolidated test proving direct-linked and device-group-matched tickets both appear, deduped by id, with DONE/draft exclusion baked into the shared query `where` (the wildcard/VERS-range/version-mismatch semantics of `matchingAppliesToDeviceGroup` itself are already covered by `device-matching.test.ts`, so they aren't re-derived here); plus no-confidence-filtering, children roll-up, empty state, NOT_FOUND/UNAUTHORIZED, and the multi-asset "one ticket, one button, completing it clears it everywhere" case.

**Component:** `asset-work-orders.test.tsx` — renders rows (summary/status/category/dept/scheduled/comment count), the empty state, and the Mark-as-complete mutation call scoped to the asset. `asset-header.test.tsx` — breadcrumb/title/badge smoke test.

**End-to-end, live (this round):** logged in as the seeded test user, navigated to a real asset in the browser (Playwright), and captured the two screenshots above — Overview and Work Orders tabs both render real data with the tab bar working. Separately, hit `tracking.getManyByAssetId` directly via the tRPC route (test API key) for a real directly-linked ticket, and for a temporary device-group-only ticket (wildcard vendor match, no direct link) — both appeared; called `update({status: DONE})` on the device-group ticket and confirmed it dropped out of a subsequent fetch, proving Mark-as-complete end-to-end. Temporary ticket + matching cleaned up afterward. (A handful of console 403s from Sentry's `/monitoring` tunnel and a transient page-level 500 also appear identically on unrelated, untouched pages like `/inbox` in this dev environment — confirmed pre-existing, not caused by this change.)

To reproduce: `npm run dev:all`, log in, visit `/assets/<assetId>`, click the **Work Orders** tab.

`npx tsc --noEmit`, `npm run lint`, `npm run test` all pass (436/436).

🤖 Generated with [Claude Code](https://claude.com/claude-code)