### PR TITLE
[VW-391] Paginate vendors.getMany and render the /vendors list

### DIFF
--- a/src/app/(dashboard)/(rest)/vendors/page.tsx
+++ b/src/app/(dashboard)/(rest)/vendors/page.tsx
@@ -1,8 +1,18 @@
-import { requireAuth } from "@/lib/auth-utils";
+import {
+  VendorsContainer,
+  VendorsError,
+  VendorsList,
+  VendorsLoading,
+} from "@/features/vendors/components/vendors";
+import { vendorsParamsLoader } from "@/features/vendors/server/params-loader";
+import { prefetchVendors } from "@/features/vendors/server/prefetch";
+import { createListPage } from "@/lib/page-factory";
 
-const Page = async () => {
-  await requireAuth();
-  return null;
-};
-
-export default Page;
+export default createListPage({
+  paramsLoader: vendorsParamsLoader,
+  prefetch: prefetchVendors,
+  Container: VendorsContainer,
+  List: VendorsList,
+  Loading: VendorsLoading,
+  Error: VendorsError,
+});

--- a/src/features/vendors/components/columns.tsx
+++ b/src/features/vendors/components/columns.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import type { VendorListItem } from "../types";
+
+export const columns: ColumnDef<VendorListItem>[] = [
+  {
+    accessorKey: "canonicalName",
+    meta: { title: "Vendor" },
+    header: "Vendor",
+  },
+  {
+    accessorKey: "assetCount",
+    meta: { title: "Assets" },
+    header: "Assets",
+  },
+];

--- a/src/features/vendors/components/vendors.tsx
+++ b/src/features/vendors/components/vendors.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  EntityContainer,
+  EntityHeader,
+  ErrorView,
+  LoadingView,
+} from "@/components/entity-components";
+import { DataTable } from "@/components/ui/data-table";
+import { useSuspenseVendors } from "../hooks/use-vendors";
+import { columns } from "./columns";
+
+export const VendorsList = () => {
+  const { data, isFetching } = useSuspenseVendors();
+
+  return (
+    <DataTable paginatedData={data} columns={columns} isLoading={isFetching} />
+  );
+};
+
+export const VendorsHeader = () => {
+  return (
+    <EntityHeader
+      title="Vendors"
+      description="Companies the hospital contracts with to service its equipment"
+    />
+  );
+};
+
+export const VendorsContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return (
+    <EntityContainer header={<VendorsHeader />}>{children}</EntityContainer>
+  );
+};
+
+export const VendorsLoading = () => {
+  return <LoadingView message="Loading vendors..." />;
+};
+
+export const VendorsError = () => {
+  return <ErrorView message="Error loading vendors" />;
+};

--- a/src/features/vendors/hooks/use-vendors-params.ts
+++ b/src/features/vendors/hooks/use-vendors-params.ts
@@ -1,4 +1,6 @@
 import { useQueryStates } from "nuqs";
 import { vendorsParams } from "../params";
 
-export const useVendorsParams = () => useQueryStates(vendorsParams);
+export const useVendorsParams = () => {
+  return useQueryStates(vendorsParams);
+};

--- a/src/features/vendors/hooks/use-vendors-params.ts
+++ b/src/features/vendors/hooks/use-vendors-params.ts
@@ -1,0 +1,4 @@
+import { useQueryStates } from "nuqs";
+import { vendorsParams } from "../params";
+
+export const useVendorsParams = () => useQueryStates(vendorsParams);

--- a/src/features/vendors/hooks/use-vendors.ts
+++ b/src/features/vendors/hooks/use-vendors.ts
@@ -1,0 +1,13 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
+import { useVendorsParams } from "./use-vendors-params";
+
+/**
+ * Hook to fetch a page of vendors using suspense
+ */
+export const useSuspenseVendors = () => {
+  const trpc = useTRPC();
+  const [params] = useVendorsParams();
+
+  return useSuspenseQuery(trpc.vendors.getMany.queryOptions(params));
+};

--- a/src/features/vendors/params.ts
+++ b/src/features/vendors/params.ts
@@ -1,0 +1,3 @@
+import { createPaginationParams } from "@/lib/url-state";
+
+export const vendorsParams = createPaginationParams();

