### PR TITLE
[VW-322] Asset detail view that contains all open work orders

### DIFF
--- a/src/app/(dashboard)/(rest)/assets/[assetId]/layout.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/layout.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import {
+  AssetContainer,
+  AssetError,
+  AssetHeader,
+  AssetLoading,
+} from "@/features/assets/components/asset";
+import { AssetTabs } from "@/features/assets/components/asset-tabs";
+import { prefetchAsset } from "@/features/assets/server/prefetch";
+import { requireAuth } from "@/lib/auth-utils";
+import { HydrateClient } from "@/trpc/server";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ assetId: string }>;
+}
+
+const Layout = async ({ children, params }: LayoutProps) => {
+  await requireAuth();
+
+  const { assetId } = await params;
+  prefetchAsset(assetId);
+
+  return (
+    <AssetContainer>
+      <HydrateClient>
+        <div className="flex flex-col gap-4">
+          <ErrorBoundary fallback={<AssetError />}>
+            <Suspense fallback={<AssetLoading />}>
+              <AssetHeader assetId={assetId} />
+            </Suspense>
+          </ErrorBoundary>
+          <AssetTabs assetId={assetId} />
+          {children}
+        </div>
+      </HydrateClient>
+    </AssetContainer>
+  );
+};
+
+export default Layout;

--- a/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
@@ -1,15 +1,12 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
-  AssetContainer,
   AssetDetailPage,
   AssetError,
   AssetLoading,
 } from "@/features/assets/components/asset";
-import { prefetchAsset } from "@/features/assets/server/prefetch";
 import { prefetchIssuesByAssetId } from "@/features/issues/server/prefetch";
 import { IssueStatus } from "@/generated/prisma";
