### PR TITLE
[VW-373] Vendor Email template frontend and api (1/3)

### DIFF
--- a/src/features/inbox/components/notification-detail.tsx
+++ b/src/features/inbox/components/notification-detail.tsx
@@ -22,7 +22,10 @@ import {
 } from "@/components/ui/hover-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSuspenseMitigationPlans } from "@/features/mitigation/hooks/use-mitigation";
-import { useSuspenseQuestionsByNotificationId } from "@/features/questions/hooks/use-questions";
+import {
+  useSuspenseQuestionsByNotificationId,
+  useSuspenseSuggestedEmailsByNotificationId,
+} from "@/features/questions/hooks/use-questions";
 import { CategoryColorProvider } from "@/features/tag-colors/context";
 import type { NotificationType, Priority } from "@/generated/prisma";
 import {
@@ -146,9 +149,17 @@ export const NotificationDetailPage = ({ id }: { id: string }) => {
   const { data: questions } = useSuspenseQuestionsByNotificationId(
     notification.id,
   );
+  const { data: suggestedEmails } = useSuspenseSuggestedEmailsByNotificationId(
+    notification.id,
+  );
+  const emailsCount = suggestedEmails.filter(
+    (email) => email.status === "DRAFT",
+  ).length;
+
   const pendingQuestionCount = questions.filter(
     (q) => q.status === "PENDING",
   ).length;
+  const questionTabCount = pendingQuestionCount + emailsCount;
 
   const tabs = (
     [
@@ -201,12 +212,12 @@ export const NotificationDetailPage = ({ id }: { id: string }) => {
         trigger: (
           <>
             Questions{" "}
-            {pendingQuestionCount > 0 && (
+            {questionTabCount > 0 && (
               <Badge
                 variant="destructive"
                 className="rounded-full border-orange-200/80 bg-orange-50/80 dark:border-orange-900/70 dark:bg-orange-950/40"
               >
-                {pendingQuestionCount}
+                {questionTabCount}
               </Badge>
             )}
           </>

--- a/src/features/inbox/components/notification-questions-tab.tsx
+++ b/src/features/inbox/components/notification-questions-tab.tsx
@@ -2,11 +2,11 @@
 
 import { CheckCircle2, MessageSquareText } from "lucide-react";
 import { QuestionCard } from "@/features/questions/components/question-card";
+import { SuggestedEmailCard } from "@/features/questions/components/suggested-vendor-email-card";
 import {
   useSuspenseQuestionsByNotificationId,
   useSuspenseSuggestedEmailsByNotificationId,
 } from "@/features/questions/hooks/use-questions";
-import { SuggestedEmailCard } from "@/features/questions/components/suggested-vendor-email-card";
 
 export function NotificationQuestionTab({
   notificationId,

--- a/src/features/inbox/components/notification-questions-tab.tsx
+++ b/src/features/inbox/components/notification-questions-tab.tsx
@@ -2,8 +2,11 @@
 
 import { CheckCircle2, MessageSquareText } from "lucide-react";
 import { QuestionCard } from "@/features/questions/components/question-card";
-import { useSuspenseQuestionsByNotificationId } from "@/features/questions/hooks/use-questions";
-import { groupQuestionChains } from "@/features/questions/types";
+import {
+  useSuspenseQuestionsByNotificationId,
+  useSuspenseSuggestedEmailsByNotificationId,
+} from "@/features/questions/hooks/use-questions";
+import { SuggestedEmailCard } from "@/features/questions/components/suggested-vendor-email-card";
 
 export function NotificationQuestionTab({
   notificationId,
@@ -13,17 +16,27 @@ export function NotificationQuestionTab({
   const { data: questions } =
     useSuspenseQuestionsByNotificationId(notificationId);
 
-  if (questions.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        No questions for this notification
-      </p>
-    );
-  }
+  const { data: suggestedEmails } =
+    useSuspenseSuggestedEmailsByNotificationId(notificationId);
+
+  const handleApprove = () => {
+    console.log("Approve the draft and send email");
+  };
+  const handleDismiss = () => {
+    console.log("Approve the draft and send email");
+  };
 
   const pending = questions.filter((q) => q.status === "PENDING");
+  const emails = suggestedEmails.filter((email) => email.status === "DRAFT");
 
-  if (pending.length === 0) {
+  if (pending.length === 0 && emails.length === 0) {
+    if (questions.length === 0 && suggestedEmails.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          No questions for this notification
+        </p>
+      );
+    }
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <CheckCircle2 className="size-4" />
@@ -32,15 +45,27 @@ export function NotificationQuestionTab({
     );
   }
 
+  const bannerText: string[] = [];
+  if (pending.length > 0) {
+    bannerText.push(
+      `${pending.length} question${pending.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (emails.length > 0) {
+    bannerText.push(
+      `${emails.length} suggested vendor email${emails.length === 1 ? "" : "s"}`,
+    );
+  }
+  const fullText = bannerText.join(" and ");
+
   return (
     <div className="flex flex-col gap-4">
-      {pending.length > 0 && (
+      {(pending.length > 0 || emails.length > 0) && (
         <div className="flex items-start gap-2 rounded-md border bg-muted/50 p-4 text-sm rounded-xl border-orange-200/80 bg-orange-50/80 dark:border-orange-900/70 dark:bg-orange-950/40">
           <MessageSquareText className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
           <p>
             <span className="font-semibold">
-              {pending.length} question{pending.length === 1 ? "" : "s"} can
-              sharpen this assessment.
+              {fullText} can sharpen this assessment.
             </span>{" "}
             <span className="text-sm text-muted-foreground">
               Answer what you know, or send a clarification request to the
@@ -52,6 +77,16 @@ export function NotificationQuestionTab({
       {pending.map((q) => (
         <QuestionCard key={q.id} question={q} />
       ))}
+      {false &&
+        emails.map((email) => (
+          <SuggestedEmailCard
+            key={email.id}
+            email={email}
+            isSending={false}
+            onApprove={handleApprove}
+            onDismiss={handleDismiss}
+          />
+        ))}
     </div>
   );
 }

--- a/src/features/questions/components/suggested-vendor-email-card.tsx
+++ b/src/features/questions/components/suggested-vendor-email-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+import { Copy, Info, Mail, Send } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { SuggestedVendorEmail } from "../types";
+
+export const SuggestedEmailCard = ({
+  email,
+  onApprove,
+  onDismiss,
+  isSending = false,
+}: {
+  email: SuggestedVendorEmail;
+  onApprove: () => void;
+  onDismiss: () => void;
+  isSending: boolean;
+}) => {
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(`${email.subject}\n\n&{email.body}`);
+    toast.success("Email text copied");
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row flex-wrap items-center gap-2 pb-2">
+        <Mail className="size-4 text-blue-600" />
+        <span className="text-xs font-bold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+          Suggested vendor email
+        </span>
+        <Badge
+          variant="secondary"
+          className="border-blue-500/30 bg-blue-500/15 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/25 dark:text-blue-300"
+        >
+          {email.companyName}
+        </Badge>
+        <Badge variant="secondary">{email.productName}</Badge>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <p className="flex items-start gap-1.5 text-sm text-muted-foreground">
+          <Info className="size-3.5 mt-0.5 shrink-0" />
+          <span className="font-bold text-foreground whitespace-nowrap">
+            Why send this:
+          </span>
+          {email.reasonWhy}
+        </p>
+        <div className="rounded border">
+          <div className="flex flex-col gap-1 text-sm border-b bg-muted/50 p-3">
+            <div className="flex gap-2">
+              <span className="w-16 shrink-0 text-muted-foreground">To</span>
+              <span className="font-mono">{email.toEmail}</span>
+            </div>
+            <div className="flex gap-2">
+              <span className="w-16 shrink-0 text-muted-foreground">
+                Subject
+              </span>
+              <span className="font-bold">{email.subject}</span>
+            </div>
+          </div>
+          <p className="whitespace-pre-line text-sm text-muted-foreground px-3 py-4">
+            {email.body}
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            className="rounded"
+            variant="outline"
+            onClick={onDismiss}
+            disabled={isSending}
+          >
+            Dismiss
+          </Button>
+          <Button
+            className="rounded"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={isSending}
+          >
+            <Copy className="size-4" />
+            <span className="font-bold">Copy text</span>
+          </Button>
+          <Button className="rounded" onClick={onApprove} disabled={isSending}>
+            <Send className="size-4" />
+            {isSending ? "Sending..." : "Approve & Send"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/features/questions/components/suggested-vendor-email-card.tsx
+++ b/src/features/questions/components/suggested-vendor-email-card.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { handleCopy } from "@/lib/copy";
 import type { SuggestedVendorEmail } from "../types";
 
 export const SuggestedEmailCard = ({
@@ -17,9 +18,8 @@ export const SuggestedEmailCard = ({
   onDismiss: () => void;
   isSending: boolean;
 }) => {
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(`${email.subject}\n\n&{email.body}`);
-    toast.success("Email text copied");
+  const onhandleClickCopy = async () => {
+    await handleCopy(`${email.body}`, () => toast.success("Email text copied"));
   };
 
   return (
@@ -74,7 +74,7 @@ export const SuggestedEmailCard = ({
           <Button
             className="rounded"
             variant="outline"
-            onClick={handleCopy}
+            onClick={onhandleClickCopy}
             disabled={isSending}
           >
             <Copy className="size-4" />

--- a/src/features/questions/hooks/use-questions.ts
+++ b/src/features/questions/hooks/use-questions.ts
@@ -47,3 +47,14 @@ export function useRespondToQuestion() {
     }),
   );
 }
+
+export function useSuspenseSuggestedEmailsByNotificationId(
+  notificationId: string,
+) {
+  const trpc = useTRPC();
+  return useSuspenseQuery(
+    trpc.questions.getSuggestedEmailByNotificationId.queryOptions({
+      notificationId,
+    }),
+  );
+}

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -4,7 +4,27 @@ import { inngest } from "@/inngest/client";
 import prisma from "@/lib/db";
 import { renderQnA } from "@/lib/markdown/note";
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
-import { questionInclude } from "../types";
+import { questionInclude, type SuggestedVendorEmail } from "../types";
+import { SuggestedEmailCard } from "../components/suggested-vendor-email-card";
+import { SuggestedQuestionsProvider } from "@/features/chat/context/suggested-questions-context";
+
+// TODO for testing only, wire with real DB later with dummy body text
+const MOCK_EMAIL: SuggestedVendorEmail[] = [
+  {
+    id: "email-1",
+    questionId: "qustion-1",
+    audience: "MANUFACTURER",
+    companyName: "Siemens Healthineers",
+    productName: "SOMATOM go.All",
+    reasonWhy:
+      "The advisory doesn't help Viper confirm the running version on the go.All. A written confirmation from Siemens (or an SRS query) would let Viper move this asset out of 'potentially at risk' with confidence.",
+    toEmail: "productcert@siemens-healthineers.com",
+    subject:
+      "Version confirmation - SOMATOM go.All exposure to SSA-220609 (CVE-2022-29875)",
+    body: `Hello Siemens Healthineers ProductCERT,\n\n We are scoping remediation for....\n\n\ We operate... `,
+    status: "DRAFT",
+  },
+];
 
 export const questionsRouter = createTRPCRouter({
   getManyByNotificationId: protectedProcedure
@@ -117,4 +137,8 @@ export const questionsRouter = createTRPCRouter({
 
       return { status };
     }),
+
+  getSuggestedEmailByNotificationId: protectedProcedure
+    .input(z.object({ notificationId: z.string() }))
+    .query((): SuggestedVendorEmail[] => MOCK_EMAIL)
 });

--- a/src/features/questions/server/routers.ts
+++ b/src/features/questions/server/routers.ts
@@ -5,8 +5,6 @@ import prisma from "@/lib/db";
 import { renderQnA } from "@/lib/markdown/note";
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { questionInclude, type SuggestedVendorEmail } from "../types";
-import { SuggestedEmailCard } from "../components/suggested-vendor-email-card";
-import { SuggestedQuestionsProvider } from "@/features/chat/context/suggested-questions-context";
 
 // TODO for testing only, wire with real DB later with dummy body text
 const MOCK_EMAIL: SuggestedVendorEmail[] = [
@@ -140,5 +138,5 @@ export const questionsRouter = createTRPCRouter({
 
   getSuggestedEmailByNotificationId: protectedProcedure
     .input(z.object({ notificationId: z.string() }))
-    .query((): SuggestedVendorEmail[] => MOCK_EMAIL)
+    .query((): SuggestedVendorEmail[] => MOCK_EMAIL),
 });

--- a/src/features/questions/types.ts
+++ b/src/features/questions/types.ts
@@ -1,5 +1,18 @@
 import type { Prisma } from "@/generated/prisma";
 
+export type SuggestedVendorEmail = {
+  id: string;
+  questionId: string;
+  audience: "VENDOR" | "MANUFACTURER";
+  companyName: string;
+  productName: string;
+  reasonWhy: string;
+  toEmail: string;
+  subject: string;
+  body: string;
+  status: "DRAFT" | "SENT" | "FAILED" | "RESPONDED" | "DISMISSED";
+};
+
 export const questionInclude = {
   issue: {
     include: {


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-414 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Suggested vendor emails now appear alongside questions in notification details.
  - Questions tab badges and banners include pending questions and draft email suggestions.
  - Added email cards with recipient, subject, message content, company/product details, and rationale.
  - Users can copy email content or dismiss suggestions; approval and sending are not yet available.
- **Bug Fixes**
  - Empty-state messaging now accounts for both pending questions and suggested emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Light mode
<img width="1392" height="921" alt="lightmode-email" src="https://github.com/user-attachments/assets/080dc40b-1f0d-4b45-982a-93cb2748fb65" />

### dark mode
<img width="1454" height="915" alt="darkmode-email" src="https://github.com/user-attachments/assets/af384f96-230a-4acf-b382-8c1236019bf1" />