--- a/src/features/vendors/server/params-loader.ts
+++ b/src/features/vendors/server/params-loader.ts
@@ -1,0 +1,4 @@
+import { createLoader } from "nuqs/server";
+import { vendorsParams } from "../params";
+
+export const vendorsParamsLoader = createLoader(vendorsParams);

--- a/src/features/vendors/server/prefetch.ts
+++ b/src/features/vendors/server/prefetch.ts
@@ -1,0 +1,11 @@
+import type { inferInput } from "@trpc/tanstack-react-query";
+import { prefetch, trpc } from "@/trpc/server";
+
+type Input = inferInput<typeof trpc.vendors.getMany>;
+
+/**
+ * Prefetch a page of vendors
+ */
+export const prefetchVendors = (params: Input) => {
+  return prefetch(trpc.vendors.getMany.queryOptions(params));
+};

--- a/src/features/vendors/server/routers.test.ts
+++ b/src/features/vendors/server/routers.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 const { mockPrisma, mockGetSession } = vi.hoisted(() => ({
   mockPrisma: {
     vendor: {
+      count: vi.fn(),
       findMany: vi.fn(),
     },
   },
@@ -51,12 +52,23 @@ const setup = () => {
   return createCaller({ req: {} as any });
 };
 
+const PAGE_INPUT = {
+  page: 1,
+  pageSize: 10,
+  search: "",
+  sort: "",
+  lastUpdatedStartTime: "",
+  lastUpdatedEndTime: "",
+} as const;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPrisma.vendor.count.mockResolvedValue(0);
 });
 
 describe("vendorsRouter.getMany", () => {
   it("counts each asset once even when two contracts cover it", async () => {
+    mockPrisma.vendor.count.mockResolvedValue(1);
     mockPrisma.vendor.findMany.mockResolvedValue([
       {
         id: "vendor-1",
@@ -72,9 +84,9 @@ describe("vendorsRouter.getMany", () => {
     ]);
     const caller = setup();
 
-    const result = await caller.getMany();
+    const result = await caller.getMany(PAGE_INPUT);
 
-    expect(result).toEqual([
+    expect(result.items).toEqual([
       {
         id: "vendor-1",
         canonicalName: "siemens healthineers",
@@ -84,6 +96,7 @@ describe("vendorsRouter.getMany", () => {
         assetCount: 3,
       },
     ]);
+    expect(result.totalCount).toBe(1);
   });
 
   it("reports zero for a vendor with no contracts", async () => {
@@ -99,7 +112,9 @@ describe("vendorsRouter.getMany", () => {
     ]);
     const caller = setup();
 
-    const [vendor] = await caller.getMany();
+    const {
+      items: [vendor],
+    } = await caller.getMany(PAGE_INPUT);
 
     expect(vendor.assetCount).toBe(0);
   });
@@ -108,10 +123,24 @@ describe("vendorsRouter.getMany", () => {
     mockPrisma.vendor.findMany.mockResolvedValue([]);
     const caller = setup();
 
-    await caller.getMany();
+    await caller.getMany(PAGE_INPUT);
 
     expect(mockPrisma.vendor.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ orderBy: { canonicalDisplayName: "asc" } }),
     );
+  });
+
+  it("pages through the vendor list", async () => {
+    mockPrisma.vendor.count.mockResolvedValue(25);
+    mockPrisma.vendor.findMany.mockResolvedValue([]);
+    const caller = setup();
+
+    const result = await caller.getMany({ ...PAGE_INPUT, page: 2 });
+
+    expect(mockPrisma.vendor.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 10, take: 10 }),
+    );
+    expect(result.totalPages).toBe(3);
+    expect(result.hasNextPage).toBe(true);
   });
 });

--- a/src/features/vendors/server/routers.test.ts
+++ b/src/features/vendors/server/routers.test.ts
@@ -129,18 +129,4 @@ describe("vendorsRouter.getMany", () => {
       expect.objectContaining({ orderBy: { canonicalDisplayName: "asc" } }),
     );
   });
-
-  it("pages through the vendor list", async () => {
-    mockPrisma.vendor.count.mockResolvedValue(25);
-    mockPrisma.vendor.findMany.mockResolvedValue([]);
-    const caller = setup();
-
-    const result = await caller.getMany({ ...PAGE_INPUT, page: 2 });
-
-    expect(mockPrisma.vendor.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ skip: 10, take: 10 }),
-    );
-    expect(result.totalPages).toBe(3);
-    expect(result.hasNextPage).toBe(true);
-  });
 });

