### PR TITLE
[VW-393] Create record_note tool for chat agent, allows the system to create/update/delete a note with user chat input 

### DIFF
--- a/src/features/chat/viper-agent/langgraph/chat-graph.ts
+++ b/src/features/chat/viper-agent/langgraph/chat-graph.ts
@@ -66,7 +66,7 @@ Scope it. A fact about one device goes on that asset. A fact covering every devi
 goes on the DEVICE_GROUP_MATCHING, not on one asset.
 
 You do not choose create vs update vs delete, the notes agent does, after reading what already exists.
-Recording is asynchronous, so never tell the user a note was created. Always state in your replay what you recorded,
+Recording is asynchronous, so never tell the user a note was created. Always state in your reply what you recorded,
 in one short sentence (e.g. "I've noted that these ventilators run firmware 3.2").
 The sentence is what carries the fact forward in this conversation.
 `;

--- a/src/features/chat/viper-agent/langgraph/chat-graph.ts
+++ b/src/features/chat/viper-agent/langgraph/chat-graph.ts
@@ -26,6 +26,7 @@ Be concise, accurate, and prioritize patient safety in your recommendations.
 - list_fleet_managed_assets: list the assets Siemens Healthineers services.
 - propose_fleet_work_order: propose a work order on Siemens Healthineers'
   teamplay Fleet platform. Your turn ends here until the user accepts or dismisses.
+- record_note: record a durable fact the user tells you about. Fire and forget, a separate notes agent decides whether it creates, updates or deletes a note.
 </tools>
 
 ## Data access
@@ -49,8 +50,26 @@ tell the user to phone Siemens — those can't be filed online.
 
 ## Notes
 Persistent hospital-wide notes are provided below as context. Treat them as authoritative
-standing facts about this hospital.`;
-// TODO: VW-393: Add new tool for note management
+standing facts about this hospital. Entity-specific notes come back on the records you fetch 
+with query_platform_data, in each record's "notes" array.
+
+## Recording notes
+When the user tells you something durable about their fleet, record it with record_note: 
+fleet composition, configuration or exposure specifics, standing operational constraints,
+or a correction to how a device or vulnerability should be read going forward.
+Do NOT record one-time questions, what you just looked up, or your own analysis.
+
+Check first. If the fact is already in the record's "notes" array or in the hospital-wide notes below,
+say so instead of recording it again. One atomic fact per call, split a message carrying two unrelated facts into two calls.
+
+Scope it. A fact about one device goes on that asset. A fact covering every device of a make/model
+goes on the DEVICE_GROUP_MATCHING, not on one asset.
+
+You do not choose create vs update vs delete, the notes agent does, after reading what already exists.
+Recording is asynchronous, so never tell the user a note was created. Always state in your replay what you recorded,
+in one short sentence (e.g. "I've noted that these ventilators run firmware 3.2").
+The sentence is what carries the fact forward in this conversation.
+`;
 
 function buildSystemPrompt(role: UserRole): string {
   return [

--- a/src/features/chat/viper-agent/langgraph/note-tool.ts
+++ b/src/features/chat/viper-agent/langgraph/note-tool.ts
@@ -6,7 +6,6 @@ import { ChatNoteInput } from "@/features/notes/types";
 import { ScopeTargetModel } from "@/generated/prisma";
 import { requestNoteAction } from "@/inngest/functions/notes-action";
 
-// https://code.claude.com/docs/en/agent-sdk/custom-tools
 export function makeRecordNoteTool(userId: string) {
   return tool(
     async ({ text, targetModel, instanceId }) => {
@@ -31,7 +30,7 @@ export function makeRecordNoteTool(userId: string) {
         input,
       );
       if (!queued) {
-        return `NOT RECORDED. Tell the user their note did not save and to try again in a momment. Do you claim you record anything.`;
+        return `Failed to queue. Nothing was recorded.`;
       }
 
       return [
@@ -42,12 +41,7 @@ export function makeRecordNoteTool(userId: string) {
     },
     {
       name: "record_note",
-      description: `Record a durable fact the user told you about, so it is available to staff and to every later AI run.
-            Use this to record, correct, or retract information. A separate notes agent reads the notes that already exist on the target and decides whether to create a new note, update an existing one, or delete one.
-            Record: fleet composition, configuration or exposure specifics, standing operational constraints, and corrections to how a device or vulnerability should be read going forward.
-            Do NOT record transient chat: one off questions, what you just looked up, or your own analysis.
-            Before calling, check the "notes" array already returned on that record by query_platform_data - if the fact is there, say so instead of recording it again.
-            One atomic fact per call. Recording is asynchronous, so never tell the user a specific note was created, say you have recorded the fact.`,
+      description: `Record a durable fact the user told you about, so it is available to staff and to every later AI run. Use this to record, correct, or retract information. A separate notes agent reads the notes that already exist on the target and decides whether to create a new note, update an existing one, or delete one. Before calling, check the "notes" array already returned on that record by query_platform_data - if the fact is there, say so instead of recording it again.One atomic fact per call. Recording is asynchronous, so never tell the user a specific note was created, say you have recorded the fact.`,
       schema: z.object({
         text: z
           .string()

--- a/src/features/chat/viper-agent/langgraph/note-tool.ts
+++ b/src/features/chat/viper-agent/langgraph/note-tool.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+import { resolveNoteTargetLabel } from "@/features/notes/server/note-targets";
+import { ChatNoteInput } from "@/features/notes/types";
+import { ScopeTargetModel } from "@/generated/prisma";
+import { requestNoteAction } from "@/inngest/functions/notes-action";
+
+// https://code.claude.com/docs/en/agent-sdk/custom-tools
+export function makeRecordNoteTool(userId: string) {
+  return tool(
+    async ({ text, targetModel, instanceId }) => {
+      const statement = text.trim();
+      if (!statement) return "Text was empty";
+
+      const targetLabel = await resolveNoteTargetLabel(targetModel, instanceId);
+      if (!targetLabel) {
+        return `No ${targetModel} exists with id ${instanceId}`;
+      }
+
+      const input: ChatNoteInput = {
+        comment: statement,
+        targetModel,
+        instanceId,
+        userId,
+      };
+
+      await requestNoteAction("CHAT", crypto.randomUUID(), input);
+
+      return [
+        `Queued for ${targetModel}.`,
+        "The notes agent will compare this against the notes already on that target and may update an existing note instead of creating a new one.",
+        "Do not call record_note again for this same fact. State in your reply what you recorded, so it stays on the record for later turn.",
+      ].join(" ");
+    },
+    {
+      name: "record_note",
+      description: `Record a durable fact the user told you about, so it is available to staff and to every later AI run.
+            Use this to record, correct, or retract information. A separate notes agent reads the notes that already exist on the target and decides whether to create a new note, update an existing one, or delete one.
+            Record: fleet composition, configuration or exposure specifics, standing operational constraints, and corrections to how a device or vulnerability should be read going forward.
+            Do NOT record transient chat: one off questions, what you just looked up, or your own analysis.
+            Before calling, check the "notes" array already returned on that record by query_platform_data - if the fact is there, say so instead of recording it again.
+            One atomic fact per call. Recording is asynchronous, so never tell the user a specific note was created, say you have recorded the fact.`,
+      schema: z.object({
+        text: z
+          .string()
+          .describe(
+            "The fact to record, as a standalone statement. A reader six months from now must understand it with no other context: no 'the user said', no reference to this conversation.",
+          ),
+        targetModel: z
+          .enum(ScopeTargetModel)
+          .describe(
+            "Which kind of record this is about. A fact covering every device of a make/model goes on DEVICE_GROUP_MATCHING, not on one ASSET.",
+          ),
+        instanceId: z
+          .string()
+          .describe(
+            "The id of the record, taken from a query_platform_data result. Never invent one.",
+          ),
+      }),
+    },
+  );
+}

--- a/src/features/chat/viper-agent/langgraph/note-tool.ts
+++ b/src/features/chat/viper-agent/langgraph/note-tool.ts
@@ -25,7 +25,14 @@ export function makeRecordNoteTool(userId: string) {
         userId,
       };
 
-      await requestNoteAction("CHAT", crypto.randomUUID(), input);
+      const queued = await requestNoteAction(
+        "CHAT",
+        crypto.randomUUID(),
+        input,
+      );
+      if (!queued) {
+        return `NOT RECORDED. Tell the user their note did not save and to try again in a momment. Do you claim you record anything.`;
+      }
 
       return [
         `Queued for ${targetModel}.`,

--- a/src/features/chat/viper-agent/langgraph/notes-preload.ts
+++ b/src/features/chat/viper-agent/langgraph/notes-preload.ts
@@ -1,6 +1,5 @@
 import "server-only";
 import { getRelevantNotes } from "@/features/notes/server/get-relevant-notes";
-import { type NoteTargetLabels, renderNoteTarget } from "@/lib/markdown/note";
 
 /**
  * Example:

--- a/src/features/chat/viper-agent/langgraph/tools.ts
+++ b/src/features/chat/viper-agent/langgraph/tools.ts
@@ -18,6 +18,7 @@ import {
 } from "@/features/integrations/teamplay-fleet/tracking";
 import { TicketCategory } from "@/generated/prisma";
 import { TOOL_REJECTED_PREFIX } from "./build-graph";
+import { makeRecordNoteTool } from "./note-tool";
 import { makeQueryPlatformDataTool } from "./query-platform-tool";
 
 /** ```viper-ask-user ...``` block the chat UI parses to render question chips. */
@@ -211,5 +212,6 @@ export function buildChatTools(userId: string) {
     askUserQuestions,
     listFleetManagedAssetsTool,
     proposeFleetWorkOrder,
+    makeRecordNoteTool(userId),
   ];
 }

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -61,7 +61,10 @@ function renderQuestionPrompt(args: {
     sections.push(
       "## Notes (evidence)\n\n" +
         args.notes
-          .map((n) => `- **${renderNoteTarget(n, args.labels)}** ${n.text}`)
+          .map((n) => {
+            const target = renderNoteTarget(n, args.labels);
+            return target ? `- **${target}** ${n.text}`: `- ${n.text}`; 
+          })
           .join("\n"),
     );
   }
@@ -102,7 +105,7 @@ function buildNoteLabels(args: {
     matchingLabel: new Map(
       args.matchings.map((matching) => [
         matching.id,
-        deviceGroupMatchingLabel(matching),
+        deviceGroupMatchingLabel(matching) || matching.id,
       ]),
     ),
     cveById: new Map(

--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -6,7 +6,12 @@ import {
   type MatchingLike,
   matchingAppliesToDeviceGroup,
 } from "@/lib/device-matching";
-import { deviceGroupMatchingLabel, type NoteRow } from "@/lib/markdown";
+import {
+  deviceGroupMatchingLabel,
+  type NoteRow,
+  type NoteTargetLabels,
+  renderNoteTarget,
+} from "@/lib/markdown";
 import { renderQnA } from "@/lib/markdown/note";
 
 export type QuestionIssueContext = { issueId: string; vulnerabilityId: string };
@@ -38,6 +43,7 @@ function renderQuestionPrompt(args: {
     statusNotes: string | null;
   }>;
   notes: NoteRow[];
+  labels: NoteTargetLabels;
 }): string {
   const sections: string[] = [];
 
@@ -53,7 +59,10 @@ function renderQuestionPrompt(args: {
 
   if (args.notes.length > 0) {
     sections.push(
-      "## Notes (evidence)\n\n" + args.notes.map((n) => `${n.text}`).join("\n"),
+      "## Notes (evidence)\n\n" +
+        args.notes
+          .map((n) => `- **${renderNoteTarget(n, args.labels)}** ${n.text}`)
+          .join("\n"),
     );
   }
   sections.push(
@@ -73,6 +82,36 @@ function renderQuestionPrompt(args: {
   );
 
   return sections.join("\n\n");
+}
+
+function buildNoteLabels(args: {
+  groups: { assets: { id: string; hostname: string | null; ip: string }[] }[];
+  matchings: MatchingWithRefs[];
+  vulnerabilities: { id: string; cveId: string | null }[];
+}): NoteTargetLabels {
+  return {
+    assetLabel: new Map(
+      args.groups.flatMap((g) =>
+        g.assets.map(
+          (asset) =>
+            [asset.id, asset.hostname ?? asset.ip ?? asset.id] as const,
+        ),
+      ),
+    ),
+    groupLabel: new Map(),
+    matchingLabel: new Map(
+      args.matchings.map((matching) => [
+        matching.id,
+        deviceGroupMatchingLabel(matching),
+      ]),
+    ),
+    cveById: new Map(
+      args.vulnerabilities.map(
+        (vulnerability) =>
+          [vulnerability.id, vulnerability.cveId ?? vulnerability.id] as const,
+      ),
+    ),
+  };
 }
 
 export async function gatherQuestionContext(
@@ -131,7 +170,7 @@ export async function gatherQuestionContext(
             versionId: true,
             version: { select: { canonicalName: true } },
             assets: {
-              select: { id: true },
+              select: { id: true, hostname: true, ip: true },
             },
           },
         })
@@ -189,10 +228,17 @@ export async function gatherQuestionContext(
     assetIds,
   });
 
+  const labels: NoteTargetLabels = buildNoteLabels({
+    groups: candidateGroups,
+    matchings,
+    vulnerabilities,
+  });
+
   const markdown = renderQuestionPrompt({
     vulnerabilities,
     issueRenders,
     notes,
+    labels,
   });
 
   return { notificationId, markdown, issues };
@@ -235,7 +281,7 @@ export async function gatherQuestionContextForIssue(
       productId: true,
       versionId: true,
       version: { select: { canonicalName: true } },
-      assets: { select: { id: true } },
+      assets: { select: { id: true, hostname: true, ip: true } },
     },
   });
 
@@ -250,6 +296,12 @@ export async function gatherQuestionContextForIssue(
     vulnerabilityIds: [issue.vulnerabilityId],
     deviceGroupMatchingIds: [matching.id],
     assetIds,
+  });
+
+  const labels: NoteTargetLabels = buildNoteLabels({
+    groups,
+    matchings: [matching],
+    vulnerabilities: [issue.vulnerability],
   });
 
   const priorQnAText = priorQnA
@@ -269,6 +321,7 @@ export async function gatherQuestionContextForIssue(
         },
       ],
       notes,
+      labels,
     }) +
     "\n\n## Already asked and answered - do not repeat this, ask something more specific\n\n" +
     priorQnAText;

--- a/src/features/notes/agent/noteAction/context.ts
+++ b/src/features/notes/agent/noteAction/context.ts
@@ -36,6 +36,10 @@ function renderNoteActionPrompt(args: {
   const { request, candidates } = args;
   const sections: string[] = [];
 
+  sections.push(
+    "## What this note is about\n\n" +
+      `${request.targetLabel} ${request.target.targetModel}, id: ${request.target.instanceId}`,
+  );
   sections.push(`## The updated note is\n\n${request.updatedText.trim()}`);
 
   sections.push(
@@ -43,11 +47,6 @@ function renderNoteActionPrompt(args: {
       ? "## Existing notes\n\n(none)"
       : "## Existing notes (update or delete these instead of duplicating)\n\n" +
           candidates.map((n) => `- [${n.id} ${n.text}`).join("\n"),
-  );
-
-  sections.push(
-    "## Where a new note will attach\n\n" +
-      `${request.targetLabel} (${request.target.targetModel}, id: ${request.target.instanceId})`,
   );
 
   return sections.join("\n\n");
@@ -68,25 +67,57 @@ export async function gatherNoteActionContext(
 
 // TODO: Agent should have a choice to omit notes, best decision would come from seeing user behavior, VW-393 will have another agent using a tool to record notes
 // https://github.com/PATCH-UPGRADE/viper/pull/194#discussion_r3691510350
-export const SYSTEM_PROMPT = `You maintain a hospital vulnerability-management team's notes about their medice devices, assets, vulnerabilities, and remediations. Notes are the team's durable memory: they can fed back into every later AI run and shown to staff on the asset, vulnerability, and remediation pages. A user has just taken an action and left a comment.
+export const SYSTEM_PROMPT = `You maintain a hospital vulnerability-management team's notes about their medice devices, assets, vulnerabilities,
+and remediations. Notes are the team's durable memory: they are fed into every later AI run and shown to staff on the asset, vulnerability, and
+remediation pages. A user has just taken an action and left a comment. Decide what should change in the notes.
 
-Your job is to record what they told us, do not judge whether a comment is "important enough" and emit note operations. Any claim about a device, vulnerability, or remediation must come from "what the user said". Never invent a technical or clinical claim the user did not make.
+## Your authority
 
-What to record:
-- Facts about the hospital's fleet ("the ward 4 infusion pumps were decomissioned in Q3 2024")
-- Device configuration, deployment, or exposure specifics ("these ventilators run fireware 3.2, not 4.x")
-- Standing operational constraints ("this analyzer can ony be patched during the Sunday 02:00 window")
+Record what the user told you. You do not evaluate whether their claim is correct, whether it matters enough, or whether it fits the team's priorities,
+and their comment is the only source of truth you have. Never invent a technical or clinical claim the user did not make, and never soften, generalize, or embellish one they did.
+
+## What counts as a durable fact
+
+Something still true and still useful to someone reading this record months from now:
+- Fleet composition: e.g. ("the ward 4 infusion pumps were decommissioned in Q3 2024")
+- Device configuration, deployment, or exposure specifics: e.g. ("these ventilators run firmware 3.2, not 4.x")
+- Standing operational constraints: e.g. ("this analyzer can only be patched during the Sunday 02:00 window")
 - Corrections to how a device or vulnerability should be interpreted going forward
 
+Record nothing for:
+- Acknowledgements, thanks, frustration, or commentary carrying no factual claim
+- Questions, or requests for someone to do something
+- Anything about this conversation or the action that produced the comment
+
 Operations:
-- "create" - new information, new fact. Provide "text". Omit "noteId".
-- "update" - an existing note covers this topic and the comment refines, corrects, or extends it. Provide "noteId" from the Existing notes list and the full replacement "text". Prefer this over creating a near-duplicate.
+- "create" - new information, new durable fact no existing notes states. Provide "text". Provide "text". Omit "noteId".
+- "update" - an existing note covers the same attribute and the comment corrects, refines, or extends it. Provide "noteId" from the Existing notes list and the full replacement "text". Prefer this over creating a near-duplicate.
 - "delete" - an existing note is now definitively contradicted or obsolete. Provide "noteId". Refinement is an update, NOT a delete. Only delete when the note would actively mislead a future render.
 
-Rules:
-- Only reference note ids that appear in the Existing notes list. Never invent an id.
-- Write each note as a standalone statement of fact. Do not mention "the user", "this notification", or the action that produced it. A reader six months from now should understand it with no other context.
-- One atomic fact per note. Split a comment carrying two unreleated facts into two creates.
-- Always give a one-sentence "reason" for each op.
-- When in doubt, do less.
+## Avoiding duplicates
+
+Two notes stating the same fact about the same thing is always a defect: both are fed into later AI runs and shown to staff, and
+nothing reconciles them. A duplicate costs more than a missed nuance, so when create and update are both defensible, update.
+
+Work through this in order before emitting any create:
+1. Does an existing note already state this fact, even in different words? => Emit nothing. Do not restate it more precisely, and do not add a second note "for clarity".
+2. Does an existing note state the same attribute with a different or older value? => update that note. This is the usual shape of a correction.
+3. Is a candidate marked "LIKELY THE SAME FACT"? => it is an update or nothing. Never a create.
+4. Does the comment repeat something under "Standing hospital-wide facts"? => Emit nothing. Those already apply everywherel a scoped copy adds noise and will drift out of sync.
+5. Only if none of the above apply => create.
+
+A comment carrying two genuinely unrelated facts becomes two operations. A comment stating one fact in two ways in one operation.
+
+## Writing the text
+
+- Name the subject. A note is stored on its own and is often read detached from the record it hangs off: e.g. "MRI-01 runs firmware 3.2" is usable, "runs firmware 3.2" is not. Take the subject from "What this note is about", and never use a pronoun for the device.
+- Write standalone statement of fact. Do not mention "the user", "the comment", "the notification", or the action that produced it. A reader six months from now should understand it with no other context.
+- One atomic fact per note.
+- Keep the user's specificity. Do not round numbers, generalize a model name, or drop a qualifier.
+
+## Output
+
+- Only reference note ids that appear in Existing notes. Never invent one.
+- Give a one-sentence "reason" for every operation, naming which rule above drove it.
+- When genuinely torn between acting and not acting, do not act.
 `;

--- a/src/features/notes/agent/noteAction/context.ts
+++ b/src/features/notes/agent/noteAction/context.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { ScopedNote } from "@/features/notes/schemas";
 import { getScopedNotesByInstance } from "@/features/notes/server/get-relevant-notes";
 import type { ScopeTargetModel } from "@/generated/prisma";
+import prisma from "@/lib/db";
 
 // current and future create/edit Note Source
 export type NoteActionSource =
@@ -29,12 +30,27 @@ export type NoteActionContext = {
   candidates: ScopedNote[];
 };
 
+async function loadPersistentNoteTexts(): Promise<string[]> {
+  const rows = await prisma.note.findMany({
+    where: { status: "PERSISTENT", deletedAt: null },
+    select: { text: true },
+  });
+  return rows.map((row) => row.text);
+}
+
 function renderNoteActionPrompt(args: {
   request: NoteActionRequest;
   candidates: ScopedNote[];
+  persistent: string[];
 }): string {
-  const { request, candidates } = args;
+  const { request, candidates, persistent } = args;
   const sections: string[] = [];
+
+  if (persistent.length > 0) {
+    sections.push(
+      `## Standing hospital wide facts (already recorded, never created a duplicate of these)\n\n`,
+    ) + persistent.map((perstn) => `- ${perstn}`).join("\n");
+  }
 
   sections.push(
     "## What this note is about\n\n" +
@@ -58,9 +74,12 @@ export async function gatherNoteActionContext(
   if (!request.updatedText.trim()) return null;
 
   const { targetModel, instanceId } = request.target;
-  const byEntity = await getScopedNotesByInstance(targetModel, [instanceId]);
+  const [byEntity, persistent] = await Promise.all([
+    getScopedNotesByInstance(targetModel, [instanceId]),
+    loadPersistentNoteTexts(),
+  ]);
   const candidates = byEntity.get(instanceId) ?? [];
-  const markdown = renderNoteActionPrompt({ request, candidates });
+  const markdown = renderNoteActionPrompt({ request, candidates, persistent });
 
   return { request, markdown, candidates };
 }
@@ -108,8 +127,9 @@ A comment carrying two genuinely unrelated facts becomes two operations. A comme
 
 ## Writing the text
 
-- Name the subject. A note is stored on its own and is often read detached from the record it hangs off: e.g. "MRI-01 runs firmware 3.2" is usable, "runs firmware 3.2" is not. Take the subject from "What this note is about", and never use a pronoun for the device.
+- A note is stored on its own and is often read detached from the record it hangs off. Take the subject from "What this note is about", and never use a pronoun for the device.
 - Write standalone statement of fact. Do not mention "the user", "the comment", "the notification", or the action that produced it. A reader six months from now should understand it with no other context.
+- Do not restate the subject. The note is displayed alongside the record it is attached to, and that record's name is resolved fresh at read time. A name written into the text goes stale the moment the device is renamed - writes "runs firmware 3.2, not 4.x", not "MRI-01 runs firmware 3.2.".
 - One atomic fact per note.
 - Keep the user's specificity. Do not round numbers, generalize a model name, or drop a qualifier.
 

--- a/src/features/notes/agent/noteAction/context.ts
+++ b/src/features/notes/agent/noteAction/context.ts
@@ -48,7 +48,7 @@ function renderNoteActionPrompt(args: {
 
   if (persistent.length > 0) {
     sections.push(
-      `## Standing hospital wide facts (already recorded, never created a duplicate of these)\n\n`,
+      `## Standing hospital wide facts\n\n `,
     ) + persistent.map((perstn) => `- ${perstn}`).join("\n");
   }
 
@@ -127,7 +127,7 @@ A comment carrying two genuinely unrelated facts becomes two operations. A comme
 
 ## Writing the text
 
-- A note is stored on its own and is often read detached from the record it hangs off. Take the subject from "What this note is about", and never use a pronoun for the device.
+- A note is stored alongside its target. Use "What this note is about" to understand the target. Do not include the target label or a pronoune for it in note text.
 - Write standalone statement of fact. Do not mention "the user", "the comment", "the notification", or the action that produced it. A reader six months from now should understand it with no other context.
 - Do not restate the subject. The note is displayed alongside the record it is attached to, and that record's name is resolved fresh at read time. A name written into the text goes stale the moment the device is renamed - writes "runs firmware 3.2, not 4.x", not "MRI-01 runs firmware 3.2.".
 - One atomic fact per note.

--- a/src/features/notes/agent/noteAction/context.ts
+++ b/src/features/notes/agent/noteAction/context.ts
@@ -65,8 +65,6 @@ export async function gatherNoteActionContext(
   return { request, markdown, candidates };
 }
 
-// TODO: Agent should have a choice to omit notes, best decision would come from seeing user behavior, VW-393 will have another agent using a tool to record notes
-// https://github.com/PATCH-UPGRADE/viper/pull/194#discussion_r3691510350
 export const SYSTEM_PROMPT = `You maintain a hospital vulnerability-management team's notes about their medice devices, assets, vulnerabilities,
 and remediations. Notes are the team's durable memory: they are fed into every later AI run and shown to staff on the asset, vulnerability, and
 remediation pages. A user has just taken an action and left a comment. Decide what should change in the notes.

--- a/src/features/notes/server/note-action-requests.ts
+++ b/src/features/notes/server/note-action-requests.ts
@@ -9,6 +9,8 @@ import type {
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
 import { deviceGroupMatchingLabel } from "@/lib/markdown";
+import { ChatNoteInput } from "../types";
+import { resolveNoteTargetLabel } from "./note-targets";
 
 type ResolvedTarget = {
   targetModel: ScopeTargetModel;
@@ -79,14 +81,38 @@ async function resolveMatchFeedbackRequest(
   };
 }
 
+async function resolveChatInput(
+  input: ChatNoteInput,
+): Promise<NoteActionRequest | null> {
+  const comment = input.comment?.trim();
+  if (!comment) return null;
+
+  const label = await resolveNoteTargetLabel(
+    input.targetModel,
+    input.instanceId,
+  );
+  if (!label) return null;
+
+  return {
+    source: "CHAT",
+    updatedText: comment,
+    target: { targetModel: input.targetModel, instanceId: input.instanceId },
+    targetLabel: label,
+    userId: input.userId,
+  };
+}
+
 // add other note source case here
 export async function resolveNoteActionRequest(
   source: NoteActionSource,
   refId: string,
+  input?: ChatNoteInput,
 ): Promise<NoteActionRequest | null> {
   switch (source) {
     case "MATCH_FEEDBACK":
       return resolveMatchFeedbackRequest(refId);
+    case "CHAT":
+      return input ? resolveChatInput(input) : null;
     default:
       return null;
   }

--- a/src/features/notes/server/note-targets.ts
+++ b/src/features/notes/server/note-targets.ts
@@ -28,7 +28,8 @@ export async function resolveNoteTargetLabel(
         select: { description: true },
       });
       if (!remediation) return null;
-      return `Remediation ${instanceId}`;
+      const firstSentence = remediation.description?.trim().split("\n")[0];
+      return firstSentence ? firstSentence : `Remediation ${instanceId}`;
     }
     case "DEVICE_GROUP_MATCHING": {
       const matching = await prisma.deviceGroupMatching.findUnique({

--- a/src/features/notes/server/note-targets.ts
+++ b/src/features/notes/server/note-targets.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import type { ScopeTargetModel } from "@/generated/prisma";
+import prisma from "@/lib/db";
+import { deviceGroupMatchingLabel } from "@/lib/markdown";
+
+export async function resolveNoteTargetLabel(
+  targetModel: ScopeTargetModel,
+  instanceId: string,
+): Promise<string | null> {
+  switch (targetModel) {
+    case "ASSET": {
+      const asset = await prisma.asset.findUnique({
+        where: { id: instanceId },
+        select: { hostname: true, ip: true },
+      });
+      return asset ? (asset.hostname ?? asset.ip) : null;
+    }
+    case "VULNERABILITY": {
+      const vuln = await prisma.vulnerability.findUnique({
+        where: { id: instanceId },
+        select: { cveId: true },
+      });
+      return vuln ? (vuln.cveId ?? `Vulnerability ${instanceId}`) : null;
+    }
+    case "REMEDIATION": {
+      const remediation = await prisma.remediation.findUnique({
+        where: { id: instanceId },
+        select: { description: true },
+      });
+      if (!remediation) return null;
+      return `Remediation ${instanceId}`;
+    }
+    case "DEVICE_GROUP_MATCHING": {
+      const matching = await prisma.deviceGroupMatching.findUnique({
+        where: { id: instanceId },
+        select: {
+          versionRange: true,
+          manufacturer: { select: { canonicalDisplayName: true } },
+          product: { select: { canonicalDisplayName: true } },
+          version: { select: { canonicalDisplayName: true } },
+        },
+      });
+      return matching ? deviceGroupMatchingLabel(matching) : null;
+    }
+  }
+}

--- a/src/features/notes/types.ts
+++ b/src/features/notes/types.ts
@@ -1,0 +1,19 @@
+import type { NoteStatus, ScopeTargetModel } from "@/generated/prisma";
+export type NoteScopeInput =
+  | { kind: "instance"; targetModel: ScopeTargetModel; instanceId: string }
+  | { kind: "filter"; targetModel: ScopeTargetModel };
+
+export type CreateNoteInput = {
+  text: string;
+  userId: string | null;
+  scope: NoteScopeInput;
+  status?: NoteStatus;
+  skipDuplicate: boolean;
+};
+
+export type ChatNoteInput = {
+  comment: string;
+  targetModel: ScopeTargetModel;
+  instanceId: string;
+  userId: string;
+};

--- a/src/inngest/functions/notes-action.ts
+++ b/src/inngest/functions/notes-action.ts
@@ -11,14 +11,16 @@ export async function requestNoteAction(
   source: NoteActionSource,
   refId: string,
   input?: ChatNoteInput,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await inngest.send({
       name: ACTION_EVENT,
       data: { source, refId, input, key: `${source}: ${refId}` },
     });
+    return true;
   } catch (err) {
     console.error(`Failed to request note edit for ${source}: ${refId}`, err);
+    return false;
   }
 }
 

--- a/src/inngest/functions/notes-action.ts
+++ b/src/inngest/functions/notes-action.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { actionNotesForRequest } from "@/features/notes/agent/noteAction";
 import type { NoteActionSource } from "@/features/notes/agent/noteAction/context";
 import { resolveNoteActionRequest } from "@/features/notes/server/note-action-requests";
+import { ChatNoteInput } from "@/features/notes/types";
 import { inngest } from "../client";
 
 const ACTION_EVENT = "note/action.requested" as const;
@@ -9,11 +10,12 @@ const ACTION_EVENT = "note/action.requested" as const;
 export async function requestNoteAction(
   source: NoteActionSource,
   refId: string,
+  input?: ChatNoteInput,
 ): Promise<void> {
   try {
     await inngest.send({
       name: ACTION_EVENT,
-      data: { source, refId, key: `${source}: ${refId}` },
+      data: { source, refId, input, key: `${source}: ${refId}` },
     });
   } catch (err) {
     console.error(`Failed to request note edit for ${source}: ${refId}`, err);
@@ -30,13 +32,14 @@ export const actionNotesFn = inngest.createFunction(
     event: ACTION_EVENT,
   },
   async ({ event, step }) => {
-    const { source, refId } = event.data as {
+    const { source, refId, input } = event.data as {
       source: NoteActionSource;
       refId: string;
+      input?: ChatNoteInput;
     };
 
     const request = await step.run("resolve-note-request", () =>
-      resolveNoteActionRequest(source, refId),
+      resolveNoteActionRequest(source, refId, input),
     );
     if (!request) return { skipped: true as const, source, refId };
 


### PR DESCRIPTION
ticket: https://northeastern-patch.atlassian.net/browse/VW-393

## Summary

  * Added a new tool for chat agent to record relevant info provided by user.
  * Added the ability to create/update/delete notes through chat info provided by user.
  * Supports notes for specific records and broader filtered scopes.
  * Automatically identifies note targets and displays clear labels.
  * Added guidance to prevent duplicate notes and capture durable facts appropriately.
  * Notes are recorded asynchronously with confirmation messaging.

### Out of scope
- EntityFilter creation

https://github.com/user-attachments/assets/fb3a9fa4-4b56-43c9-be60-9a329d2d1089



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added chat support for recording persistent and target-specific notes.
  - Notes can be linked to assets, vulnerabilities, remediations, or device-group matches with clear target labels.
  - Added validation, duplicate avoidance, and asynchronous note processing.
  - Improved note context for AI-generated actions with durable facts and appropriate scoping.

- **Bug Fixes**
  - Improved handling of invalid note content and unresolved targets.
  - Added clearer target labels to inbox question context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->