### PR TITLE
[VW-404] Modal appears with suggested work order ticket, if any present

### DIFF
--- a/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
@@ -6,8 +6,6 @@ import {
   AssetLoading,
 } from "@/features/assets/components/asset";
 import { prefetchIssuesByAssetId } from "@/features/issues/server/prefetch";
-import { SuggestedWorkOrderModal } from "@/features/tracking/components/suggested-work-order-modal";
-import { prefetchAssetWorkOrders } from "@/features/tracking/server/prefetch";
 import { IssueStatus } from "@/generated/prisma";
 import { HydrateClient } from "@/trpc/server";
 
@@ -23,13 +21,11 @@ const Page = async ({ params }: PageProps) => {
   for (const issueStatus of Object.values(IssueStatus)) {
     prefetchIssuesByAssetId({ assetId, issueStatus });
   }
-  prefetchAssetWorkOrders(assetId);
 
   return (
     <HydrateClient>
       <ErrorBoundary fallback={<AssetError />}>
         <Suspense fallback={<AssetLoading />}>
-          <SuggestedWorkOrderModal assetId={assetId} />
           <AssetDetailPage assetId={assetId} />
         </Suspense>
       </ErrorBoundary>

--- a/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/page.tsx
@@ -6,6 +6,8 @@ import {
   AssetLoading,
 } from "@/features/assets/components/asset";
 import { prefetchIssuesByAssetId } from "@/features/issues/server/prefetch";
+import { SuggestedWorkOrderModal } from "@/features/tracking/components/suggested-work-order-modal";
+import { prefetchAssetWorkOrders } from "@/features/tracking/server/prefetch";
 import { IssueStatus } from "@/generated/prisma";
 import { HydrateClient } from "@/trpc/server";
 
@@ -21,11 +23,13 @@ const Page = async ({ params }: PageProps) => {
   for (const issueStatus of Object.values(IssueStatus)) {
     prefetchIssuesByAssetId({ assetId, issueStatus });
   }
+  prefetchAssetWorkOrders(assetId);
 
   return (
     <HydrateClient>
       <ErrorBoundary fallback={<AssetError />}>
         <Suspense fallback={<AssetLoading />}>
+          <SuggestedWorkOrderModal assetId={assetId} />
           <AssetDetailPage assetId={assetId} />
         </Suspense>
       </ErrorBoundary>

--- a/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
+++ b/src/app/(dashboard)/(rest)/assets/[assetId]/work-orders/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { AssetWorkOrders } from "@/features/tracking/components/asset-work-orders";
+import { SuggestedWorkOrderModal } from "@/features/tracking/components/suggested-work-order-modal";
 import {
   TrackingError,
   TrackingLoading,
@@ -22,6 +23,7 @@ const Page = async ({ params }: PageProps) => {
     <HydrateClient>
       <ErrorBoundary fallback={<TrackingError />}>
         <Suspense fallback={<TrackingLoading />}>
+          <SuggestedWorkOrderModal assetId={assetId} />
           <div className="px-4">
             <AssetWorkOrders assetId={assetId} />
           </div>

--- a/src/features/tracking/components/suggested-work-order-modal.test.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockMutate, mockUseSuspenseAssetWorkOrders } = vi.hoisted(() => ({
   mockMutate: vi.fn(),
@@ -17,6 +17,7 @@ import { SuggestedWorkOrderModal } from "./suggested-work-order-modal";
 beforeEach(() => {
   vi.clearAllMocks();
 });
+afterEach(() => vi.useRealTimers());
 
 const HOUR_MS = 60 * 60 * 1000;
 const hoursFromNow = (hours: number) => new Date(Date.now() + hours * HOUR_MS);
@@ -42,6 +43,17 @@ const renderModal = (tickets: Ticket[]) => {
 };
 
 describe("SuggestedWorkOrderModal", () => {
+  it.each([-48, 48])(
+    "includes a ticket scheduled exactly %i hours from now",
+    (hours) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-03T12:00:00Z"));
+      renderModal([makeTicket({ scheduledAt: hoursFromNow(hours) })]);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    },
+  );
+
   it("ignores unscheduled tickets and tickets outside the 2-day window", () => {
     renderModal([
       makeTicket({ scheduledAt: null }),

--- a/src/features/tracking/components/suggested-work-order-modal.test.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockMutate, mockUseSuspenseAssetWorkOrders } = vi.hoisted(() => ({
   mockMutate: vi.fn(),
@@ -17,7 +17,6 @@ import { SuggestedWorkOrderModal } from "./suggested-work-order-modal";
 beforeEach(() => {
   vi.clearAllMocks();
 });
-afterEach(() => vi.useRealTimers());
 
 const HOUR_MS = 60 * 60 * 1000;
 const hoursFromNow = (hours: number) => new Date(Date.now() + hours * HOUR_MS);
@@ -43,17 +42,6 @@ const renderModal = (tickets: Ticket[]) => {
 };
 
 describe("SuggestedWorkOrderModal", () => {
-  it.each([-48, 48])(
-    "includes a ticket scheduled exactly %i hours from now",
-    (hours) => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-08-03T12:00:00Z"));
-      renderModal([makeTicket({ scheduledAt: hoursFromNow(hours) })]);
-
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    },
-  );
-
   it("ignores unscheduled tickets and tickets outside the 2-day window", () => {
     renderModal([
       makeTicket({ scheduledAt: null }),

--- a/src/features/tracking/components/suggested-work-order-modal.test.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.test.tsx
@@ -28,6 +28,7 @@ type Ticket = ReturnType<
 const makeTicket = (overrides: Partial<Ticket> = {}): Ticket => ({
   id: "t1",
   summary: "Patch ICU monitor",
+  body: null,
   status: "TO_DO",
   category: "PATCH",
   scheduledAt: new Date(),
@@ -60,6 +61,7 @@ describe("SuggestedWorkOrderModal", () => {
       }),
       makeTicket({
         summary: "Past work order",
+        body: "Routine coolant filter swap.",
         scheduledAt: hoursFromNow(-1),
       }),
     ]);
@@ -70,6 +72,9 @@ describe("SuggestedWorkOrderModal", () => {
     expect(screen.getByText("Past work order")).toBeInTheDocument();
     expect(screen.queryByText("Future work order")).not.toBeInTheDocument();
     expect(screen.getByText("Biomed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Routine coolant filter swap."),
+    ).toBeInTheDocument();
   });
 
   it("dismisses without mutating when 'No' is clicked", async () => {

--- a/src/features/tracking/components/suggested-work-order-modal.test.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockMutate, mockUseSuspenseAssetWorkOrders } = vi.hoisted(() => ({
+  mockMutate: vi.fn(),
+  mockUseSuspenseAssetWorkOrders: vi.fn(),
+}));
+
+vi.mock("../hooks/use-tracking", () => ({
+  useUpdateTicket: () => ({ mutate: mockMutate, isPending: false }),
+  useSuspenseAssetWorkOrders: mockUseSuspenseAssetWorkOrders,
+}));
+
+import { SuggestedWorkOrderModal } from "./suggested-work-order-modal";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const HOUR_MS = 60 * 60 * 1000;
+const hoursFromNow = (hours: number) => new Date(Date.now() + hours * HOUR_MS);
+
+type Ticket = ReturnType<
+  typeof import("../hooks/use-tracking").useSuspenseAssetWorkOrders
+>["data"][number];
+
+const makeTicket = (overrides: Partial<Ticket> = {}): Ticket => ({
+  id: "t1",
+  summary: "Patch ICU monitor",
+  status: "TO_DO",
+  category: "PATCH",
+  scheduledAt: new Date(),
+  departments: [{ id: "d1", name: "Biomed", color: "green" }],
+  commentCount: 0,
+  ...overrides,
+});
+
+const renderModal = (tickets: Ticket[]) => {
+  mockUseSuspenseAssetWorkOrders.mockReturnValue({ data: tickets });
+  render(<SuggestedWorkOrderModal assetId="asset-1" />);
+};
+
+describe("SuggestedWorkOrderModal", () => {
+  it("ignores unscheduled tickets and tickets outside the 2-day window", () => {
+    renderModal([
+      makeTicket({ scheduledAt: null }),
+      makeTicket({ scheduledAt: hoursFromNow(49) }),
+      makeTicket({ scheduledAt: hoursFromNow(-49) }),
+    ]);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the closest eligible ticket with its details", () => {
+    renderModal([
+      makeTicket({
+        summary: "Future work order",
+        scheduledAt: hoursFromNow(40),
+      }),
+      makeTicket({
+        summary: "Past work order",
+        scheduledAt: hoursFromNow(-1),
+      }),
+    ]);
+
+    expect(
+      screen.getByText(/are you completing this work order/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Past work order")).toBeInTheDocument();
+    expect(screen.queryByText("Future work order")).not.toBeInTheDocument();
+    expect(screen.getByText("Biomed")).toBeInTheDocument();
+  });
+
+  it("dismisses without mutating when 'No' is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal([makeTicket()]);
+
+    await user.click(screen.getByRole("button", { name: /^no$/i }));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("marks the ticket DONE and closes when 'Yes' is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal([makeTicket({ id: "ticket-9" })]);
+
+    await user.click(screen.getByRole("button", { name: /^yes$/i }));
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [payload, opts] = mockMutate.mock.calls[0];
+    expect(payload).toEqual({ id: "ticket-9", status: "DONE" });
+
+    act(opts.onSuccess);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/tracking/components/suggested-work-order-modal.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -75,14 +76,19 @@ export const SuggestedWorkOrderModal = ({ assetId }: { assetId: string }) => {
             <Badge variant="outline">{categoryLabels[ticket.category]}</Badge>
             <DepartmentChips departments={ticket.departments} />
           </div>
+          {ticket.body && (
+            <p className="line-clamp-2 text-sm text-muted-foreground">
+              {ticket.body}
+            </p>
+          )}
           <div className="text-sm text-muted-foreground">
             Scheduled {formatScheduled(ticket.scheduledAt)}
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)}>
-            No
-          </Button>
+          <DialogClose asChild>
+            <Button variant="outline">No</Button>
+          </DialogClose>
           <Button onClick={complete} disabled={update.isPending}>
             Yes
           </Button>

--- a/src/features/tracking/components/suggested-work-order-modal.tsx
+++ b/src/features/tracking/components/suggested-work-order-modal.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TicketStatus } from "@/generated/prisma";
+import {
+  useSuspenseAssetWorkOrders,
+  useUpdateTicket,
+} from "../hooks/use-tracking";
+import {
+  categoryLabels,
+  DepartmentChips,
+  formatScheduled,
+  StatusChip,
+} from "./ticket-detail/shared";
+
+type Ticket = ReturnType<typeof useSuspenseAssetWorkOrders>["data"][number];
+
+const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
+
+const findSuggested = (tickets: Ticket[]): Ticket | null => {
+  const now = Date.now();
+  let suggested: Ticket | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const ticket of tickets) {
+    if (!ticket.scheduledAt) continue;
+    const distance = Math.abs(ticket.scheduledAt.getTime() - now);
+    if (distance > TWO_DAYS_MS || distance >= closestDistance) continue;
+    suggested = ticket;
+    closestDistance = distance;
+  }
+
+  return suggested;
+};
+
+export const SuggestedWorkOrderModal = ({ assetId }: { assetId: string }) => {
+  const { data: tickets } = useSuspenseAssetWorkOrders(assetId);
+  const ticket = findSuggested(tickets);
+  const update = useUpdateTicket(ticket?.id ?? "");
+  const [open, setOpen] = useState(true);
+
+  if (!ticket) return null;
+
+  const complete = () =>
+    update.mutate(
+      { id: ticket.id, status: TicketStatus.DONE },
+      { onSuccess: () => setOpen(false) },
+    );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Are you completing this work order?</DialogTitle>
+          <DialogDescription>
+            This ticket is scheduled within two days of now.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 rounded-lg border p-4">
+          <div className="flex items-start justify-between gap-2">
+            <span className="font-medium">{ticket.summary}</span>
+            <StatusChip status={ticket.status} />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{categoryLabels[ticket.category]}</Badge>
+            <DepartmentChips departments={ticket.departments} />
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Scheduled {formatScheduled(ticket.scheduledAt)}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            No
+          </Button>
+          <Button onClick={complete} disabled={update.isPending}>
+            Yes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/tracking/server/routers.ts
+++ b/src/features/tracking/server/routers.ts
@@ -375,6 +375,7 @@ export const trackingRouter = createTRPCRouter({
         select: {
           id: true,
           summary: true,
+          body: true,
           status: true,
           category: true,
           scheduledAt: true,
@@ -408,6 +409,7 @@ export const trackingRouter = createTRPCRouter({
         .map((ticket) => ({
           id: ticket.id,
           summary: ticket.summary,
+          body: ticket.body,
           status: ticket.status,
           category: ticket.category,
           scheduledAt: ticket.scheduledAt,


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-404

## Summary

- On load of `/assets/[assetId]`, if there's a work order ticket for this asset that isn't `DONE` and is scheduled within ±2 days of now, show a modal asking "Are you completing this work order?" with the ticket's summary, status, category, department, and scheduled date. If several tickets qualify, the one scheduled closest to now wins.
- "Yes" calls the existing `tracking.update` mutation to set the ticket to `DONE` and closes the modal. "No" just dismisses it 

## Screenshots

Modal appears — eligible ticket found
(ticket scheduled within 2 days, status To Do)
<img width="1429" height="986" alt="image" src="https://github.com/user-attachments/assets/873cb4b4-4bf2-4423-8e19-608b797121de" />



Dismissed via "No" — back to normal Overview
<img width="1512" height="809" alt="Dismissed via No" src="https://github.com/user-attachments/assets/ad7cd117-d4e9-4ca7-86cd-95b9504748fe" />

"Yes" — ticket marked complete, modal doesn't reappear on reload
<img width="1512" height="809" alt="Yes marks ticket done" src="https://github.com/user-attachments/assets/aae351ab-5aea-43ae-bb11-48fd9e721473" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suggested work order dialog to asset work-order pages.
  * Displays the nearest eligible scheduled work order and its details.
  * Allows users to confirm and mark the suggested work order as complete.
  * The dialog only appears when a qualifying work order is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->