--- a/src/features/vendors/server/routers.ts
+++ b/src/features/vendors/server/routers.ts
@@ -1,27 +1,31 @@
 import "server-only";
 import prisma from "@/lib/db";
+import { paginationInputSchema } from "@/lib/pagination";
+import { fetchPaginated } from "@/lib/router-utils";
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { type VendorListRow, vendorListSelect } from "../types";
 
 export const vendorsRouter = createTRPCRouter({
-  getMany: protectedProcedure.query(async () => {
-    const vendors = await prisma.vendor.findMany({
-      orderBy: { canonicalDisplayName: "asc" },
-      select: {
-        id: true,
-        canonicalName: true,
-        canonicalDisplayName: true,
-        overview: true,
-        partnerSince: true,
-        contracts: { select: { covers: { select: { assetId: true } } } },
-      },
-    });
+  getMany: protectedProcedure
+    .input(paginationInputSchema)
+    .query(async ({ input }) => {
+      const result = await fetchPaginated(prisma.vendor, input, {
+        orderBy: { canonicalDisplayName: "asc" },
+        select: vendorListSelect,
+      });
 
-    return vendors.map(({ contracts, ...vendor }) => ({
-      ...vendor,
-      // Contracts under one vendor may overlap, so the same asset can appear twice.
-      assetCount: new Set(
-        contracts.flatMap((contract) => contract.covers.map((c) => c.assetId)),
-      ).size,
-    }));
-  }),
+      const items = (result.items as VendorListRow[]).map(
+        ({ contracts, ...vendor }) => ({
+          ...vendor,
+          // Contracts under one vendor may overlap, so the same asset can appear twice.
+          assetCount: new Set(
+            contracts.flatMap((contract) =>
+              contract.covers.map((c) => c.assetId),
+            ),
+          ).size,
+        }),
+      );
+
+      return { ...result, items };
+    }),
 });

--- a/src/features/vendors/types.ts
+++ b/src/features/vendors/types.ts
@@ -1,0 +1,20 @@
+import type { inferOutput } from "@trpc/tanstack-react-query";
+import type { Prisma } from "@/generated/prisma";
+import type { trpc } from "@/trpc/server";
+
+export const vendorListSelect = {
+  id: true,
+  canonicalName: true,
+  canonicalDisplayName: true,
+  overview: true,
+  partnerSince: true,
+  contracts: { select: { covers: { select: { assetId: true } } } },
+} satisfies Prisma.VendorSelect;
+
+export type VendorListRow = Prisma.VendorGetPayload<{
+  select: typeof vendorListSelect;
+}>;
+
+export type VendorListItem = inferOutput<
+  typeof trpc.vendors.getMany
+>["items"][number];


### PR DESCRIPTION
[VW-391](https://northeastern-patch.atlassian.net/browse/VW-391)

Follow-up to #204.

## Summary
- Add a Table to /vendors that fetching assets for vendor
- use fetchPaginated

## Testing
<img width="1585" height="1323" alt="Screenshot 2026-08-05 at 11 19 13 AM" src="https://github.com/user-attachments/assets/5b8a2ceb-3b26-4f44-8c17-9aa2be4171f3" />



[VW-391]: https://northeastern-patch.atlassian.net/browse/VW-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paginated vendors list with vendor names and asset counts.
  * Added loading and error states for the vendors page.
  * Added pagination support for browsing vendor results.
  * Vendor results remain ordered by display name, with accurate deduplicated asset counts.

* **Bug Fixes**
  * Updated vendor data handling to include total result counts alongside list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->