### PR TITLE
[VW-423] Filter asset work orders for VW-420 and show AssetTickets on work order detail

### DIFF
--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -46,10 +46,8 @@ const {
   mockUseAttachableChildren,
   mockAttachAssetMutate,
   mockDetachAssetMutate,
-  mockUpdateAssetTicketStatusMutate,
   mockUseAttachAsset,
   mockUseDetachAsset,
-  mockUseUpdateAssetTicketStatus,
   mockUseAttachableAssets,
 } = vi.hoisted(() => {
   const mockMutate = vi.fn();
@@ -60,7 +58,6 @@ const {
   const mockDetachMutate = vi.fn();
   const mockAttachAssetMutate = vi.fn();
   const mockDetachAssetMutate = vi.fn();
-  const mockUpdateAssetTicketStatusMutate = vi.fn();
   return {
     mockMutate,
     mockAddCommentMutate,
@@ -70,17 +67,12 @@ const {
     mockDetachMutate,
     mockAttachAssetMutate,
     mockDetachAssetMutate,
-    mockUpdateAssetTicketStatusMutate,
     mockUseAttachAsset: vi.fn(() => ({
       mutate: mockAttachAssetMutate,
       isPending: false,
     })),
     mockUseDetachAsset: vi.fn(() => ({
       mutate: mockDetachAssetMutate,
-      isPending: false,
-    })),
-    mockUseUpdateAssetTicketStatus: vi.fn(() => ({
-      mutate: mockUpdateAssetTicketStatusMutate,
       isPending: false,
     })),
     mockUseAttachableAssets: vi.fn(() => ({
@@ -179,7 +171,6 @@ vi.mock("../hooks/use-tracking", () => ({
   useAttachableChildren: mockUseAttachableChildren,
   useAttachAsset: mockUseAttachAsset,
   useDetachAsset: mockUseDetachAsset,
-  useUpdateAssetTicketStatus: mockUseUpdateAssetTicketStatus,
   useAttachableAssets: mockUseAttachableAssets,
 }));
 
@@ -724,7 +715,7 @@ describe("LinkedAssetsTable", () => {
       />,
     );
 
-    const link = screen.getByRole("link", { name: /host-1/i });
+    const link = screen.getByRole("link", { name: "asset-1" });
     expect(link).toHaveAttribute("href", "/tracking/child-42");
   });
 
@@ -760,13 +751,8 @@ describe("LinkedAssetsTable", () => {
     await user.click(screen.getByRole("combobox", { name: /ticket status/i }));
     await user.click(screen.getByRole("option", { name: "Done" }));
 
-    // Bound to the parent ticket (whose cache backs this table), not the
-    // child's own — otherwise the row wouldn't refresh after a successful edit.
-    expect(mockUseUpdateAssetTicketStatus).toHaveBeenCalledWith(
-      "t1",
-      "asset-1",
-    );
-    expect(mockUpdateAssetTicketStatusMutate).toHaveBeenCalledWith({
+    expect(mockUseUpdateTicket).toHaveBeenCalledWith("child-42", "t1");
+    expect(mockMutate).toHaveBeenCalledWith({
       id: "child-42",
       status: "DONE",
     });

--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -676,8 +676,6 @@ const sampleAsset = (overrides: Record<string, unknown> = {}) => ({
   hostname: "host-1",
   ip: "10.0.0.5",
   role: "Infusion Pump",
-  status: "Active",
-  macAddress: "00:11:22:33:44:55",
   location: { building: "A", floor: "3", room: "302" },
   deviceGroupId: "dg-1",
   deviceGroup: {
@@ -764,7 +762,10 @@ describe("LinkedAssetsTable", () => {
 
     // Bound to the parent ticket (whose cache backs this table), not the
     // child's own — otherwise the row wouldn't refresh after a successful edit.
-    expect(mockUseUpdateAssetTicketStatus).toHaveBeenCalledWith("t1");
+    expect(mockUseUpdateAssetTicketStatus).toHaveBeenCalledWith(
+      "t1",
+      "asset-1",
+    );
     expect(mockUpdateAssetTicketStatusMutate).toHaveBeenCalledWith({
       id: "child-42",
       status: "DONE",

--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -46,8 +46,10 @@ const {
   mockUseAttachableChildren,
   mockAttachAssetMutate,
   mockDetachAssetMutate,
+  mockUpdateAssetTicketStatusMutate,
   mockUseAttachAsset,
   mockUseDetachAsset,
+  mockUseUpdateAssetTicketStatus,
   mockUseAttachableAssets,
 } = vi.hoisted(() => {
   const mockMutate = vi.fn();
@@ -58,6 +60,7 @@ const {
   const mockDetachMutate = vi.fn();
   const mockAttachAssetMutate = vi.fn();
   const mockDetachAssetMutate = vi.fn();
+  const mockUpdateAssetTicketStatusMutate = vi.fn();
   return {
     mockMutate,
     mockAddCommentMutate,
@@ -67,12 +70,17 @@ const {
     mockDetachMutate,
     mockAttachAssetMutate,
     mockDetachAssetMutate,
+    mockUpdateAssetTicketStatusMutate,
     mockUseAttachAsset: vi.fn(() => ({
       mutate: mockAttachAssetMutate,
       isPending: false,
     })),
     mockUseDetachAsset: vi.fn(() => ({
       mutate: mockDetachAssetMutate,
+      isPending: false,
+    })),
+    mockUseUpdateAssetTicketStatus: vi.fn(() => ({
+      mutate: mockUpdateAssetTicketStatusMutate,
       isPending: false,
     })),
     mockUseAttachableAssets: vi.fn(() => ({
@@ -171,6 +179,7 @@ vi.mock("../hooks/use-tracking", () => ({
   useAttachableChildren: mockUseAttachableChildren,
   useAttachAsset: mockUseAttachAsset,
   useDetachAsset: mockUseDetachAsset,
+  useUpdateAssetTicketStatus: mockUseUpdateAssetTicketStatus,
   useAttachableAssets: mockUseAttachableAssets,
 }));
 
@@ -692,28 +701,28 @@ const sampleAssetTicket = (
 });
 
 describe("LinkedAssetsTable", () => {
-  it("renders one row per asset with role, model, IP, MAC, and location", () => {
+  it("renders one row per asset with role, model, IP, location, and an editable status", () => {
     render(
       <LinkedAssetsTable
+        parentTicketId="t1"
         assetTickets={[sampleAssetTicket()] as never}
-        remediations={[]}
       />,
     );
 
     expect(screen.getByText("Infusion Pump")).toBeInTheDocument();
     expect(screen.getByText("ICU Medical Plum 360")).toBeInTheDocument();
     expect(screen.getByText("10.0.0.5")).toBeInTheDocument();
-    expect(screen.getByText("00:11:22:33:44:55")).toBeInTheDocument();
     expect(screen.getByText("A · 3 · 302")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
-    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /ticket status/i }),
+    ).toHaveTextContent("To Do");
   });
 
   it("links the asset id cell to its dedicated per-asset ticket", () => {
     render(
       <LinkedAssetsTable
+        parentTicketId="t1"
         assetTickets={[sampleAssetTicket({}, { id: "child-42" })] as never}
-        remediations={[]}
       />,
     );
 
@@ -721,79 +730,45 @@ describe("LinkedAssetsTable", () => {
     expect(link).toHaveAttribute("href", "/tracking/child-42");
   });
 
-  it("falls back to em-dashes for missing role, MAC, and location fields", () => {
+  it("falls back to em-dashes for missing role and location fields", () => {
     render(
       <LinkedAssetsTable
+        parentTicketId="t1"
         assetTickets={
           [
             sampleAssetTicket({
               role: null,
-              macAddress: null,
               location: null,
               deviceGroup: null,
             }),
           ] as never
         }
-        remediations={[]}
       />,
     );
 
-    // The role cell contains a "—" link, MAC cell contains "—", location cell contains "—"
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
+    // The role cell and location cell each contain a "—"
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 
-  it("matches a remediation to the asset via device-group matching rules", () => {
+  it("changes the asset's ticket status via the status dropdown", async () => {
+    const user = userEvent.setup();
     render(
       <LinkedAssetsTable
-        assetTickets={[sampleAssetTicket()] as never}
-        remediations={
-          [
-            {
-              id: "rem-1",
-              description: "Apply firmware patch v2.3",
-              deviceGroupMatchings: [
-                {
-                  manufacturerId: "manufacturer-icu",
-                  productId: "product-plum",
-                  versionId: null,
-                  versionRange: null,
-                },
-              ],
-            },
-          ] as never
-        }
+        parentTicketId="t1"
+        assetTickets={[sampleAssetTicket({}, { id: "child-42" })] as never}
       />,
     );
 
-    expect(screen.getByText(/firmware patch v2\.3/i)).toBeInTheDocument();
-  });
+    await user.click(screen.getByRole("combobox", { name: /ticket status/i }));
+    await user.click(screen.getByRole("option", { name: "Done" }));
 
-  it("shows em-dash when no remediation targets the asset's device group", () => {
-    render(
-      <LinkedAssetsTable
-        assetTickets={[sampleAssetTicket()] as never}
-        remediations={
-          [
-            {
-              id: "rem-1",
-              description: "Different group only",
-              deviceGroupMatchings: [
-                {
-                  manufacturerId: "manufacturer-other",
-                  productId: null,
-                  versionId: null,
-                  versionRange: null,
-                },
-              ],
-            },
-          ] as never
-        }
-      />,
-    );
-
-    // role/MAC/location are populated; the remediation cell should be the lone "—"
-    const dashes = screen.getAllByText("—");
-    expect(dashes.length).toBe(1);
+    // Bound to the parent ticket (whose cache backs this table), not the
+    // child's own — otherwise the row wouldn't refresh after a successful edit.
+    expect(mockUseUpdateAssetTicketStatus).toHaveBeenCalledWith("t1");
+    expect(mockUpdateAssetTicketStatusMutate).toHaveBeenCalledWith({
+      id: "child-42",
+      status: "DONE",
+    });
   });
 });
 

--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -715,7 +715,7 @@ describe("LinkedAssetsTable", () => {
       />,
     );
 
-    const link = screen.getByRole("link", { name: "asset-1" });
+    const link = screen.getByRole("link", { name: "host-1" });
     expect(link).toHaveAttribute("href", "/tracking/child-42");
   });
 
@@ -751,7 +751,11 @@ describe("LinkedAssetsTable", () => {
     await user.click(screen.getByRole("combobox", { name: /ticket status/i }));
     await user.click(screen.getByRole("option", { name: "Done" }));
 
-    expect(mockUseUpdateTicket).toHaveBeenCalledWith("child-42", "t1");
+    expect(mockUseUpdateTicket).toHaveBeenCalledWith(
+      "child-42",
+      "t1",
+      "asset-1",
+    );
     expect(mockMutate).toHaveBeenCalledWith({
       id: "child-42",
       status: "DONE",

--- a/src/features/tracking/components/ticket-detail/index.tsx
+++ b/src/features/tracking/components/ticket-detail/index.tsx
@@ -190,7 +190,6 @@ export const TicketDetailContent = ({ id }: { id: string }) => {
             <LinkedAssetsTabContent
               ticketId={data.id}
               assetTickets={data.assets}
-              remediations={data.remediations}
             />
           </TabsContent>
 

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -19,22 +19,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useUpdateAssetTicketStatus } from "@/features/tracking/hooks/use-tracking";
+import { useUpdateTicket } from "@/features/tracking/hooks/use-tracking";
 import type { TicketStatus } from "@/generated/prisma";
 import { type DetailAssetTicket, formatLocation, statusLabels } from "./shared";
 
 const AssetTicketStatusSelect = ({
   parentTicketId,
-  assetId,
   ticketId,
   status,
 }: {
   parentTicketId: string;
-  assetId: string;
   ticketId: string;
   status: TicketStatus;
 }) => {
-  const update = useUpdateAssetTicketStatus(parentTicketId, assetId);
+  const update = useUpdateTicket(ticketId, parentTicketId);
 
   return (
     <Select
@@ -99,13 +97,12 @@ export const LinkedAssetsTable = ({
                   href={`/tracking/${ticket.id}`}
                   className="font-mono text-xs font-medium text-primary hover:underline"
                 >
-                  {asset.hostname ?? asset.id.slice(0, 8)}
+                  {asset.id}
                 </Link>
               </TableCell>
               <TableCell>
                 <AssetTicketStatusSelect
                   parentTicketId={parentTicketId}
-                  assetId={asset.id}
                   ticketId={ticket.id}
                   status={ticket.status}
                 />

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -25,14 +25,16 @@ import { type DetailAssetTicket, formatLocation, statusLabels } from "./shared";
 
 const AssetTicketStatusSelect = ({
   parentTicketId,
+  assetId,
   ticketId,
   status,
 }: {
   parentTicketId: string;
+  assetId: string;
   ticketId: string;
   status: TicketStatus;
 }) => {
-  const update = useUpdateAssetTicketStatus(parentTicketId);
+  const update = useUpdateAssetTicketStatus(parentTicketId, assetId);
 
   return (
     <Select
@@ -103,6 +105,7 @@ export const LinkedAssetsTable = ({
               <TableCell>
                 <AssetTicketStatusSelect
                   parentTicketId={parentTicketId}
+                  assetId={asset.id}
                   ticketId={ticket.id}
                   status={ticket.status}
                 />

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -2,9 +2,15 @@
 
 import { XIcon } from "lucide-react";
 import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ClampedCell } from "@/components/ui/clamped-cell";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -13,73 +19,69 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getChipClass } from "@/features/tag-colors/palette";
-import type { AssetStatus } from "@/generated/prisma";
-import { matchingAppliesToDeviceGroup } from "@/lib/device-matching";
-import {
-  type DetailAssetTicket,
-  type DetailRemediation,
-  formatLocation,
-  StatusChip,
-} from "./shared";
+import { useUpdateAssetTicketStatus } from "@/features/tracking/hooks/use-tracking";
+import type { TicketStatus } from "@/generated/prisma";
+import { type DetailAssetTicket, formatLocation, statusLabels } from "./shared";
 
-const assetStatusHue: Record<AssetStatus, string> = {
-  Active: "green",
-  Maintenance: "yellow",
-  Decommissioned: "gray",
-};
+const AssetTicketStatusSelect = ({
+  parentTicketId,
+  ticketId,
+  status,
+}: {
+  parentTicketId: string;
+  ticketId: string;
+  status: TicketStatus;
+}) => {
+  const update = useUpdateAssetTicketStatus(parentTicketId);
 
-const AssetStatusBadge = ({ status }: { status: AssetStatus | null }) => {
-  if (!status) return <span className="text-muted-foreground">—</span>;
   return (
-    <Badge variant="outline" className={getChipClass(assetStatusHue[status])}>
-      {status}
-    </Badge>
+    <Select
+      value={status}
+      onValueChange={(v) =>
+        update.mutate({ id: ticketId, status: v as TicketStatus })
+      }
+      disabled={update.isPending}
+    >
+      <SelectTrigger size="sm" aria-label="Ticket status">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {(Object.keys(statusLabels) as TicketStatus[]).map((s) => (
+          <SelectItem key={s} value={s}>
+            {statusLabels[s]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 };
 
 export const LinkedAssetsTable = ({
+  parentTicketId,
   assetTickets,
-  remediations,
   onDetach,
   detachPending,
 }: {
+  parentTicketId: string;
   assetTickets: DetailAssetTicket[];
-  remediations: DetailRemediation[];
   onDetach?: (assetId: string) => void;
   detachPending?: boolean;
 }) => {
-  // Remediations no longer link device groups directly; each carries
-  // manufacturer/product/version matching rules. Resolve the first remediation whose
-  // rules apply to a given asset's device group.
-  const remediationForAsset = (
-    asset: DetailAssetTicket["asset"],
-  ): DetailRemediation | undefined =>
-    remediations.find((remediation) =>
-      remediation.deviceGroupMatchings.some((matching) =>
-        matchingAppliesToDeviceGroup(matching, asset.deviceGroup),
-      ),
-    );
-
   return (
     <Table>
       <TableHeader>
         <TableRow>
           <TableHead>Asset ID</TableHead>
+          <TableHead>Status</TableHead>
           <TableHead>Role</TableHead>
           <TableHead>Model</TableHead>
           <TableHead>IP Address</TableHead>
-          <TableHead>MAC Address</TableHead>
           <TableHead>Location</TableHead>
-          <TableHead>Remediation</TableHead>
-          <TableHead>Asset Status</TableHead>
-          <TableHead>Ticket Status</TableHead>
           {onDetach && <TableHead className="w-10" />}
         </TableRow>
       </TableHeader>
       <TableBody>
         {assetTickets.map(({ asset, ticket }) => {
-          const remediation = remediationForAsset(asset);
           const model = asset.deviceGroup
             ? [
                 asset.deviceGroup.manufacturer?.canonicalDisplayName,
@@ -98,6 +100,13 @@ export const LinkedAssetsTable = ({
                   {asset.hostname ?? asset.id.slice(0, 8)}
                 </Link>
               </TableCell>
+              <TableCell>
+                <AssetTicketStatusSelect
+                  parentTicketId={parentTicketId}
+                  ticketId={ticket.id}
+                  status={ticket.status}
+                />
+              </TableCell>
               <TableCell className="text-sm">
                 <ClampedCell text={asset.role} />
               </TableCell>
@@ -105,28 +114,8 @@ export const LinkedAssetsTable = ({
                 <ClampedCell text={model} />
               </TableCell>
               <TableCell className="font-mono text-xs">{asset.ip}</TableCell>
-              <TableCell className="font-mono text-xs">
-                {asset.macAddress ?? "—"}
-              </TableCell>
               <TableCell className="text-sm text-muted-foreground">
                 <ClampedCell text={formatLocation(asset.location)} />
-              </TableCell>
-              <TableCell className="text-sm">
-                <ClampedCell
-                  text={
-                    remediation
-                      ? (remediation.description ??
-                        `Remediation ${remediation.id}`)
-                      : null
-                  }
-                  maxWidthClass="max-w-[14rem]"
-                />
-              </TableCell>
-              <TableCell>
-                <AssetStatusBadge status={asset.status} />
-              </TableCell>
-              <TableCell>
-                <StatusChip status={ticket.status} />
               </TableCell>
               {onDetach && (
                 <TableCell className="w-10">

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -25,14 +25,16 @@ import { type DetailAssetTicket, formatLocation, statusLabels } from "./shared";
 
 const AssetTicketStatusSelect = ({
   parentTicketId,
+  assetId,
   ticketId,
   status,
 }: {
   parentTicketId: string;
+  assetId: string;
   ticketId: string;
   status: TicketStatus;
 }) => {
-  const update = useUpdateTicket(ticketId, parentTicketId);
+  const update = useUpdateTicket(ticketId, parentTicketId, assetId);
 
   return (
     <Select
@@ -97,12 +99,13 @@ export const LinkedAssetsTable = ({
                   href={`/tracking/${ticket.id}`}
                   className="font-mono text-xs font-medium text-primary hover:underline"
                 >
-                  {asset.id}
+                  {asset.hostname ?? asset.id}
                 </Link>
               </TableCell>
               <TableCell>
                 <AssetTicketStatusSelect
                   parentTicketId={parentTicketId}
+                  assetId={asset.id}
                   ticketId={ticket.id}
                   status={ticket.status}
                 />

--- a/src/features/tracking/components/ticket-detail/linked-assets.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets.tsx
@@ -23,7 +23,7 @@ import {
   useDetachAsset,
 } from "../../hooks/use-tracking";
 import { LinkedAssetsTable } from "./linked-assets-table";
-import type { DetailAssetTicket, DetailRemediation } from "./shared";
+import type { DetailAssetTicket } from "./shared";
 
 const AttachAssetPopover = ({ ticketId }: { ticketId: string }) => {
   const [open, setOpen] = useState(false);
@@ -87,11 +87,9 @@ const AttachAssetPopover = ({ ticketId }: { ticketId: string }) => {
 export const LinkedAssetsTabContent = ({
   ticketId,
   assetTickets,
-  remediations,
 }: {
   ticketId: string;
   assetTickets: DetailAssetTicket[];
-  remediations: DetailRemediation[];
 }) => {
   const detach = useDetachAsset(ticketId);
 
@@ -107,8 +105,8 @@ export const LinkedAssetsTabContent = ({
       <div className="p-2">
         {assetTickets.length > 0 ? (
           <LinkedAssetsTable
+            parentTicketId={ticketId}
             assetTickets={assetTickets}
-            remediations={remediations}
             onDetach={(assetId) => detach.mutate({ ticketId, assetId })}
             detachPending={detach.isPending}
           />

--- a/src/features/tracking/components/ticket-detail/linked-assets.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets.tsx
@@ -92,21 +92,24 @@ export const LinkedAssetsTabContent = ({
   assetTickets: DetailAssetTicket[];
 }) => {
   const detach = useDetachAsset(ticketId);
+  // Same "quickly see what's remaining" reasoning as the asset's own work-orders
+  // view: once a per-asset ticket is Done, it drops off this list too.
+  const active = assetTickets.filter((at) => at.ticket.status !== "DONE");
 
   return (
     <Card className="gap-0 py-0">
       <div className="flex items-center justify-between gap-2 border-b px-5 py-4">
         <h2 className="text-base font-semibold">
           Linked Assets{" "}
-          <span className="text-muted-foreground">({assetTickets.length})</span>
+          <span className="text-muted-foreground">({active.length})</span>
         </h2>
         <AttachAssetPopover ticketId={ticketId} />
       </div>
       <div className="p-2">
-        {assetTickets.length > 0 ? (
+        {active.length > 0 ? (
           <LinkedAssetsTable
             parentTicketId={ticketId}
-            assetTickets={assetTickets}
+            assetTickets={active}
             onDetach={(assetId) => detach.mutate({ ticketId, assetId })}
             detachPending={detach.isPending}
           />

--- a/src/features/tracking/components/ticket-detail/linked-assets.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets.tsx
@@ -92,32 +92,27 @@ export const LinkedAssetsTabContent = ({
   assetTickets: DetailAssetTicket[];
 }) => {
   const detach = useDetachAsset(ticketId);
-  // Same "quickly see what's remaining" reasoning as the asset's own work-orders
-  // view: once a per-asset ticket is Done, it drops off this list too.
-  const active = assetTickets.filter((at) => at.ticket.status !== "DONE");
 
   return (
     <Card className="gap-0 py-0">
       <div className="flex items-center justify-between gap-2 border-b px-5 py-4">
         <h2 className="text-base font-semibold">
           Linked Assets{" "}
-          <span className="text-muted-foreground">({active.length})</span>
+          <span className="text-muted-foreground">({assetTickets.length})</span>
         </h2>
         <AttachAssetPopover ticketId={ticketId} />
       </div>
       <div className="p-2">
-        {active.length > 0 ? (
+        {assetTickets.length > 0 ? (
           <LinkedAssetsTable
             parentTicketId={ticketId}
-            assetTickets={active}
+            assetTickets={assetTickets}
             onDetach={(assetId) => detach.mutate({ ticketId, assetId })}
             detachPending={detach.isPending}
           />
         ) : (
           <p className="p-4 text-sm text-muted-foreground">
-            {assetTickets.length > 0
-              ? "No active assets linked to this ticket."
-              : "No assets linked to this ticket."}
+            No assets linked to this ticket.
           </p>
         )}
       </div>

--- a/src/features/tracking/components/ticket-detail/linked-assets.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets.tsx
@@ -115,7 +115,9 @@ export const LinkedAssetsTabContent = ({
           />
         ) : (
           <p className="p-4 text-sm text-muted-foreground">
-            No assets linked to this ticket.
+            {assetTickets.length > 0
+              ? "No active assets linked to this ticket."
+              : "No assets linked to this ticket."}
           </p>
         )}
       </div>

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -90,7 +90,6 @@ export const DepartmentChips = ({
 };
 
 export type DetailAssetTicket = TicketDetail["assets"][number];
-export type DetailRemediation = TicketDetail["remediations"][number];
 
 export const formatLocation = (location: unknown): string => {
   if (!location || typeof location !== "object") return "—";

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -396,6 +396,58 @@ export const useAttachAsset = (ticketId: string) => {
   );
 };
 
+/** Updates one asset's dedicated child ticket's status from the Linked Assets
+ * table, patching the parent ticket's cached `assets` list (the table's own
+ * data source) rather than the child ticket's own — unmounted — queries. */
+export const useUpdateAssetTicketStatus = (parentTicketId: string) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.tracking.update.mutationOptions({
+      onMutate: async ({ id, status }) => {
+        const detailFilter = trpc.tracking.getOne.queryFilter({
+          id: parentTicketId,
+        });
+        await queryClient.cancelQueries(detailFilter);
+        const previousDetail = queryClient.getQueriesData(detailFilter);
+        // biome-ignore lint/suspicious/noExplicitAny: trpc cache shape
+        queryClient.setQueriesData<any>(detailFilter, (old: any) => {
+          if (!old?.assets) return old;
+          return {
+            ...old,
+            assets: old.assets.map((at: { ticket: { id: string } }) =>
+              at.ticket.id === id
+                ? { ...at, ticket: { ...at.ticket, status } }
+                : at,
+            ),
+          };
+        });
+        return { previousDetail };
+      },
+      onError: (error, _vars, context) => {
+        if (context?.previousDetail) {
+          for (const [key, data] of context.previousDetail) {
+            queryClient.setQueryData(key, data);
+          }
+        }
+        toast.error(`Failed to update status: ${error.message}`);
+      },
+      onSettled: (_data, _error, { id }) => {
+        queryClient.invalidateQueries(
+          trpc.tracking.getOne.queryFilter({ id: parentTicketId }),
+        );
+        // The child ticket has its own detail page (linked from the Asset ID
+        // cell) — invalidate its cache too, not just the parent's.
+        queryClient.invalidateQueries(trpc.tracking.getOne.queryFilter({ id }));
+        queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
+        queryClient.invalidateQueries(
+          trpc.tracking.getManyByAssetId.queryFilter(),
+        );
+      },
+    }),
+  );
+};
+
 export const useDetachAsset = (ticketId: string) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -7,7 +7,6 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { TicketStatus } from "@/generated/prisma";
 import { useTRPC } from "@/trpc/client";
 import { useTrackingParams } from "./use-tracking-params";
 
@@ -29,7 +28,7 @@ export const useSuspenseAssetWorkOrders = (assetId: string) => {
   );
 };
 
-export const useUpdateTicket = (ticketId: string) => {
+export const useUpdateTicket = (ticketId: string, relatedTicketId?: string) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   return useMutation(
@@ -38,6 +37,11 @@ export const useUpdateTicket = (ticketId: string) => {
         queryClient.invalidateQueries(
           trpc.tracking.getOne.queryFilter({ id: ticketId }),
         );
+        if (relatedTicketId) {
+          queryClient.invalidateQueries(
+            trpc.tracking.getOne.queryFilter({ id: relatedTicketId }),
+          );
+        }
         queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
         queryClient.invalidateQueries(
           trpc.tracking.getManyByAssetId.queryFilter(),
@@ -395,71 +399,6 @@ export const useAttachAsset = (ticketId: string) => {
       },
     }),
   );
-};
-
-/** Updates one asset's dedicated child ticket's status from the Linked Assets
- * table. The optimistic patch targets the parent ticket's cached `assets`
- * list, since that's what's actually mounted and rendering this table; the
- * child's own detail page and the asset's work-orders page aren't currently
- * visible, so they're invalidated (not patched) to stay correct next time
- * they're opened rather than showing stale data from before this edit. */
-export const useUpdateAssetTicketStatus = (
-  parentTicketId: string,
-  assetId: string,
-) => {
-  const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const mutation = useMutation(
-    trpc.tracking.update.mutationOptions({
-      onMutate: async ({ id, status }) => {
-        const detailFilter = trpc.tracking.getOne.queryFilter({
-          id: parentTicketId,
-        });
-        await queryClient.cancelQueries(detailFilter);
-        const previousDetail = queryClient.getQueriesData(detailFilter);
-        // biome-ignore lint/suspicious/noExplicitAny: trpc cache shape
-        queryClient.setQueriesData<any>(detailFilter, (old: any) => {
-          if (!old?.assets) return old;
-          return {
-            ...old,
-            assets: old.assets.map((at: { ticket: { id: string } }) =>
-              at.ticket.id === id
-                ? { ...at, ticket: { ...at.ticket, status } }
-                : at,
-            ),
-          };
-        });
-        return { previousDetail };
-      },
-      onError: (error, _vars, context) => {
-        if (context?.previousDetail) {
-          for (const [key, data] of context.previousDetail) {
-            queryClient.setQueryData(key, data);
-          }
-        }
-        toast.error(`Failed to update status: ${error.message}`);
-      },
-      onSettled: (_data, _error, { id }) => {
-        queryClient.invalidateQueries(
-          trpc.tracking.getOne.queryFilter({ id: parentTicketId }),
-        );
-        queryClient.invalidateQueries(trpc.tracking.getOne.queryFilter({ id }));
-        queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
-        queryClient.invalidateQueries(
-          trpc.tracking.getManyByAssetId.queryFilter({ assetId }),
-        );
-      },
-    }),
-  );
-  // Narrows the exposed mutate() to exactly what the optimistic patch above
-  // assumes — trpc.tracking.update itself accepts far more optional fields,
-  // and calling this hook with anything but {id, status} would silently
-  // write status: undefined into the cache until the next refetch corrects it.
-  return {
-    ...mutation,
-    mutate: (variables: { id: string; status: TicketStatus }) =>
-      mutation.mutate(variables),
-  };
 };
 
 export const useDetachAsset = (ticketId: string) => {

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -28,7 +28,11 @@ export const useSuspenseAssetWorkOrders = (assetId: string) => {
   );
 };
 
-export const useUpdateTicket = (ticketId: string, relatedTicketId?: string) => {
+export const useUpdateTicket = (
+  ticketId: string,
+  relatedTicketId?: string,
+  assetId?: string,
+) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   return useMutation(
@@ -44,7 +48,9 @@ export const useUpdateTicket = (ticketId: string, relatedTicketId?: string) => {
         }
         queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
         queryClient.invalidateQueries(
-          trpc.tracking.getManyByAssetId.queryFilter(),
+          assetId
+            ? trpc.tracking.getManyByAssetId.queryFilter({ assetId })
+            : trpc.tracking.getManyByAssetId.queryFilter(),
         );
         toast.success("Ticket updated");
       },

--- a/src/features/tracking/hooks/use-tracking.ts
+++ b/src/features/tracking/hooks/use-tracking.ts
@@ -7,6 +7,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
+import type { TicketStatus } from "@/generated/prisma";
 import { useTRPC } from "@/trpc/client";
 import { useTrackingParams } from "./use-tracking-params";
 
@@ -397,12 +398,18 @@ export const useAttachAsset = (ticketId: string) => {
 };
 
 /** Updates one asset's dedicated child ticket's status from the Linked Assets
- * table, patching the parent ticket's cached `assets` list (the table's own
- * data source) rather than the child ticket's own — unmounted — queries. */
-export const useUpdateAssetTicketStatus = (parentTicketId: string) => {
+ * table. The optimistic patch targets the parent ticket's cached `assets`
+ * list, since that's what's actually mounted and rendering this table; the
+ * child's own detail page and the asset's work-orders page aren't currently
+ * visible, so they're invalidated (not patched) to stay correct next time
+ * they're opened rather than showing stale data from before this edit. */
+export const useUpdateAssetTicketStatus = (
+  parentTicketId: string,
+  assetId: string,
+) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  return useMutation(
+  const mutation = useMutation(
     trpc.tracking.update.mutationOptions({
       onMutate: async ({ id, status }) => {
         const detailFilter = trpc.tracking.getOne.queryFilter({
@@ -436,16 +443,23 @@ export const useUpdateAssetTicketStatus = (parentTicketId: string) => {
         queryClient.invalidateQueries(
           trpc.tracking.getOne.queryFilter({ id: parentTicketId }),
         );
-        // The child ticket has its own detail page (linked from the Asset ID
-        // cell) — invalidate its cache too, not just the parent's.
         queryClient.invalidateQueries(trpc.tracking.getOne.queryFilter({ id }));
         queryClient.invalidateQueries(trpc.tracking.getMany.queryFilter());
         queryClient.invalidateQueries(
-          trpc.tracking.getManyByAssetId.queryFilter(),
+          trpc.tracking.getManyByAssetId.queryFilter({ assetId }),
         );
       },
     }),
   );
+  // Narrows the exposed mutate() to exactly what the optimistic patch above
+  // assumes — trpc.tracking.update itself accepts far more optional fields,
+  // and calling this hook with anything but {id, status} would silently
+  // write status: undefined into the cache until the next refetch corrects it.
+  return {
+    ...mutation,
+    mutate: (variables: { id: string; status: TicketStatus }) =>
+      mutation.mutate(variables),
+  };
 };
 
 export const useDetachAsset = (ticketId: string) => {


### PR DESCRIPTION
https://northeastern-patch.atlassian.net/browse/VW-420
https://northeastern-patch.atlassian.net/browse/VW-423

## Summary
VW-420 — the asset work-orders view (/assets/[assetId]/work-orders) already only shows tickets matched to exactly one asset, via getManyByAssetId's existing ticket: { assetId } + status: { not: DONE } filters (built as part of VW-419). 

VW-423 — the work order detail's Linked Assets tab now shows a table of AssetTickets (not raw Assets) with: Asset ID, Status, Role, Model, IP Address, Location.
- Status is editable inline via a dropdown 
- Once a per-asset ticket is marked Done, it drops off this list too
- Dropped the MAC Address, Remediation, and Asset Status columns 

## Screenshots
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/80c9bc0d-a03d-4e0e-95c1-a7df908ccf91" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/15a7c377-a353-4efd-8dcd-a9d44c7974e7" />

<img width="1158" height="911" alt="image" src="https://github.com/user-attachments/assets/fdcd8311-75bf-4ee6-bd31-33e202c8e37a" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline status editing for tickets linked to assets.
  * Disabled status updates while changes are being saved.
  * Asset links now display the full asset ID when no hostname is available.

* **Bug Fixes**
  * Improved refresh behavior after updating linked ticket statuses.
  * Simplified linked asset details by removing outdated status, MAC address, and remediation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->