-import { requireAuth } from "@/lib/auth-utils";
 import { HydrateClient } from "@/trpc/server";
 
 interface PageProps {
@@ -19,26 +16,20 @@ interface PageProps {
 }
 
 const Page = async ({ params }: PageProps) => {
-  await requireAuth();
-
   const { assetId } = await params;
 
-  prefetchAsset(assetId);
-
   for (const issueStatus of Object.values(IssueStatus)) {
-    prefetchIssuesByAssetId({ assetId: assetId, issueStatus });
+    prefetchIssuesByAssetId({ assetId, issueStatus });
   }
 
   return (
-    <AssetContainer>
-      <HydrateClient>
-        <ErrorBoundary fallback={<AssetError />}>
-          <Suspense fallback={<AssetLoading />}>
-            <AssetDetailPage assetId={assetId} />
-          </Suspense>
-        </ErrorBoundary>
-      </HydrateClient>
-    </AssetContainer>
+    <HydrateClient>
+      <ErrorBoundary fallback={<AssetError />}>
+        <Suspense fallback={<AssetLoading />}>
+          <AssetDetailPage assetId={assetId} />
+        </Suspense>
+      </ErrorBoundary>
+    </HydrateClient>
   );
 };
 

--- a/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { AssetWorkOrders } from "@/features/tracking/components/asset-work-orders";
+import {
+  TrackingError,
+  TrackingLoading,
+} from "@/features/tracking/components/tracking";
+import { prefetchAssetWorkOrders } from "@/features/tracking/server/prefetch";
+import { HydrateClient } from "@/trpc/server";
+
+interface PageProps {
+  params: Promise<{
+    assetId: string;
+  }>;
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { assetId } = await params;
+  prefetchAssetWorkOrders(assetId);
+
+  return (
+    <HydrateClient>
+      <ErrorBoundary fallback={<TrackingError />}>
+        <Suspense fallback={<TrackingLoading />}>
+          <div className="px-4">
+            <AssetWorkOrders assetId={assetId} />
+          </div>
+        </Suspense>
+      </ErrorBoundary>
+    </HydrateClient>
+  );
+};
+
+export default Page;

--- a/src/features/assets/components/asset-tabs.tsx
+++ b/src/features/assets/components/asset-tabs.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export const AssetTabs = ({ assetId }: { assetId: string }) => {
+  const pathname = usePathname();
+  const activeTab = pathname.endsWith("/work-orders")
+    ? "work-orders"
+    : "overview";
+
+  return (
+    <div className="px-4">
+      <Tabs value={activeTab}>
+        <TabsList variant="line-primary">
+          <TabsTrigger value="overview" asChild>
+            <Link href={`/assets/${assetId}`}>Overview</Link>
+          </TabsTrigger>
+          <TabsTrigger value="work-orders" asChild>
+            <Link href={`/assets/${assetId}/work-orders`}>Work Orders</Link>
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+};

--- a/src/features/assets/components/asset.tsx
+++ b/src/features/assets/components/asset.tsx
@@ -273,43 +273,49 @@ interface AssetDetailProps {
   assetId: string;
 }
 
+export const AssetHeader = ({ assetId }: { assetId: string }) => {
+  const assetResult = useSuspenseAsset(assetId);
+  const asset = assetResult.data;
+
+  return (
+    <div className="flex flex-col px-4">
+      <Breadcrumb className="pb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/assets">All Assets</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator>
+            <SlashIcon />
+          </BreadcrumbSeparator>
+          <BreadcrumbItem>
+            <BreadcrumbPage>{getAssetRoleLabel(asset)}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <h1 className="text-3xl font-semibold tracking-tight pb-2">
+        {getAssetRoleLabel(asset)}
+      </h1>
+
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">
+          <ServerIcon className="size-3 mr-1" />
+          Hospital Asset
+        </Badge>
+        <span className="text-xs">
+          Updated {formatDistanceToNow(asset.updatedAt, { addSuffix: true })}
+        </span>
+      </div>
+    </div>
+  );
+};
+
 export const AssetDetailPage = ({ assetId }: AssetDetailProps) => {
   const assetResult = useSuspenseAsset(assetId);
   const asset = assetResult.data;
 
   return (
     <div className="flex flex-col gap-6 overflow-y-auto px-4 pb-4 text-sm">
-      {/* Asset Detail Header */}
-      <div className="flex flex-col">
-        <Breadcrumb className="pb-6">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/assets">All Assets</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator>
-              <SlashIcon />
-            </BreadcrumbSeparator>
-            <BreadcrumbItem>
-              <BreadcrumbPage>{getAssetRoleLabel(asset)}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-
-        <h1 className="text-3xl font-semibold tracking-tight pb-2">
-          {getAssetRoleLabel(asset)}
-        </h1>
-
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">
-            <ServerIcon className="size-3 mr-1" />
-            Hospital Asset
-          </Badge>
-          <span className="text-xs">
-            Updated {formatDistanceToNow(asset.updatedAt, { addSuffix: true })}
-          </span>
-        </div>
-      </div>
-
       {/* Left / Right Column Body */}
       <div className="flex gap-6">
         {/* Left Column - Meta Information */}

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -1,30 +1,12 @@
 "use client";
 
-import { CheckIcon, MessageSquareIcon } from "lucide-react";
 import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { CategoryColorProvider } from "@/features/tag-colors/context";
-import { getChipClass } from "@/features/tag-colors/palette";
 import { TicketStatus } from "@/generated/prisma";
 import {
   useSuspenseAssetWorkOrders,
   useUpdateTicket,
 } from "../hooks/use-tracking";
-import {
-  CategoryChip,
-  formatScheduled,
-  statusHue,
-  statusLabels,
-} from "./ticket-detail/shared";
 
 const MarkCompleteButton = ({ ticketId }: { ticketId: string }) => {
   const update = useUpdateTicket(ticketId);
@@ -36,7 +18,6 @@ const MarkCompleteButton = ({ ticketId }: { ticketId: string }) => {
       disabled={update.isPending}
       onClick={() => update.mutate({ id: ticketId, status: TicketStatus.DONE })}
     >
-      <CheckIcon className="size-3.5" />
       Mark as complete
     </Button>
   );
@@ -54,78 +35,21 @@ export const AssetWorkOrders = ({ assetId }: { assetId: string }) => {
   }
 
   return (
-    <CategoryColorProvider>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Summary</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>
-              <span className="sr-only">Actions</span>
-            </TableHead>
-            <TableHead>Dept</TableHead>
-            <TableHead>Scheduled</TableHead>
-            <TableHead>
-              <MessageSquareIcon className="size-3.5" aria-hidden="true" />
-              <span className="sr-only">Comments</span>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {tickets.map((ticket) => (
-            <TableRow key={ticket.id} className="hover:bg-muted/40">
-              <TableCell className="max-w-96">
-                <div className="flex flex-col gap-1">
-                  <Link
-                    href={`/tracking/${ticket.id}`}
-                    className="font-medium hover:underline"
-                  >
-                    {ticket.summary}
-                  </Link>
-                  <CategoryChip category={ticket.category} />
-                </div>
-              </TableCell>
-              <TableCell>
-                <Badge
-                  variant="outline"
-                  className={getChipClass(statusHue[ticket.status])}
-                >
-                  {statusLabels[ticket.status]}
-                </Badge>
-              </TableCell>
-              <TableCell>
-                <MarkCompleteButton ticketId={ticket.id} />
-              </TableCell>
-              <TableCell>
-                {ticket.departments.length === 0 ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  <div className="flex flex-wrap gap-1">
-                    {ticket.departments.map((department) => (
-                      <Badge
-                        key={department.id}
-                        variant="outline"
-                        className={getChipClass(department.color)}
-                      >
-                        {department.name}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-              </TableCell>
-              <TableCell className="text-sm">
-                {formatScheduled(ticket.scheduledAt) ?? "—"}
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-1 text-muted-foreground">
-                  <MessageSquareIcon className="size-3.5" />
-                  <span>{ticket.commentCount}</span>
-                </div>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </CategoryColorProvider>
+    <ul className="divide-y rounded-md border">
+      {tickets.map((ticket) => (
+        <li
+          key={ticket.id}
+          className="flex items-center justify-between gap-4 p-3"
+        >
+          <Link
+            href={`/tracking/${ticket.id}`}
+            className="font-medium hover:underline"
+          >
+            {ticket.summary}
+          </Link>
+          <MarkCompleteButton ticketId={ticket.id} />
+        </li>
+      ))}
+    </ul>
   );
 };

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -12,11 +12,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { CategoryColorProvider } from "@/features/tag-colors/context";
-import { TicketStatus } from "@/generated/prisma";
 import {
   useSuspenseAssetWorkOrders,
   useUpdateTicket,
-} from "`@/features/tracking/hooks/use-tracking`";
+} from "@/features/tracking/hooks/use-tracking";
+import { TicketStatus } from "@/generated/prisma";
 import {
   CategoryChip,
   DepartmentChips,

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -16,7 +16,7 @@ import { TicketStatus } from "@/generated/prisma";
 import {
   useSuspenseAssetWorkOrders,
   useUpdateTicket,
-} from "../hooks/use-tracking";
+} from "`@/features/tracking/hooks/use-tracking`";
 import {
   CategoryChip,
   DepartmentChips,

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -1,12 +1,28 @@
 "use client";
 
+import { CheckIcon, MessageSquareIcon } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CategoryColorProvider } from "@/features/tag-colors/context";
 import { TicketStatus } from "@/generated/prisma";
 import {
   useSuspenseAssetWorkOrders,
   useUpdateTicket,
 } from "../hooks/use-tracking";
+import {
+  CategoryChip,
+  DepartmentChips,
+  formatScheduled,
+  StatusChip,
+} from "./ticket-detail/shared";
 
 const MarkCompleteButton = ({ ticketId }: { ticketId: string }) => {
   const update = useUpdateTicket(ticketId);
@@ -18,6 +34,7 @@ const MarkCompleteButton = ({ ticketId }: { ticketId: string }) => {
       disabled={update.isPending}
       onClick={() => update.mutate({ id: ticketId, status: TicketStatus.DONE })}
     >
+      <CheckIcon className="size-3.5" />
       Mark as complete
     </Button>
   );
@@ -35,21 +52,59 @@ export const AssetWorkOrders = ({ assetId }: { assetId: string }) => {
   }
 
   return (
-    <ul className="divide-y rounded-md border">
-      {tickets.map((ticket) => (
-        <li
-          key={ticket.id}
-          className="flex items-center justify-between gap-4 p-3"
-        >
-          <Link
-            href={`/tracking/${ticket.id}`}
-            className="font-medium hover:underline"
-          >
-            {ticket.summary}
-          </Link>
-          <MarkCompleteButton ticketId={ticket.id} />
-        </li>
-      ))}
-    </ul>
+    <CategoryColorProvider>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Summary</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>
+              <span className="sr-only">Actions</span>
+            </TableHead>
+            <TableHead>Dept</TableHead>
+            <TableHead>Scheduled</TableHead>
+            <TableHead>
+              <MessageSquareIcon className="size-3.5" aria-hidden="true" />
+              <span className="sr-only">Comments</span>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tickets.map((ticket) => (
+            <TableRow key={ticket.id} className="hover:bg-muted/40">
+              <TableCell className="max-w-96">
+                <div className="flex flex-col gap-1">
+                  <Link
+                    href={`/tracking/${ticket.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {ticket.summary}
+                  </Link>
+                  <CategoryChip category={ticket.category} />
+                </div>
+              </TableCell>
+              <TableCell>
+                <StatusChip status={ticket.status} />
+              </TableCell>
+              <TableCell>
+                <MarkCompleteButton ticketId={ticket.id} />
+              </TableCell>
+              <TableCell>
+                <DepartmentChips departments={ticket.departments} />
+              </TableCell>
+              <TableCell className="text-sm">
+                {formatScheduled(ticket.scheduledAt) ?? "—"}
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-1 text-muted-foreground">
+                  <MessageSquareIcon className="size-3.5" />
+                  <span>{ticket.commentCount}</span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </CategoryColorProvider>
   );
 };

--- a/src/features/tracking/components/asset-work-orders.tsx
+++ b/src/features/tracking/components/asset-work-orders.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { CheckIcon, MessageSquareIcon } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CategoryColorProvider } from "@/features/tag-colors/context";
+import { getChipClass } from "@/features/tag-colors/palette";
+import { TicketStatus } from "@/generated/prisma";
+import {
+  useSuspenseAssetWorkOrders,
+  useUpdateTicket,
+} from "../hooks/use-tracking";
+import {
+  CategoryChip,
+  formatScheduled,
+  statusHue,
+  statusLabels,
+} from "./ticket-detail/shared";
+
+const MarkCompleteButton = ({ ticketId }: { ticketId: string }) => {
+  const update = useUpdateTicket(ticketId);
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={update.isPending}
+      onClick={() => update.mutate({ id: ticketId, status: TicketStatus.DONE })}
+    >
+      <CheckIcon className="size-3.5" />
+      Mark as complete
+    </Button>
+  );
+};
+
+export const AssetWorkOrders = ({ assetId }: { assetId: string }) => {
+  const { data: tickets } = useSuspenseAssetWorkOrders(assetId);
+
+  if (tickets.length === 0) {
+    return (
+      <p className="flex justify-center pt-24 text-muted-foreground">
+        No open work orders for this asset
+      </p>
+    );
+  }
+
+  return (
+    <CategoryColorProvider>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Summary</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>
+              <span className="sr-only">Actions</span>
+            </TableHead>
+            <TableHead>Dept</TableHead>
+            <TableHead>Scheduled</TableHead>
+            <TableHead>
+              <MessageSquareIcon className="size-3.5" aria-hidden="true" />
+              <span className="sr-only">Comments</span>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tickets.map((ticket) => (
+            <TableRow key={ticket.id} className="hover:bg-muted/40">
+              <TableCell className="max-w-96">
+                <div className="flex flex-col gap-1">
+                  <Link
+                    href={`/tracking/${ticket.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {ticket.summary}
+                  </Link>
+                  <CategoryChip category={ticket.category} />
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge
+                  variant="outline"
+                  className={getChipClass(statusHue[ticket.status])}
+                >
+                  {statusLabels[ticket.status]}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <MarkCompleteButton ticketId={ticket.id} />
+              </TableCell>
+              <TableCell>
+                {ticket.departments.length === 0 ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : (
+                  <div className="flex flex-wrap gap-1">
+                    {ticket.departments.map((department) => (
+                      <Badge
+                        key={department.id}
+                        variant="outline"
+                        className={getChipClass(department.color)}
+                      >
+                        {department.name}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </TableCell>
+              <TableCell className="text-sm">
+                {formatScheduled(ticket.scheduledAt) ?? "—"}
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-1 text-muted-foreground">
+                  <MessageSquareIcon className="size-3.5" />
+                  <span>{ticket.commentCount}</span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </CategoryColorProvider>
+  );
+};

--- a/src/features/tracking/components/columns.tsx
+++ b/src/features/tracking/components/columns.tsx
@@ -18,12 +18,15 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
-import { getChipClass } from "@/features/tag-colors/palette";
 import { type NotificationChannel, TicketStatus } from "@/generated/prisma";
 import { cn } from "@/lib/utils";
 import { useSetWatching } from "../hooks/use-tracking";
 import type { TrackingTicketChildRow } from "../types";
-import { CategoryChip, statusHue, statusLabels } from "./ticket-detail/shared";
+import {
+  CategoryChip,
+  DepartmentChips,
+  StatusChip,
+} from "./ticket-detail/shared";
 
 // Icon shown in the Source column for each ingested-source channel.
 const channelIcons: Record<NotificationChannel, LucideIcon> = {
@@ -170,14 +173,7 @@ export const trackingColumns: ColumnDef<TrackingTicketChildRow>[] = [
     id: "status",
     accessorKey: "status",
     header: "Status",
-    cell: ({ row }) => (
-      <Badge
-        variant="outline"
-        className={getChipClass(statusHue[row.original.status])}
-      >
-        {statusLabels[row.original.status]}
-      </Badge>
-    ),
+    cell: ({ row }) => <StatusChip status={row.original.status} />,
   },
   {
     id: "category",
@@ -188,24 +184,9 @@ export const trackingColumns: ColumnDef<TrackingTicketChildRow>[] = [
   {
     id: "dept",
     header: "Dept",
-    cell: ({ row }) => {
-      const depts = row.original.departments;
-      if (!depts || depts.length === 0)
-        return <span className="text-muted-foreground">—</span>;
-      return (
-        <div className="flex flex-wrap gap-1">
-          {depts.map((d) => (
-            <Badge
-              key={d.id}
-              variant="outline"
-              className={getChipClass(d.color)}
-            >
-              {d.name}
-            </Badge>
-          ))}
-        </div>
-      );
-    },
+    cell: ({ row }) => (
+      <DepartmentChips departments={row.original.departments} />
+    ),
   },
   {
     id: "assignee",

--- a/src/features/tracking/components/ticket-detail/index.tsx
+++ b/src/features/tracking/components/ticket-detail/index.tsx
@@ -39,6 +39,7 @@ import { TicketEditForm } from "./edit-form";
 import { LinkedAssetsTabContent } from "./linked-assets";
 import {
   CategoryChip,
+  DepartmentChips,
   formatDate,
   formatScheduled,
   MetadataRow,
@@ -149,21 +150,7 @@ export const TicketDetailContent = ({ id }: { id: string }) => {
               </div>
             </MetadataRow>
             <MetadataRow label="Departments">
-              {data.departments.length > 0 ? (
-                <div className="flex flex-wrap gap-1">
-                  {data.departments.map((d) => (
-                    <Badge
-                      key={d.id}
-                      variant="outline"
-                      className={getChipClass(d.color)}
-                    >
-                      {d.name}
-                    </Badge>
-                  ))}
-                </div>
-              ) : (
-                <span className="text-sm text-muted-foreground">—</span>
-              )}
+              <DepartmentChips departments={data.departments} />
             </MetadataRow>
             <MetadataRow label="Scheduled for">
               <div className="flex items-center gap-1.5 text-sm">

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -22,6 +22,12 @@ export const statusHue: Record<TicketStatus, string> = {
   DONE: "green",
 };
 
+export const StatusChip = ({ status }: { status: TicketStatus }) => (
+  <Badge variant="outline" className={getChipClass(statusHue[status])}>
+    {statusLabels[status]}
+  </Badge>
+);
+
 export const categoryLabels: Record<TicketCategory, string> = {
   PATCH: "Patch",
   CONFIG_CHANGE: "Config Change",
@@ -68,6 +74,30 @@ export const CategoryChip = ({ category }: { category: TicketCategory }) => {
     <Badge variant="outline" className={getChipClass(color)}>
       {categoryLabels[category]}
     </Badge>
+  );
+};
+
+export const DepartmentChips = ({
+  departments,
+}: {
+  departments: { id: string; name: string; color: string | null }[];
+}) => {
+  if (departments.length === 0) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {departments.map((department) => (
+        <Badge
+          key={department.id}
+          variant="outline"
+          className={getChipClass(department.color)}
+        >
+          {department.name}
+        </Badge>
+      ))}
+    </div>
   );
 };
 

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -21,6 +21,13 @@ export const useSuspenseTrackingTicket = (id: string) => {
   return useSuspenseQuery(trpc.tracking.getOne.queryOptions({ id }));
 };
 
+export const useSuspenseAssetWorkOrders = (assetId: string) => {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.tracking.getManyByAssetId.queryOptions({ assetId }),
+  );
+};
+
 export const useUpdateTicket = (ticketId: string) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -31,6 +38,9 @@ export const useUpdateTicket = (ticketId: string) => {
           trpc.tracking.getOne.queryFilter({ id: ticketId }),
         );
         queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
+        queryClient.invalidateQueries(
+          trpc.tracking.getManyByAssetId.queryFilter(),
+        );
         toast.success("Ticket updated");
       },
       onError: (error) => {

--- a/src/features/tracking/server/prefetch.ts
+++ b/src/features/tracking/server/prefetch.ts
@@ -14,6 +14,5 @@ export const prefetchTrackingTicket = (id: string) => {
 };
 
 export const prefetchAssetWorkOrders = (assetId: string) => {
-  prefetch(trpc.tagColors.getCategoryColors.queryOptions());
   return prefetch(trpc.tracking.getManyByAssetId.queryOptions({ assetId }));
 };

--- a/src/features/tracking/server/prefetch.ts
+++ b/src/features/tracking/server/prefetch.ts
@@ -14,5 +14,6 @@ export const prefetchTrackingTicket = (id: string) => {
 };
 
 export const prefetchAssetWorkOrders = (assetId: string) => {
+  prefetch(trpc.tagColors.getCategoryColors.queryOptions());
   return prefetch(trpc.tracking.getManyByAssetId.queryOptions({ assetId }));
 };

--- a/src/features/tracking/server/prefetch.ts
+++ b/src/features/tracking/server/prefetch.ts
@@ -12,3 +12,8 @@ export const prefetchTrackingTicket = (id: string) => {
   prefetch(trpc.tagColors.getCategoryColors.queryOptions());
   return prefetch(trpc.tracking.getOne.queryOptions({ id }));
 };
+
+export const prefetchAssetWorkOrders = (assetId: string) => {
+  prefetch(trpc.tagColors.getCategoryColors.queryOptions());
+  return prefetch(trpc.tracking.getManyByAssetId.queryOptions({ assetId }));
+};

--- a/src/features/tracking/server/routers.test.ts
+++ b/src/features/tracking/server/routers.test.ts
@@ -908,8 +908,13 @@ describe("trackingRouter.getManyByAssetId", () => {
     });
     const ticket = {
       summary: "Ticket",
+      status: "TO_DO",
+      category: "OTHER",
+      scheduledAt: null,
+      departments: [],
       assets: [],
       deviceGroups: [],
+      _count: { comments: 0 },
     };
     const matching = {
       deviceGroupMatching: {

--- a/src/features/tracking/server/routers.test.ts
+++ b/src/features/tracking/server/routers.test.ts
@@ -908,13 +908,8 @@ describe("trackingRouter.getManyByAssetId", () => {
     });
     const ticket = {
       summary: "Ticket",
-      status: "TO_DO",
-      category: "OTHER",
-      scheduledAt: null,
-      departments: [],
       assets: [],
       deviceGroups: [],
-      _count: { comments: 0 },
     };
     const matching = {
       deviceGroupMatching: {

--- a/src/features/tracking/server/routers.test.ts
+++ b/src/features/tracking/server/routers.test.ts
@@ -894,6 +894,78 @@ describe("trackingRouter.getMany", () => {
   });
 });
 
+describe("trackingRouter.getManyByAssetId", () => {
+  it("returns direct and device-group-matched open work orders", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue({
+      deviceGroup: {
+        id: "dg-1",
+        vendorId: "vendor-1",
+        productId: "product-1",
+        versionId: "version-1",
+        version: { canonicalName: "1.0.0" },
+      },
+    });
+    const ticket = {
+      summary: "Ticket",
+      status: "TO_DO",
+      category: "OTHER",
+      scheduledAt: null,
+      departments: [],
+      assets: [],
+      deviceGroups: [],
+      _count: { comments: 0 },
+    };
+    const matching = {
+      deviceGroupMatching: {
+        vendorId: "vendor-1",
+        productId: "product-1",
+        versionId: "version-1",
+        versionRange: null,
+      },
+    };
+    mockPrisma.workOrderTicket.findMany.mockResolvedValue([
+      { ...ticket, id: "direct", assets: [{ id: "a1" }] },
+      { ...ticket, id: "matched", deviceGroups: [matching] },
+      {
+        ...ticket,
+        id: "unmatched",
+        deviceGroups: [
+          {
+            deviceGroupMatching: {
+              ...matching.deviceGroupMatching,
+              versionId: "version-2",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await caller.getManyByAssetId({ assetId: "a1" });
+
+    expect(result.map(({ id }) => id)).toEqual(["direct", "matched"]);
+    expect(mockPrisma.workOrderTicket.findMany).toHaveBeenCalledOnce();
+    expect(
+      mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where,
+    ).toMatchObject({
+      isDraft: false,
+      status: { not: "DONE" },
+    });
+    expect(
+      mockPrisma.workOrderTicket.findMany.mock.calls[0][0].where,
+    ).not.toHaveProperty("parentId");
+  });
+
+  it("throws NOT_FOUND for a missing asset", async () => {
+    const caller = setup();
+    mockPrisma.asset.findUnique.mockResolvedValue(null);
+
+    await expect(
+      caller.getManyByAssetId({ assetId: "missing" }),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
 describe("trackingRouter.markSeen", () => {
   it("upserts a TicketSeen row for (current user, ticket)", async () => {
     const caller = setup();

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -375,13 +375,6 @@ export const trackingRouter = createTRPCRouter({
         select: {
           id: true,
           summary: true,
-          status: true,
-          category: true,
-          scheduledAt: true,
-          departments: {
-            select: { id: true, name: true, color: true },
-            orderBy: { name: "asc" },
-          },
           assets: {
             where: { id: input.assetId },
             select: { id: true },
@@ -389,7 +382,6 @@ export const trackingRouter = createTRPCRouter({
           deviceGroups: {
             select: { deviceGroupMatching: true },
           },
-          _count: { select: { comments: true } },
         },
         orderBy: { updatedAt: "desc" },
       });
@@ -408,11 +400,6 @@ export const trackingRouter = createTRPCRouter({
         .map((ticket) => ({
           id: ticket.id,
           summary: ticket.summary,
-          status: ticket.status,
-          category: ticket.category,
-          scheduledAt: ticket.scheduledAt,
-          departments: ticket.departments,
-          commentCount: ticket._count.comments,
         }));
     }),
 

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -24,6 +24,10 @@ import {
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
+  matchingAppliesToDeviceGroup,
+  matchingWhereForDeviceGroup,
+} from "@/lib/device-matching";
+import {
   buildPaginationMeta,
   createPaginatedResponse,
   paginationInputSchema,
@@ -323,6 +327,93 @@ export const trackingRouter = createTRPCRouter({
       });
 
       return createPaginatedResponse(items, meta);
+    }),
+
+  getManyByAssetId: protectedProcedure
+    .input(z.object({ assetId: z.string() }))
+    .query(async ({ input }) => {
+      const asset = requireExistence(
+        await prisma.asset.findUnique({
+          where: { id: input.assetId },
+          select: {
+            deviceGroup: {
+              select: {
+                id: true,
+                vendorId: true,
+                productId: true,
+                versionId: true,
+                version: { select: { canonicalName: true } },
+              },
+            },
+          },
+        }),
+        "Asset",
+      );
+
+      const candidates: Prisma.WorkOrderTicketWhereInput[] = [
+        { assets: { some: { id: input.assetId } } },
+      ];
+      if (asset.deviceGroup.vendorId) {
+        candidates.push({
+          deviceGroups: {
+            some: {
+              deviceGroupMatching: matchingWhereForDeviceGroup({
+                vendorId: asset.deviceGroup.vendorId,
+                productId: asset.deviceGroup.productId,
+              }),
+            },
+          },
+        });
+      }
+
+      const tickets = await prisma.workOrderTicket.findMany({
+        where: {
+          isDraft: false,
+          status: { not: TicketStatus.DONE },
+          OR: candidates,
+        },
+        select: {
+          id: true,
+          summary: true,
+          status: true,
+          category: true,
+          scheduledAt: true,
+          departments: {
+            select: { id: true, name: true, color: true },
+            orderBy: { name: "asc" },
+          },
+          assets: {
+            where: { id: input.assetId },
+            select: { id: true },
+          },
+          deviceGroups: {
+            select: { deviceGroupMatching: true },
+          },
+          _count: { select: { comments: true } },
+        },
+        orderBy: { updatedAt: "desc" },
+      });
+
+      return tickets
+        .filter(
+          (ticket) =>
+            ticket.assets.length > 0 ||
+            ticket.deviceGroups.some((mapping) =>
+              matchingAppliesToDeviceGroup(
+                mapping.deviceGroupMatching,
+                asset.deviceGroup,
+              ),
+            ),
+        )
+        .map((ticket) => ({
+          id: ticket.id,
+          summary: ticket.summary,
+          status: ticket.status,
+          category: ticket.category,
+          scheduledAt: ticket.scheduledAt,
+          departments: ticket.departments,
+          commentCount: ticket._count.comments,
+        }));
     }),
 
   getOne: protectedProcedure

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -375,6 +375,13 @@ export const trackingRouter = createTRPCRouter({
         select: {
           id: true,
           summary: true,
+          status: true,
+          category: true,
+          scheduledAt: true,
+          departments: {
+            select: { id: true, name: true, color: true },
+            orderBy: { name: "asc" },
+          },
           assets: {
             where: { id: input.assetId },
             select: { id: true },
@@ -382,6 +389,7 @@ export const trackingRouter = createTRPCRouter({
           deviceGroups: {
             select: { deviceGroupMatching: true },
           },
+          _count: { select: { comments: true } },
         },
         orderBy: { updatedAt: "desc" },
       });
@@ -400,6 +408,11 @@ export const trackingRouter = createTRPCRouter({
         .map((ticket) => ({
           id: ticket.id,
           summary: ticket.summary,
+          status: ticket.status,
+          category: ticket.category,
+          scheduledAt: ticket.scheduledAt,
+          departments: ticket.departments,
+          commentCount: ticket._count.comments,
         }));
     }),
 


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-322

## Summary

- Adds a Work Orders tab to the asset detail page (`/assets/[assetId]/work-orders`), following the same route-based tab pattern as `/connectors/[resourceTypeUrl]` (layout.tsx + tab bar over sibling pages)
- Lists open work orders linked directly to the asset, or indirectly via device-group matching (reuses `matchingAppliesToDeviceGroup`, not rewritten)
- Each row supports marking the ticket complete from the tab

Overview tab

![Overview tab](https://github.com/user-attachments/assets/aa1558bc-2d13-456a-a073-976644a79a42)

Work Orders tab

<img width="1512" height="768" alt="image" src="https://github.com/user-attachments/assets/99f826fa-3b46-4f38-a4c7-becb7f30b53f" />


Work Orders tab (no open orders)

![Work Orders tab empty state](https://github.com/user-attachments/assets/0a8fdd91-bab2-4dda-84b6-c961798a07b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added an asset Work Orders page with loading and error handling.
* Added Overview and Work Orders navigation tabs.
* Added a work-order table showing status, category, department, schedule, and comments.
* Added options to mark work orders as completed.
* Enhanced asset pages with clearer headers and updated asset information.

## Bug Fixes
* Work orders now refresh automatically after ticket updates.
* Improved filtering to show only relevant open work orders.
* Standardized status and department badges across ticket views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->