### PR TITLE
[VW-0] Fix biome format errors blocking CI

### DIFF
--- a/src/features/inbox/agent/question/context.ts
+++ b/src/features/inbox/agent/question/context.ts
@@ -63,7 +63,7 @@ function renderQuestionPrompt(args: {
         args.notes
           .map((n) => {
             const target = renderNoteTarget(n, args.labels);
-            return target ? `- **${target}** ${n.text}`: `- ${n.text}`; 
+            return target ? `- **${target}** ${n.text}` : `- ${n.text}`;
           })
           .join("\n"),
     );

--- a/src/features/notes/agent/noteAction/context.ts
+++ b/src/features/notes/agent/noteAction/context.ts
@@ -47,9 +47,8 @@ function renderNoteActionPrompt(args: {
   const sections: string[] = [];
 
   if (persistent.length > 0) {
-    sections.push(
-      `## Standing hospital wide facts\n\n `,
-    ) + persistent.map((perstn) => `- ${perstn}`).join("\n");
+    sections.push(`## Standing hospital wide facts\n\n `) +
+      persistent.map((perstn) => `- ${perstn}`).join("\n");
   }
 
   sections.push(


### PR DESCRIPTION
[VW-0]

## Summary

Fixes the two `biome ci` **format errors** on `main` (introduced with #209) that fail the Lint step of every PR branched from it — currently blocking #212. Mechanical `npx biome format --write` output on two files; no logic changes.

- `src/features/inbox/agent/question/context.ts` — spacing in a ternary.
- `src/features/notes/agent/noteAction/context.ts` — reflow of a `sections.push(...) + ...` expression. **Formatting preserved as-is, but note this line looks like a latent bug**: the `+ persistent.map(...).join("\n")` result is discarded (`push` returns a length), so the "Standing hospital wide facts" section header is pushed without its facts. Left untouched here since fixing it changes agent-prompt content — flagging for the #209 author.

The 22 pre-existing biome *warnings* are untouched; they don't fail CI.

## Testing

`npx biome ci .` — was `Found 2 errors`, now passes with warnings only. Reproduced the errors on a clean `origin/main` checkout first to confirm they predate any open branch.