### PR TITLE
[VW-427] Creating new db models for VW-426

### DIFF
--- a/docs/integrations-ai-partner.md
+++ b/docs/integrations-ai-partner.md
@@ -1,0 +1,95 @@
+### How were Integrations originally designed to work?
+
+`ExternalAssetMapping` / `External*Mapping`: Used for synchronizing a VIPER model with a representation of it on an external platform. “Our row mirror a row that exists over there”.
+
+```
+model Asset {
+  id             String  @id @default(cuid())
+  serialNumber String?
+  macAddress String?
+  upstreamApi String
+  externalMappings     ExternalAssetMapping[]
+}
+
+model ExternalAssetMapping {
+  id            String      @id @default(cuid())
+  itemId        String
+  integrationId String
+  externalId    String // the id the asset has on say, Blueflow
+  // Relationships
+  item          Asset       @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  lastSynced    DateTime?
+
+  // Composite unique constraint: one external ID per integration per item
+  @@unique([itemId, integrationId], name: "external_asset_mappings_item_integration_key")
+  // Critical index for fast lookups: "find item by integration's external ID"
+  @@unique([integrationId, externalId], name: "external_asset_mappings_integration_external_key")
+  @@index([itemId])
+  @@map("external_asset_mappings")
+}
+
+model Integration {
+  id                 String          @id @default(cuid())
+  name               String
+  platform           String? // The name of the integration platform, e.g "BlueFlow"
+  integrationUri     String          @map("integration-uri")
+  integrationType    IntegrationType
+  // ^PARTNER: Helm, Blueflow. Follows VIPER standard 
+  // AI: uses AI to pull data from any platform
+  // REST: Used for teamplay Fleet integration?
+  prompt             String?         @db.Text // optional, additional instructions for AI
+  authType           AuthType
+  resourceType       ResourceType
+  authentication     Json? // TODO: this needs to be encrypted
+  syncEvery          Int // e.g 300, sync every 300 seconds
+  syncStatus         SyncStatus[]
+  lastSuccessfulSync DateTime?
+
+  // The user who created the integration
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // the user that this integration creates
+  integrationUserId String @unique
+  integrationUser   User   @relation(name: "integration_user", fields: [integrationUserId], references: [id], onDelete: Cascade)
+
+  assetMappings          ExternalAssetMapping[]
+  deviceArtifactMappings ExternalDeviceArtifactMapping[]
+  remediationMappings    ExternalRemediationMapping[]
+  vulnerabilityMappings  ExternalVulnerabilityMapping[]
+  workOrderMappings      ExternalWorkOrderMapping[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([integrationUserId])
+  @@map("integration")
+}
+```
+
+* Every `5 minutes`, an Inngest job gets triggered to go through all Integrations  
+* If the diff between now and `lastSuccessfulSync` is greater than `syncEvery`, we will sync this `Integration`  
+* Two pathways that merge into one:  
+  * For an AI integration:  
+    * Issues a token for the integration user (tokens expire after N minutes or when used, is essentially auth for a user)  
+    * Creates a unique callback URL with the token, provides a schema, and gives `authType`, `authentication`, `integrationUri`, and `additionalInstructions` to N8N  
+    * An N8N agent will go to `integrationUri`, authenticate, then follow `additionalInstructions`. It will find all \<assets|vulns|remediations|etc\>, format according to the schema, and then reply to the callback url  
+  * For a PARTNER integration (Blueflow):  
+    * Issue a token for the integration user  
+    * Creates a unique callback URL with the token  
+    * Authenticates, sends the callback url to `integrationUri` and a timestamp of when the last successful sync was. Should receive a 202 response  
+    * Partner service responds back to callback url with assets that were updated since the last sync timestamp.  
+* Without loss of generality, VIPER receives a list of assets at the callback url. This request is authenticated as `integrationUser`. For each asset in the payload:  
+  * VIPER looks up the field `externalId`, if provided.   
+  * Case 1\. `externalId` is provided, and VIPER has an `ExternalAssetMapping` with that unique ID, from this integration. VIPER updates the asset if any fields have changed.  
+  * Case 2\. `externalId` is provided, but VIPER does not have an `ExternalAssetMapping` with that ID. VIPER upserts an asset based on unique fields (macAddress, serialNumber). If the asset is created, it is created by the `integrationUser`. VIPER creates an `ExternalAssetMapping`, tying this asset to the integration.  
+    * Today, VIPER also modifies `upstreamApi` if provided – TODO: move `upstreamApi` from `Asset` to `ExternalAssetMapping`   
+  * Case 3\. `externalId` is not provided. Not handled today, this is a required field. XKCD 2200\.
+
+Currently, our auth middleware links requests to protected endpoints to a user, either via session or an API key (and now, token). `integrationUser` was a cheap way to extend this. An integration authenticates as a user. If an integration creates an asset, the asset `createdBy`, which expects a user, is set to the `integrationUser`. WLOG, a TA3 team creating a vulnerability on VIPER creates a user, authenticates with an API key, and then the “source tool” that created the vulnerability is the TA3 user.
+
+Not documented above: error handling, “REST” integration type

--- a/docs/integrations-redesign-implementation.md
+++ b/docs/integrations-redesign-implementation.md
@@ -1,0 +1,160 @@
+# Integrations Refactor — Implementation Guide
+
+Companion to [integrations-redesign.md](./integrations-redesign.md). That doc is the *design*; this one is the *how*, plus the context and decisions that live outside it.
+
+**Read `integrations-redesign.md` first.** It has the schema and the interfaces. Don't re-derive them from here.
+
+## Scope
+
+In scope, in this order:
+
+1. New/changed Prisma models + migrations
+2. `src/features/integrations/core/` — the platform interface and shared machinery
+3. `src/features/integrations/platforms/ai/` and `.../partner/` conforming to it
+
+**Out of scope.** Do not start these:
+
+- The `teamplay-fleet` platform module. It's the hardest one (headless auth, three resource modules) and lands after `ai`/`partner` prove the interface. Leave `src/features/integrations/teamplay-fleet/` alone.
+- UI changes beyond what's needed to typecheck.
+- Changing how `ai` sends credentials to n8n. It forwards them on purpose — see Ground rules. The POST body to `N8N_AI_SYNC_URL` must stay **byte-compatible** with what `syncAiIntegration` sends today; the committed workflow at `n8n_workflows/AI_Sync_Workflow.json` reads those exact fields.
+- Inbox-as-a-platform (see Open Questions in the RFC).
+
+## Ground rules
+
+These were decided deliberately. If a change looks like an obvious improvement, it was probably considered — check here before "fixing" it.
+
+| Decision | Why |
+|---|---|
+| `SourceRecord.raw` stays a Postgres `Json` column | S3 was proposed and rejected. Don't reintroduce it. |
+| Six separate `External*Mapping` tables | Real FKs and cascade deletes beat one polymorphic table. Additive migration. |
+| `ResourceModule`s are named fields (`workOrders`/`assets`/`notifications`), not a `ResourceType`-keyed map | Deliberate. Consequence: `core` needs a field→`ResourceType` mapping. It lives in **one** helper (`core/sync/resources.ts`) so adding a field means editing one function. |
+| No `resourcesFor` hook on `ConnectorModule` | The absence of `ResourceModule` fields *is* the signal that a platform is generic; core then reads `config.resource`, validated by a shared zod schema. Don't add a per-module hook back — it would return a 1-element array for every implementor. |
+| `ai` forwards credentials to n8n | **Intended, not a leak.** n8n crawls the upstream on our behalf and authenticates as us. `SyncCtx.creds` exists for this. |
+| `ai`/`partner` are **single-resource** (`config.resource`) | One `Integration` = one resource for generic platforms. Only code-defined platforms are multi-resource. |
+| No `InstanceCtx` type | Mappers and URL builders take `config: TConfig` and nothing else. Row-level facts (`integrationId`, shadow user) stay in `core/sync/ingest.ts`, which already loads the row. |
+| Credentials appear **only** in `createSession` | Never pass them to `toCanonical`, `apiUrlFor`, or `ingest`. A mapper that can reach credentials is one refactor from logging them. |
+| `nextSyncAt` is written at attempt **start** | If written on completion, a crashed worker never advances it and the row wedges forever — the bug that exists today. |
+| `SourceRecord.referenceUrl` is dropped | Derive from the mapping + `webUrlFor` instead. |
+| One meaning per column | `syncEvery` null = inherit. `nextSyncAt` null = due now. `enabled` = operator toggle. Pollability = `changeSources.includes('poll')`. Never overload these. |
+
+## Current state — what exists today
+
+### Prisma (`prisma/schema.prisma`)
+
+| Today | Becomes |
+|---|---|
+| `Integration` (`platform String?`, `integrationType`, `resourceType`, `authType`, `authentication Json?`, `integrationUri`, `prompt`) | `Integration` with `platform PlatformEnum`, `config Json`, `credentials Bytes?` |
+| `SyncStatus` | `IntegrationResourceSync` (adds cursor, cadence, `enabled`, `nextSyncAt`, `consecutiveFailures`) |
+| `IntegrationSession` (keyed `host @unique` — globally, so two accounts on one platform are impossible; `expiresAt` written but never read) | deleted |
+| `NotificationSource` | `SourceRecord` + `SourceLink` |
+| `NotificationChannel { Email, PolledApi, Crawl, TA4 }` | `SourceChannel { Email, Integration, TA4 }` |
+| `NotificationSourceType` | `SourceLinkType` |
+| `Asset.upstreamApi String` (**required**), same field nullable on `Vulnerability` / `Remediation` / `DeviceArtifact` | `External*Mapping.upstreamApi String?` + new sibling `webUrl String?` |
+| — | `PlatformEnum`, `ManagesRelationship`, `ExternalSourceRecordMapping` |
+
+`ExternalVulnerabilityMapping` maps to the legacy table name `external_item_mappings`. Renaming it is optional; if you do, it's a separate migration.
+
+### Code
+
+| Path | Role today |
+|---|---|
+| `src/inngest/functions/sync-integrations.ts` | Everything. `syncAllIntegrations` (cron), `syncIntegration` (the `integrationType` switch), `syncAiIntegration`, `syncPartnerIntegration`, `syncRestIntegration`, `REST_MAPPERS` + `selectRestMapper`, `getResponseConfig` |
+| `src/lib/router-utils.ts` | `processIntegrationSync` (dedup/upsert engine), `processIntegrationToken`, `upsertSyncStatus` |
+| `src/lib/utils.ts` | `parseAuthenticationJson` — builds auth headers from the plaintext JSON |
+| `src/lib/schemas.ts` | `authSchema`, `createIntegrationInputSchema` (the upload envelope — add an optional per-item `webUrl` alongside `upstreamApi`) |
+| `src/lib/tokens.ts` | `createUserToken` / `consumeUserToken` — single-use, SHA-256 hashed, 15 min TTL. The one secret handled well today. |
+| `src/features/integrations/integration-session-client.ts` | `IntegrationSessionClient` — cookie session + re-auth on 401/403 |
+| `src/features/integrations/server/routers.ts` | tRPC CRUD + `triggerSync` |
+| `src/features/integrations/types.ts` | input zod schema, `integrationsMapping` (URL slug → `ResourceType`) |
+| `src/app/api/inngest/route.ts` | registers `syncAllIntegrations`, `syncIntegration` |
+
+**Upload endpoints** (`trpc-to-openapi`, path `/{resource}/integrationUpload/{token}`) — these stay; `core/callback.ts` targets them:
+`assets`, `vulnerabilities`, `remediations`, `deviceArtifacts` (`src/features/*/server/routers.ts`) and `workOrders` (`src/features/tracking/server/routers.ts`).
+
+**Env vars.** `N8N_AI_SYNC_URL`, `N8N_KEY` (ai). Add `CREDENTIAL_ENCRYPTION_KEY` (32 bytes, base64) to `.env.example`. Note `FLEET_ADVISORY_USERNAME` / `FLEET_ADVISORY_PASSWORD` are read at runtime but missing from `.env.example` — pre-existing, Fleet-phase problem.
+
+## Phase 1 — DB models
+
+Write the schema, then the migration, then a backfill script. There is live data; none of this is a clean create.
+
+### Prisma gotchas hit while designing this
+
+- **`SourceRecord` ↔ `ExternalSourceRecordMapping` needs two *named* relations.** The snapshot list and the `latestSourceRecordId` pointer are separate relations (`"MappingSnapshots"` / `"LatestSourceRecord"`) or Prisma reads them as one ambiguous pair. `latestForMapping` is a back-reference that generates **no column** — it's required bookkeeping, not a field. Same idiom as `Artifact.latestForWrapper` ↔ `ArtifactWrapper.latestArtifact`, already in the schema.
+- **`Contract.managesRelationshipId` must be `@unique`** or Prisma makes it many-to-one instead of 1:1.
+- **`Integration` → `User` twice** (creator + shadow user); the second keeps `name: "integration_user"`.
+- **`assets Asset[] @relation("ManagedAssets")`** needs `managedBy ManagesRelationship[] @relation("ManagedAssets")` added to `Asset`.
+- Prisma client output is `src/generated/prisma`, not `node_modules`. Run `npx prisma generate` after schema edits.
+
+### Backfill
+
+| From | To | Notes |
+|---|---|---|
+| `Integration.authentication` (plaintext JSON) | `credentials` (AES-256-GCM) | Encrypt in place with a script. Read shape via `authSchema`. |
+| `Integration.integrationUri` / `prompt` / `authType` | `config` JSON | Shape depends on `platform`; write per-platform. |
+| `Integration.resourceType` | one `IntegrationResourceSync` row | Also seed `config.resource` for ai/partner. |
+| `SyncStatus` | `IntegrationResourceSync.status` / `errorMessage` | Keep only the newest per integration. |
+| `Asset.upstreamApi` (required) | `ExternalAssetMapping.upstreamApi` | Only where a mapping exists. Manually-created assets have a human-typed URL and simply lose it — intended. `webUrl` starts null everywhere. |
+| `NotificationSource.raw` | `SourceRecord.contentHash` | Hash existing `raw` to seed the column. |
+| `NotificationSource.channel` `PolledApi`/`Crawl` | `Integration` | `Crawl` is currently never written. |
+| `NotificationSource.notificationId` / `workOrderTicketId` + `sourceType` + `reasonWhy` | one `SourceLink` row each | This is the join-table split. |
+
+Only `Email` and `PolledApi` are ever written as channel values today — `Crawl` and `TA4` are declared but unused. `SourceRecord.referenceUrl`'s predecessor is likewise never populated, so dropping it moves no data.
+
+## Phase 2 — `core/`
+
+```
+src/features/integrations/core/
+  types.ts        # verbatim from the RFC
+  registry.ts     # PlatformEnum -> ConnectorModule
+  credentials.ts  # encrypt/decrypt against CREDENTIAL_ENCRYPTION_KEY
+  callback.ts     # port getResponseConfig out of sync-integrations.ts
+  urls.ts         # module.apiUrlFor/webUrlFor, else mapping.upstreamApi/webUrl
+  session/{http,basic}.ts
+  sync/
+    index.ts      # resolveSyncStrategy
+    resources.ts  # resourcesFor — module fields, else config.resource
+    poll.ts       # pollSync — unused until Fleet, but the interface needs it
+    ingest.ts     # port processIntegrationSync out of router-utils.ts
+```
+
+- `registry.ts` should assert at load that every module either has a `ResourceModule` field or a config that parses as generic (`{ resource }`). Otherwise a misconfigured platform silently never syncs.
+- `ingest.ts`: **fix the bug while porting.** `processIntegrationSync` currently `break`s out of the item loop on the first Prisma error, silently dropping the rest of the batch and reporting partial success as one `Error`. Collect errors and continue.
+- `callback.ts` is the only thing `ai` and `partner` share. Neither touches `poll.ts`.
+
+## Phase 3 — `ai` and `partner`
+
+```
+src/features/integrations/platforms/{ai,partner}/
+  index.ts config.ts sync.ts
+```
+
+Both: `createSession` is a no-op passthrough, **no `ResourceModule` fields at all**, `config.resource` names the single resource, and `changeSources: ['poll', 'push']`.
+
+That pair is not a contradiction. `'poll'` is what makes the cron schedule them — they run on `syncEvery` like any poller. `'push'` describes what happens when the tick fires: the strategy hands off and returns `{ pending: true }` instead of fetching. Drop `'poll'` and they'd never be scheduled at all.
+
+Move `syncAiIntegration` and `syncPartnerIntegration` out of `sync-integrations.ts` into each platform's `sync.ts`, reshaped as a `SyncStrategy`. Both return `{ pending: true }` — the work finishes when the callback lands, so the row must stay `Pending`, not flip to `Success`.
+
+Then `sync-integrations.ts` keeps only the two Inngest functions, with no platform knowledge: delete the `integrationType` switch, `REST_MAPPERS`, `selectRestMapper`, and `syncRestIntegration`.
+
+### Two known limits — preserve, don't fix
+
+- `partner` hard-codes `max_pages: 1`. The callback token is single-use, so page 2 would 401. Lifting this needs a multi-use or per-page token; out of scope.
+- `syncAllIntegrations` today gates on the newest `SyncStatus` row *regardless of state*, so a stuck `Pending` suppresses re-sync forever. The new `nextSyncAt` gate fixes this — make sure you don't reimplement the old predicate alongside it.
+
+Also add `concurrency: { key: integrationId + resource }` to `syncIntegration`; today there's none, so a manual *Sync Now* and the cron can run the same integration twice at once.
+
+## Verify
+
+```bash
+npx prisma validate && npx prisma generate && npm run lint
+```
+
+The design's schema was validated against a stubbed `prisma validate` run, so it compiles — but the *migration* is yours to prove.
+
+- Existing tests that touch this code: `src/app/api/v1/__tests__/remediations.test.ts`, and `teamplay-fleet/{activities,tracking}.test.ts` (should be untouched — if they break, you went out of scope).
+- Partner end-to-end: `docs/blueflow-integration-testing.md`. `scripts/create-blueflow-integration.ts` creates an `Integration` with the old fields and **will need updating**.
+- Run `npm run dev:all` and trigger a sync from the integrations page; confirm one `IntegrationResourceSync` row advances `nextSyncAt` at attempt start and stays `Pending` until the callback lands.
+
+## If something's ambiguous
+
+The RFC's "Open Questions" section lists what's genuinely undecided. Anything not there was decided — check the Ground rules table above, and ask rather than choosing for yourself.

--- a/docs/integrations-redesign-implementation.md
+++ b/docs/integrations-redesign-implementation.md
@@ -8,7 +8,7 @@ Companion to [integrations-redesign.md](./integrations-redesign.md). That doc is
 
 In scope, in this order:
 
-1. New/changed Prisma models + migrations
+1. New/changed Prisma models + migrations - First plan should be this!
 2. `src/features/integrations/core/` — the platform interface and shared machinery
 3. `src/features/integrations/platforms/ai/` and `.../partner/` conforming to it
 
@@ -79,7 +79,7 @@ Write the schema, then the migration, then a backfill script. There is live data
 
 ### Prisma gotchas hit while designing this
 
-- **`SourceRecord` ↔ `ExternalSourceRecordMapping` needs two *named* relations.** The snapshot list and the `latestSourceRecordId` pointer are separate relations (`"MappingSnapshots"` / `"LatestSourceRecord"`) or Prisma reads them as one ambiguous pair. `latestForMapping` is a back-reference that generates **no column** — it's required bookkeeping, not a field. Same idiom as `Artifact.latestForWrapper` ↔ `ArtifactWrapper.latestArtifact`, already in the schema.
+- **`SourceRecord` ↔ `ExternalSourceRecordMapping` is a plain 1:many.** There is deliberately **no** latest-snapshot pointer. `ArtifactWrapper.latestArtifact` does it that way and we're not copying it: a denormalized pointer is a second source of truth that goes stale whenever a write path forgets to repoint (and `onDelete: SetNull` orphans it if the newest snapshot is ever pruned). "Newest for this mapping" is `ORDER BY observedAt DESC LIMIT 1` against `@@index([mappingId, observedAt])` — same answer, no maintenance. Don't add the pointer back for symmetry with `ArtifactWrapper`.
 - **`Contract.managesRelationshipId` must be `@unique`** or Prisma makes it many-to-one instead of 1:1.
 - **`Integration` → `User` twice** (creator + shadow user); the second keeps `name: "integration_user"`.
 - **`assets Asset[] @relation("ManagedAssets")`** needs `managedBy ManagesRelationship[] @relation("ManagedAssets")` added to `Asset`.

--- a/docs/integrations-redesign.md
+++ b/docs/integrations-redesign.md
@@ -116,13 +116,10 @@ model SourceRecord {
   channel SourceChannel // { Email, Integration, TA4 }
 
   // null for email / TA4 sources, since those aren't mirrored rows
-  mappingId        String?
-  mapping          ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
-  // opposite side of ExternalSourceRecordMapping.latestSourceRecord.
-  // Prisma bookkeeping — declares the second relation, generates no column.
-  latestForMapping ExternalSourceRecordMapping? @relation(name: "LatestSourceRecord")
+  mappingId String?
+  mapping   ExternalSourceRecordMapping? @relation(fields: [mappingId], references: [id], onDelete: Cascade)
 
-  contentHash String // dedup: skip the write if it matches the mapping's latest
+  contentHash String // dedup: skip the write if it matches the mapping's newest
   raw         Json    @default("{}")
   markdown    String? @db.Text
   // channel-scoped id for sources with no mapping (e.g. the Resend email id)
@@ -171,9 +168,10 @@ model ExternalSourceRecordMapping {
   integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
   externalId    String // the advisory / notification id on another platform
 
-  sourceRecords        SourceRecord[] @relation(name: "MappingSnapshots")
-  latestSourceRecordId String?        @unique
-  latestSourceRecord   SourceRecord?  @relation(name: "LatestSourceRecord", fields: [latestSourceRecordId], references: [id], onDelete: SetNull)
+  // No latest-snapshot pointer. "Newest" is an ORDER BY observedAt DESC LIMIT 1
+  // over @@index([mappingId, observedAt]) on SourceRecord — same answer, one
+  // source of truth, nothing to keep in sync on write.
+  sourceRecords SourceRecord[]
 
   lastSynced DateTime?
   createdAt  DateTime  @default(now())

--- a/docs/integrations-redesign.md
+++ b/docs/integrations-redesign.md
@@ -1,0 +1,533 @@
+# Viper Integrations Refactor RFC
+
+## Why
+
+Previously our integration code lived in multiple places, and did not reuse common things like sessions. Because integration logic was spread across our backend, it seemed like every integration was a hack. Finally, some of our db models seemed to have overlapping responsibilities.
+
+This document describes first how VIPER integrations will be implemented *instead*, and then enumerates explicit changes from what we do today.
+
+## General shape of this
+
+* A Platform is a module of code that handles everything about an integration (say, work orders, assets, notifications, authentication). A platform defines what it needs from the user (config + credentials)
+* An `Integration` is an instance of a platform, which specifies its platform via a `PlatformEnum`
+* An `Integration` is pretty much just a way to save settings and auth to the db
+* A platform we wrote a module for (Fleet, ServiceNow) MAY sync several resource types from one `Integration` — one set of credentials, one row, independent cursors per resource
+* The generic platforms (`ai`, `partner`) are **single-resource**: the resource is part of their config
+* All `Platform` code lives together. A `Platform` follows a generic interface, and implements certain functions
+
+## DB Models
+
+What is an `External*Mapping`?
+
+* "Our row mirrors a row that exists over there"
+* Unique on `(integrationId, externalId)` — that constraint is the dedup key on every sync
+* Also holds `upstreamApi` / `webUrl` for platforms too generic to derive them
+
+What is a `SourceRecord`?
+
+* A snapshot of some record at a point in time, that goes on to be a source for a notification or work order
+* `SourceRecord`s are append-only, and deduplicate based on a `contentHash`. We order based on an `observedAt` field. This is cheap "version control".
+* A `SourceRecord` may come from an integration (e.g. advisories come from teamplay Fleet). We populate `ExternalSourceRecordMapping` if so, and one mapping owns many snapshots.
+* What a snapshot **is** and what it **fed** are different directions. `remediationId` is the former — a TA4 remediation POSTed to `/api/v1/remediations` writes its raw submission *and* points at the `Remediation` it created. What it fed goes through `SourceLink`.
+* `SourceLink` is a join table because `sourceType` and `reasonWhy` describe *the decision to attach*, not the snapshot — `process-inbox-email.ts` sets them at classification time. One advisory can explain several CVEs, and under content-hash dedup you can't express that by duplicating the record.
+* Examples:
+  * A copy of an email (not version controlled)
+  * What an advisory looked like when it was first published, hot off the press
+  * What an advisory looked like 10 hours after it was published, now the text is all different
+
+```prisma
+enum SourceLinkType {
+  Source // the target was created as a result of this record
+  Link   // the target already existed and this record was attached to it
+}
+
+// replaces NotificationChannel. how a record entered the system;
+// the platform behind `mappingId` says where it came from.
+enum SourceChannel {
+  Email       // inbound mail — mappingId null, externalId is the Resend id
+  Integration // from a platform — mappingId set. absorbs PolledApi and Crawl
+  TA4         // POSTed to /api/v1/remediations
+}
+
+model Integration {
+  id       String       @id @default(cuid())
+  name     String
+  platform PlatformEnum // { AI, PARTNER, FLEET, SERVICE_NOW }
+
+  config      Json   @default("{}") // validated by the platform's configSchema
+  credentials Bytes? // AES-256-GCM, key from CREDENTIAL_ENCRYPTION_KEY
+                     // decrypted plaintext is validated by the platform's credentialSchema
+
+  syncEvery Int?    // seconds. null = inherit the platform's defaultSyncEvery.
+                    // NOT "don't poll" — that's decided by changeSources.
+  enabled   Boolean @default(true)
+
+  // the user who created the integration
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // the shadow user this integration owns; ingested rows are attributed to it
+  integrationUserId String @unique
+  integrationUser   User   @relation(name: "integration_user", fields: [integrationUserId], references: [id], onDelete: Cascade)
+
+  resourceSyncs IntegrationResourceSync[]
+
+  // not pictured: back relations for `External*Mapping[]`, `ManagesRelationship[]`,
+  //               and apiKeyConnector
+  // not pictured: createdAt, updatedAt timestamps
+
+  @@index([userId])
+  @@index([integrationUserId])
+  @@map("integration")
+}
+
+// replaces SyncStatus. one row per (integration, resource)
+model IntegrationResourceSync {
+  id            String       @id @default(cuid())
+  integrationId String
+  integration   Integration  @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  resource      ResourceType // Asset | WorkOrder | SourceRecord | Vulnerability | ...
+
+  cursor              Json?          // for pagination — opaque to core, see "Cursors"
+  status              SyncStatusEnum @default(Pending)
+  errorMessage        String?
+  lastAttemptAt       DateTime?
+  lastSuccessfulSync  DateTime?
+  consecutiveFailures Int            @default(0) // drives the backoff exponent; reset to 0 on success
+
+  syncEvery Int?    // seconds. overrides Integration.
+  enabled   Boolean @default(true) // operator toggle: turn off Fleet assets, keep work orders.
+                                   // Distinct from pollability, which changeSources decides.
+  nextSyncAt DateTime? // when this resource is next due. null = due now.
+                       // Written at attempt *start* so a crashed worker can't wedge the
+                       // row, and jittered so instances don't fall into lockstep:
+                       //   now() + min(syncEvery * 2^consecutiveFailures, cap) * (0.9 + rand*0.2)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([integrationId, resource])
+  @@index([integrationId])
+  @@map("integration_resource_sync")
+}
+
+model SourceRecord {
+  id      String        @id @default(cuid())
+  channel SourceChannel // { Email, Integration, TA4 }
+
+  // null for email / TA4 sources, since those aren't mirrored rows
+  mappingId        String?
+  mapping          ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
+  // opposite side of ExternalSourceRecordMapping.latestSourceRecord.
+  // Prisma bookkeeping — declares the second relation, generates no column.
+  latestForMapping ExternalSourceRecordMapping? @relation(name: "LatestSourceRecord")
+
+  contentHash String // dedup: skip the write if it matches the mapping's latest
+  raw         Json    @default("{}")
+  markdown    String? @db.Text
+  // channel-scoped id for sources with no mapping (e.g. the Resend email id)
+  externalId  String?
+  observedAt  DateTime @default(now())
+
+  // A SourceRecord can optionally be a TA4 remediation
+  remediationId String?
+  remediation   Remediation? @relation(fields: [remediationId], references: [id], onDelete: SetNull)
+
+  links       SourceLink[] // what notifications / work orders this source feeds
+  attachments NotificationAttachment[]
+
+  @@unique([channel, externalId])
+  @@index([mappingId, observedAt])
+  @@index([remediationId])
+  @@map("source_record")
+}
+
+model SourceLink {
+  id             String       @id @default(cuid())
+  sourceRecordId String
+  sourceRecord   SourceRecord @relation(fields: [sourceRecordId], references: [id], onDelete: Cascade)
+
+  // either a notification or a work order
+  notificationId    String?
+  notification      Notification?    @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+  workOrderTicketId String?
+  workOrderTicket   WorkOrderTicket? @relation(fields: [workOrderTicketId], references: [id], onDelete: Cascade)
+
+  sourceType SourceLinkType @default(Source) // Source or Link
+  reasonWhy  String?        @db.Text
+
+  createdAt DateTime @default(now())
+
+  @@unique([sourceRecordId, notificationId])
+  @@unique([sourceRecordId, workOrderTicketId])
+  @@index([notificationId])
+  @@index([workOrderTicketId])
+  @@map("source_link")
+}
+
+model ExternalSourceRecordMapping {
+  id            String      @id @default(cuid())
+  integrationId String
+  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  externalId    String // the advisory / notification id on another platform
+
+  sourceRecords        SourceRecord[] @relation(name: "MappingSnapshots")
+  latestSourceRecordId String?        @unique
+  latestSourceRecord   SourceRecord?  @relation(name: "LatestSourceRecord", fields: [latestSourceRecordId], references: [id], onDelete: SetNull)
+
+  lastSynced DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@unique([integrationId, externalId])
+  @@index([integrationId])
+  @@map("external_source_record_mappings")
+}
+
+model ExternalAssetMapping {
+  // same fields as before
+  // Both optional, both only set by ai/partner — code-defined platforms derive
+  // these from their ResourceModule instead. Supplied per item in the upload envelope.
+  upstreamApi String? // the API endpoint
+  webUrl      String? // where a human looks at it
+}
+```
+
+New tables for "who in the hospital, or outside of it, is responsible for managing this asset?"
+
+```prisma
+model ManagesRelationship {
+  id               String @id @default(cuid())
+  responsibilities String @db.Text
+
+  departmentId String?
+  department   Department? @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+
+  // one vendor has many ManagesRelationships
+  vendorId String?
+  vendor   Vendor?   @relation(fields: [vendorId], references: [id], onDelete: SetNull)
+  contract Contract? // optional if a vendor is provided. fk lives on Contract
+
+  // where work orders for these assets get filed
+  workOrderIntegrationId String?
+  workOrderIntegration   Integration? @relation(fields: [workOrderIntegrationId], references: [id], onDelete: SetNull)
+
+  assets Asset[] @relation("ManagedAssets")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([departmentId])
+  @@index([vendorId])
+  @@index([workOrderIntegrationId])
+  @@map("manages_relationship")
+}
+
+model Contract {
+  // ... existing fields (vendor, coverageSummary, files)
+
+  // one-to-one with ManagesRelationship
+  managesRelationshipId String?              @unique
+  managesRelationship   ManagesRelationship? @relation(fields: [managesRelationshipId], references: [id], onDelete: SetNull)
+
+  // TODO: A Contract has a ContractSla in the future
+}
+```
+
+This replaces today's *derived* answer to "who manages this asset?" — currently inferred from "has an `ExternalAssetMapping` to a Fleet integration" (`teamplay-fleet/tracking.ts`).
+
+## Platforms as Code
+
+### Core
+
+* `types.ts` – types that define what a platform is
+* `registry.ts` – exports the platforms, keyed by `PlatformEnum`
+* `credentials.ts` – `encrypt` / `decrypt` against `CREDENTIAL_ENCRYPTION_KEY`
+* `callback.ts` – mints the one-time upload token, response path, and resource JSON Schema for platforms that push data back to us (today's `getResponseConfig`)
+* `urls.ts` – resolves a record's URLs. `api` = module's `apiUrlFor` ?? `mapping.upstreamApi`; `web` = module's `webUrlFor` ?? `mapping.webUrl` ?? the api URL. The two branches never collide: Fleet derives and stores nothing, a partner stores and derives nothing.
+* `session/` – auth helpers
+  * `http.ts` – fetch wrapper: base URL, timeout, JSON, retry
+  * `basic.ts` – static header auth (basic / bearer / arbitrary header)
+* `sync/` – shared sync helpers
+  * `index.ts` – `resolveSyncStrategy(platform)`: the platform's own `sync`, else `pollSync`
+  * `poll.ts` – `pollSync`: the default `listChanged` -> `toCanonical` -> ingest -> persist cursor loop
+  * `ingest.ts` – dedup + upsert against `External*Mapping` (today's `processIntegrationSync`)
+
+#### src/features/integrations/core/types.ts
+
+```ts
+export interface Session {
+  request<T>(path: string, init?: RequestInit): Promise<T>;
+  dispose?(): Promise<void>;
+}
+
+export interface ConnectorModule<TConfig = unknown, TCreds = unknown> {
+  definition: ConnectorDefinition<TConfig, TCreds>;
+  createSession(input: { config: TConfig; creds: TCreds }): Promise<Session>;
+
+  // How this platform syncs. Omitted -> core's pollSync drives the
+  // ResourceModules below. ai/partner set this and have no ResourceModules.
+  sync?: SyncStrategy<TConfig>;
+
+  workOrders?:    ResourceModule<ViperWorkOrder, unknown, TConfig>;
+  assets?:        ResourceModule<ViperAsset, unknown, TConfig>;
+  notifications?: ResourceModule<ViperSourceRecord, unknown, TConfig>;
+}
+
+export interface ConnectorDefinition<TConfig, TCreds> {
+  platform: PlatformEnum;                // no free-text slug to drift from the enum
+  displayName: string;
+  configSchema: z.ZodType<TConfig>;      // → validates instance.config
+  credentialSchema: z.ZodType<TCreds>;   // → validates what goes to `credentials` bytes
+
+  // poll    = the cron schedules it                          (fleet, ai, partner)
+  // push    = data returns via our callback instead of us fetching it (ai, partner)
+  // webhook = they notify us unprompted, nothing is scheduled
+  // These are independent: ai/partner are ['poll', 'push'] — scheduled like any
+  // poller, but the tick hands off rather than fetching. The cron filters on
+  // 'poll'; 'push' is what makes the strategy return `pending: true`.
+  changeSources: ReadonlyArray<'poll' | 'push' | 'webhook'>;
+
+  // Connection-level rate limit floor. Enforced when the operator saves the
+  // integration — before any resource is in scope, which is why it lives here
+  // and defaultSyncEvery lives on the resource module.
+  minSyncEvery?: number;
+}
+
+export interface ResourceModule<TCanonical, TRaw = unknown, TConfig = unknown> {
+  // we pull from their platform
+  listChanged(s: Session, cursor: Cursor | null): AsyncIterable<Page<TRaw>>;
+  get(s: Session, externalId: string): Promise<TRaw>;
+  toCanonical(raw: TRaw, config: TConfig): TCanonical;
+
+  // we push to their platform
+  create?(s: Session, c: CanonicalDraft<TCanonical>): Promise<PushResult<TRaw>>;
+  update?(s: Session, externalId: string, patch: Patch<TCanonical>): Promise<PushResult<TRaw>>;
+
+  // where is it on their platform?
+  //  api: what's the api url?
+  //  web: where does a human look to find this?
+  apiUrlFor?(externalId: string, config: TConfig): string | null;
+  webUrlFor?(externalId: string, config: TConfig): string | null;
+
+  defaultSyncEvery: number | null; // this resource's natural cadence
+}
+
+// A strategy owns one (integration, resource) sync attempt end to end.
+// It reports the cursor it reached; the worker persists it.
+export type SyncStrategy<TConfig = unknown> =
+  (ctx: SyncCtx<TConfig>) => Promise<{ cursor: Cursor | null; pending?: boolean }>;
+
+export interface SyncCtx<TConfig = unknown, TCreds = unknown> {
+  config: TConfig;
+  creds: TCreds;  // ai forwards these to n8n — see the note below
+  resource: ResourceType;
+  session: Session;
+  cursor: Cursor | null;
+  lastSuccessfulSync: Date | null;          // partner's `since` when there's no cursor yet
+  ingest(items: unknown[]): Promise<void>;  // core/sync/ingest.ts — closes over the row,
+                                            // so attribution and mappings stay in core
+  callback(): Promise<CallbackConfig>;      // core/callback.ts — token scoped to the shadow user
+}
+
+// Opaque to core: round-tripped through IntegrationResourceSync.cursor and
+// interpreted only by the platform that produced it. See "Cursors".
+export type Cursor = unknown;
+```
+
+Credentials reach exactly two places: `createSession` and `SyncCtx`. They must **not** reach `toCanonical`, `apiUrlFor`, `webUrlFor`, or `ingest` — a mapper that can read credentials is one refactor away from logging them, and mappers have no use for them.
+
+`SyncCtx.creds` exists because the `ai` strategy forwards them to n8n, which crawls the upstream on our behalf and needs to authenticate as us. That is intended behavior and the n8n workflow depends on it, so the POST body to `N8N_AI_SYNC_URL` stays byte-compatible with what `syncAiIntegration` sends today.
+
+#### Who speaks whose protocol
+
+This is what decides whether a platform has `ResourceModule`s at all.
+
+* **We speak theirs** (`fleet`, `service_now`). The upstream has its own shape, so the platform needs a `ResourceModule` per resource to `listChanged` / `get` / `toCanonical`.
+* **They speak ours** (`ai`, `partner`). Items arrive already in VIPER's shape — that's what "follows the VIPER standard" means, and for `ai` it's why n8n is handed `z.toJSONSchema(integrationAssetInputSchema)`. There's nothing to translate, so **every `ResourceModule` field is omitted**: no `listChanged`, no `toCanonical`, no `apiUrlFor`. Their `sync` strategy hands off, the callback validates against the existing `integration*InputSchema`, and `core/sync/ingest.ts` does the upsert.
+
+That's also why only three module fields exist. Vulnerabilities, remediations, and device artifacts arrive exclusively through `ai`/`partner` today, and those don't use `ResourceModule`s — so there's nothing to declare. The day a code-defined platform needs one, it's a one-line addition.
+
+It's also why `upstreamApi` and `webUrl` survive on the mappings: a generic platform has no `webUrlFor` to call, so its URLs have to be stored.
+
+Core resolves the resource list in one place. **There is no `resourcesFor` hook on the module** — the absence of `ResourceModule` fields is itself the signal that a platform is generic, and a generic platform's resource is in its config:
+
+```ts
+// core/sync/resources.ts
+const genericConfig = z.object({ resource: z.nativeEnum(ResourceType) });
+
+export const resourcesFor = (p: ConnectorModule, config: unknown): ResourceType[] => {
+  const fromModules = [
+    p.workOrders    && ResourceType.WorkOrder,
+    p.assets        && ResourceType.Asset,
+    p.notifications && ResourceType.SourceRecord,
+  ].filter(Boolean);
+
+  // No ResourceModules => generic platform => the resource is in config.
+  return fromModules.length ? fromModules : [genericConfig.parse(config).resource];
+};
+```
+
+`genericConfig.parse` makes "a generic platform declares `config.resource`" a validated contract rather than a silent convention — it fails loudly instead of returning `[]` and never syncing. Worth re-asserting at registry load so it's a startup error.
+
+#### Cadence
+
+Four levels, resolved in one function. The platform author knows the right cadence per resource; the operator overrides only when they have a reason.
+
+```ts
+resourceSync.syncEvery                  // per-resource override, usually null
+  ?? integration.syncEvery              // instance-wide override
+  ?? module.defaultSyncEvery            // platform knows assets are slow-moving
+  ?? INTEGRATION_SYNC_EVERY_MIN * 60    // global floor
+```
+
+Clamped to `definition.minSyncEvery` at write time.
+
+#### Cursors
+
+A cursor answers exactly one question: *what do I ask for next time?* Core never reads it — it round-trips the JSON and the platform narrows it with its own Zod schema. Shapes, by upstream pagination style:
+
+| Style | Cursor | Who |
+|---|---|---|
+| Watermark | `{ v: 1, since: '2026-08-10T04:00:00Z' }` | `partner` today (it's `lastSuccessfulSync`) |
+| Watermark + tiebreak | `{ v: 1, updatedAt: '…', lastId: 'WO-1234' }` | anything with same-second write volume |
+| Opaque token | `{ v: 1, pageToken: 'eyJvZmZzZXQiOjUwMH0' }` | most modern REST APIs |
+| Offset | `{ v: 1, offset: 500 }` | Fleet `/activities` — `deriveOffsetFromUrl` already does this |
+
+Three rules that matter more than the shape:
+
+* **Carry a tiebreaker with any timestamp.** A bare `since` silently drops records when more share one timestamp than fit in a page and the boundary lands mid-group. `lastId` makes the boundary total.
+* **Version it.** `v` lets a platform change cursor shape later; on mismatch, discard and full-resync rather than misread an old value.
+* **Overlap on purpose.** Because `ingest` dedups on `(integrationId, externalId)`, replaying is idempotent — so a watermark should rewind a few minutes to absorb upstream clock skew and late writes. Re-fetching is cheap; a missed record is invisible forever.
+
+The cursor is not `lastSuccessfulSync`: one is *where to resume*, the other is *when we last finished*, and only the second belongs in the UI. Push platforms return `pending: true` and leave the cursor untouched — the callback advances it.
+
+### Platforms
+
+#### src/features/integrations/platforms/teamplay-fleet/
+
+* `index.ts` – assembles and exports modules
+* `config.ts` – what the user has to provide. A zod schema. Any required constants.
+  * configSchema, credentialSchema
+* `session.ts` – how do we do auth?
+  * createSession
+* `urls.ts` – shared builders behind each module's `apiUrlFor` / `webUrlFor`
+* `work-orders.ts` – ResourceModule
+* `assets.ts` – ResourceModule
+* `notifications.ts` – ResourceModule (advisories → SourceRecords)
+
+`index.ts`
+
+```ts
+export const teamplayFleet: ConnectorModule<Config, Creds> = {
+  definition: {
+    platform: PlatformEnum.FLEET,
+    displayName: 'teamplay Fleet',
+    configSchema, credentialSchema,
+    changeSources: ['poll'],
+  },
+  createSession,
+  // no `sync` -- falls back to `pollSync`
+  workOrders,
+  assets,
+  notifications,
+};
+```
+
+`config.ts` – what the user has to provide (e.g. authentication, base URL…). A Zod schema. Also contains any required constants.
+
+```ts
+export const configSchema = z.object({
+  siteAddress: fleetAddressSchema, // was FLEET_SITE_ADDRESS env var
+  contactPhone: z.string(),        // was FLEET_CONTACT_PHONE env var
+});
+export const credentialSchema = z.object({ username: z.string(), password: z.string() });
+export const BASE_URL = 'https://fleet.siemens-healthineers.com';
+```
+
+This retires `FLEET_ADVISORY_USERNAME` / `FLEET_ADVISORY_PASSWORD` — per-deployment config and creds move onto the row, so a second Fleet account stops being impossible.
+
+`session.ts` – how does auth work?
+
+```ts
+// Fleet has no API auth — we drive the login form headlessly and reuse the cookie.
+// Re-implement today's capture.ts here. The cookie is cached in-process with a
+// TTL; there is no IntegrationSession table anymore.
+export async function createSession({ config, creds }): Promise<Session> { /* … */ }
+```
+
+#### src/features/integrations/platforms/ai/
+
+`config.ts`
+
+```ts
+export const configSchema = z.object({
+  integrationUri: safeUrlSchema,
+  resource: z.enum(ResourceType),                // single-resource
+  additionalInstructions: z.string().optional(), // today's Integration.prompt
+});
+export const credentialSchema = authCredentialSchema; // basic | bearer | header | none
+```
+
+`sync.ts` – move `syncAiIntegration` from `src/inngest/functions/sync-integrations.ts` to here. VIPER doesn't fetch anything itself: it POSTs `integrationUri`, `additionalInstructions`, `ctx.creds`, and `ctx.callback()`'s path + JSON Schema to `N8N_AI_SYNC_URL`, then returns `{ pending: true }`. **Keep this body byte-compatible with today's** — the committed n8n workflow (`n8n_workflows/AI_Sync_Workflow.json`) reads these exact fields. `createSession` is a no-op passthrough and every `ResourceModule` field is omitted; `changeSources: ['poll', 'push']`.
+
+#### src/features/integrations/platforms/partner/
+
+`config.ts`
+
+```ts
+export const configSchema = z.object({
+  integrationUri: safeUrlSchema,
+  resource: z.enum(ResourceType), // single-resource
+});
+export const credentialSchema = authCredentialSchema; // basic | bearer | header | none
+```
+
+`sync.ts` – move `syncPartnerIntegration` here. POSTs `{ since: cursor ?? lastSuccessfulSync, page_size, callback }` and returns `{ pending: true }`; the partner pushes pages back to the callback. `changeSources: ['poll', 'push']`. The callback token has to become multi-use (or per-page) before `max_pages: 1` can be lifted.
+
+Both `ai` and `partner` share `core/callback.ts` — that's the only thing their strategies have in common, and neither touches `core/sync/poll.ts`.
+
+## Inngest
+
+Still two functions, but the unit of work becomes `(integration, resource)` and **Inngest stops knowing anything platform-specific**. The `switch (integrationType)` in `sync-integrations.ts` goes away; so does `REST_MAPPERS`.
+
+* **`syncAllIntegrations`** — cron `*/5`. Fan out one `integration/sync.requested { integrationId, resource }` per row where the integration is `enabled`, the platform's `changeSources` includes `'poll'`, the resource sync is `enabled`, and `nextSyncAt IS NULL OR nextSyncAt <= now()`. Three separate facts, three separate columns — no nulls doing double duty.
+* **`syncIntegration`** — `concurrency: { key: 'event.data.integrationId + event.data.resource' }` so a manual *Sync Now* can't overlap the cron. Five steps, none platform-aware:
+  1. load the integration, decrypt credentials, validate both against the platform's schemas
+  2. advance `nextSyncAt` and stamp `lastAttemptAt` — **before** the work, so a crash costs one cycle instead of wedging the row
+  3. `createSession`, then `resolveSyncStrategy(platform)` and run it
+  4. persist the returned cursor + status (`pending: true` leaves it `Pending` for the callback to close out); on failure bump `consecutiveFailures`, on success reset it
+  5. `dispose()` in a finally
+
+Everything that differs between platforms — poll vs. hand-off-to-n8n vs. ask-the-partner-to-push — lives in the strategy, in the platform's own folder. Adding a platform means adding a directory; it never means editing an Inngest function.
+
+A slow asset pull can no longer block work orders, and a failing resource fails only its own row.
+
+Two bugs worth fixing while moving this code: `processIntegrationSync` `break`s out of the item loop on the first Prisma error, silently dropping the rest of the batch; and today's scheduler gates on the newest `SyncStatus` row regardless of state, so a stuck `Pending` suppresses re-sync forever.
+
+## Changes from Current System
+
+* Drop all `upstreamApi` fields, move those to `External*Mapping` fields
+  * Made optional. Used on partner+AI integrations. Otherwise use the resource module's `apiUrlFor` / `webUrlFor`
+  * Add a sibling `webUrl String?`, and accept an optional `webUrl` per item in the upload envelope (`createIntegrationInputSchema` in `src/lib/schemas.ts`) so partners can give us both. Optional, so existing partners are unaffected.
+  * Every UI link that renders `upstreamApi` today resolves through `core/urls.ts` — note those links currently point at an API endpoint, which `webUrlFor` fixes
+* Get rid of `IntegrationSession`, replace that with credentials stored encrypted in the `Integration` object
+* Rename `NotificationSource` to `SourceRecord`, and change fields
+  * Append-only, content-hashed; `referenceUrl` dropped (derive from the mapping instead)
+  * `NotificationChannel` → `SourceChannel`, values `{ Email, Integration, TA4 }` — `PolledApi` and `Crawl` collapse into `Integration`, since a crawler is just a platform
+  * Split the notification / work-order links into `SourceLink`, carrying `sourceType` + `reasonWhy`; `NotificationSourceType` → `SourceLinkType`
+* Add `ExternalSourceRecordMapping` (one row per external record, many snapshots)
+* Changes to `Integration` model
+  * Drop `resourceType`, `integrationType`, `authType`, `authentication`, `integrationUri`, `prompt` (the last two move into per-platform `config`)
+  * Add `PlatformEnum`, replacing free-text `platform` and the three places that identify a platform by substring-matching its hostname
+  * Replace `SyncStatus` with `IntegrationResourceSync` — per-resource status, cursor, cadence, enable toggle, and schedule
+* Move per-platform sync logic out of Inngest and into `platforms/*/sync.ts`; delete the `integrationType` switch and `REST_MAPPERS`
+* Reorganize all of our integration code into modular pieces
+* Add `ManagesRelationship`, changes to `Contract`
+
+## Open Questions
+
+* `Contract` → `ContractSla`
+* Webhook-driven platforms (`changeSources: ['webhook']`) — the ingest path exists but nothing declares it yet
+* Multi-page PARTNER pushes are blocked on the single-use callback token
+* Should the inbox be a platform? Resend as an `Integration` with `changeSources: ['webhook']` would put email identity on a mapping like everything else, and `SourceRecord.externalId` could go away

--- a/prisma/migrations/20260811221210_integrations_redesign/migration.sql
+++ b/prisma/migrations/20260811221210_integrations_redesign/migration.sql
@@ -1,0 +1,324 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `upstream-api` on the `asset` table. All the data in the column will be lost.
+  - You are about to drop the column `upstream-api` on the `device_artifact` table. All the data in the column will be lost.
+  - You are about to drop the column `authType` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `authentication` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `integration-uri` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `integrationType` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `lastSuccessfulSync` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `prompt` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `resourceType` on the `integration` table. All the data in the column will be lost.
+  - You are about to drop the column `upstream-api` on the `remediation` table. All the data in the column will be lost.
+  - You are about to drop the column `upstream-api` on the `vulnerability` table. All the data in the column will be lost.
+  - You are about to drop the `contract_asset` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `integration_session` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `notification_source` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `sync_status` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[managesRelationshipId]` on the table `contract` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `platform` to the `integration` table without a default value. This is not possible if the table is not empty.
+
+*/
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- HAND-EDITED PROLOGUE. Integration state is deliberately NOT migrated; every
+-- integration must be re-created after this lands. Non-integration data —
+-- assets, work orders, notifications, vulnerabilities — survives.
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- Source records first, as a DELETE rather than relying on the DROP TABLE below:
+-- notification_attachment.sourceId is ON DELETE CASCADE, so DELETE takes the
+-- attachments with it. DROP TABLE only drops the FK and would leave orphan
+-- attachment rows, which then break the re-pointed FK at the end of this file.
+DELETE FROM "notification_source";
+
+-- api_key_connector.integrationId is SET NULL, so deleting integrations first
+-- would leave these as zombies owned by neither an ApiKey nor an Integration.
+-- Rows owned by an ApiKey (integrationId IS NULL) are untouched.
+DELETE FROM "api_key_connector" WHERE "integrationId" IS NOT NULL;
+
+-- Cascades to sync_status and all five external_*_mappings. Also makes the
+-- `platform` NOT NULL column below addable without a default.
+--
+-- !! DO NOT delete the shadow integration users. Asset.userId,
+-- !! Vulnerability.userId and Remediation.userId are all ON DELETE CASCADE, so
+-- !! dropping a shadow user deletes every row that integration ever ingested.
+-- !! Orphan shadow users are harmless and stay.
+DELETE FROM "integration";
+
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- CreateEnum
+CREATE TYPE "PlatformEnum" AS ENUM ('AI', 'PARTNER', 'FLEET');
+
+-- CreateEnum
+CREATE TYPE "SourceChannel" AS ENUM ('Email', 'Integration', 'TA4');
+
+-- CreateEnum
+CREATE TYPE "SourceLinkType" AS ENUM ('Source', 'Link');
+
+-- AlterEnum
+ALTER TYPE "ResourceType" ADD VALUE 'SourceRecord';
+
+-- DropForeignKey
+ALTER TABLE "contract_asset" DROP CONSTRAINT "contract_asset_assetId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "contract_asset" DROP CONSTRAINT "contract_asset_contractId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "notification_attachment" DROP CONSTRAINT "notification_attachment_sourceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "notification_source" DROP CONSTRAINT "notification_source_notificationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "notification_source" DROP CONSTRAINT "notification_source_workOrderTicketId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "sync_status" DROP CONSTRAINT "sync_status_integrationId_fkey";
+
+-- AlterTable
+ALTER TABLE "asset" DROP COLUMN "upstream-api";
+
+-- AlterTable
+ALTER TABLE "contract" ADD COLUMN     "managesRelationshipId" TEXT;
+
+-- AlterTable
+ALTER TABLE "device_artifact" DROP COLUMN "upstream-api";
+
+-- AlterTable
+ALTER TABLE "external_asset_mappings" ADD COLUMN     "upstreamApi" TEXT,
+ADD COLUMN     "webUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "external_device_artifact_mappings" ADD COLUMN     "upstreamApi" TEXT,
+ADD COLUMN     "webUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "external_item_mappings" ADD COLUMN     "upstreamApi" TEXT,
+ADD COLUMN     "webUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "external_remediation_mappings" ADD COLUMN     "upstreamApi" TEXT,
+ADD COLUMN     "webUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "external_work_order_mappings" ADD COLUMN     "upstreamApi" TEXT,
+ADD COLUMN     "webUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "integration" DROP COLUMN "authType",
+DROP COLUMN "authentication",
+DROP COLUMN "integration-uri",
+DROP COLUMN "integrationType",
+DROP COLUMN "lastSuccessfulSync",
+DROP COLUMN "prompt",
+DROP COLUMN "resourceType",
+ADD COLUMN     "config" JSONB NOT NULL DEFAULT '{}',
+ADD COLUMN     "credentials" BYTEA,
+ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true,
+DROP COLUMN "platform",
+ADD COLUMN     "platform" "PlatformEnum" NOT NULL,
+ALTER COLUMN "syncEvery" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "remediation" DROP COLUMN "upstream-api";
+
+-- AlterTable
+ALTER TABLE "vulnerability" DROP COLUMN "upstream-api";
+
+-- DropTable
+DROP TABLE "contract_asset";
+
+-- DropTable
+DROP TABLE "integration_session";
+
+-- DropTable
+DROP TABLE "notification_source";
+
+-- DropTable
+DROP TABLE "sync_status";
+
+-- DropEnum
+DROP TYPE "IntegrationType";
+
+-- DropEnum
+DROP TYPE "NotificationChannel";
+
+-- DropEnum
+DROP TYPE "NotificationSourceType";
+
+-- CreateTable
+CREATE TABLE "manages_relationship" (
+    "id" TEXT NOT NULL,
+    "responsibilities" TEXT NOT NULL,
+    "departmentId" TEXT,
+    "vendorId" TEXT,
+    "workOrderIntegrationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "manages_relationship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "integration_resource_sync" (
+    "id" TEXT NOT NULL,
+    "integrationId" TEXT NOT NULL,
+    "resource" "ResourceType" NOT NULL,
+    "cursor" JSONB,
+    "status" "SyncStatusEnum" NOT NULL DEFAULT 'Pending',
+    "errorMessage" TEXT,
+    "lastAttemptAt" TIMESTAMP(3),
+    "lastSuccessfulSync" TIMESTAMP(3),
+    "consecutiveFailures" INTEGER NOT NULL DEFAULT 0,
+    "syncEvery" INTEGER,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "nextSyncAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "integration_resource_sync_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "source_record" (
+    "id" TEXT NOT NULL,
+    "channel" "SourceChannel" NOT NULL,
+    "mappingId" TEXT,
+    "contentHash" TEXT NOT NULL,
+    "raw" JSONB NOT NULL DEFAULT '{}',
+    "markdown" TEXT,
+    "externalId" TEXT,
+    "observedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "remediationId" TEXT,
+
+    CONSTRAINT "source_record_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "source_link" (
+    "id" TEXT NOT NULL,
+    "sourceRecordId" TEXT NOT NULL,
+    "notificationId" TEXT,
+    "workOrderTicketId" TEXT,
+    "sourceType" "SourceLinkType" NOT NULL DEFAULT 'Source',
+    "reasonWhy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "source_link_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "external_source_record_mappings" (
+    "id" TEXT NOT NULL,
+    "integrationId" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "upstreamApi" TEXT,
+    "webUrl" TEXT,
+    "lastSynced" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "external_source_record_mappings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_ManagedAssets" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_ManagedAssets_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "manages_relationship_departmentId_idx" ON "manages_relationship"("departmentId");
+
+-- CreateIndex
+CREATE INDEX "manages_relationship_vendorId_idx" ON "manages_relationship"("vendorId");
+
+-- CreateIndex
+CREATE INDEX "manages_relationship_workOrderIntegrationId_idx" ON "manages_relationship"("workOrderIntegrationId");
+
+-- CreateIndex
+CREATE INDEX "integration_resource_sync_integrationId_idx" ON "integration_resource_sync"("integrationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "integration_resource_sync_integrationId_resource_key" ON "integration_resource_sync"("integrationId", "resource");
+
+-- CreateIndex
+CREATE INDEX "source_record_mappingId_observedAt_idx" ON "source_record"("mappingId", "observedAt");
+
+-- CreateIndex
+CREATE INDEX "source_record_remediationId_idx" ON "source_record"("remediationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "source_record_channel_externalId_key" ON "source_record"("channel", "externalId");
+
+-- CreateIndex
+CREATE INDEX "source_link_notificationId_idx" ON "source_link"("notificationId");
+
+-- CreateIndex
+CREATE INDEX "source_link_workOrderTicketId_idx" ON "source_link"("workOrderTicketId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "source_link_sourceRecordId_notificationId_key" ON "source_link"("sourceRecordId", "notificationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "source_link_sourceRecordId_workOrderTicketId_key" ON "source_link"("sourceRecordId", "workOrderTicketId");
+
+-- CreateIndex
+CREATE INDEX "external_source_record_mappings_integrationId_idx" ON "external_source_record_mappings"("integrationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "external_source_record_mappings_integrationId_externalId_key" ON "external_source_record_mappings"("integrationId", "externalId");
+
+-- CreateIndex
+CREATE INDEX "_ManagedAssets_B_index" ON "_ManagedAssets"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "contract_managesRelationshipId_key" ON "contract"("managesRelationshipId");
+
+-- AddForeignKey
+ALTER TABLE "contract" ADD CONSTRAINT "contract_managesRelationshipId_fkey" FOREIGN KEY ("managesRelationshipId") REFERENCES "manages_relationship"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "manages_relationship" ADD CONSTRAINT "manages_relationship_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "manages_relationship" ADD CONSTRAINT "manages_relationship_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "vendor"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "manages_relationship" ADD CONSTRAINT "manages_relationship_workOrderIntegrationId_fkey" FOREIGN KEY ("workOrderIntegrationId") REFERENCES "integration"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "integration_resource_sync" ADD CONSTRAINT "integration_resource_sync_integrationId_fkey" FOREIGN KEY ("integrationId") REFERENCES "integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "source_record" ADD CONSTRAINT "source_record_mappingId_fkey" FOREIGN KEY ("mappingId") REFERENCES "external_source_record_mappings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "source_record" ADD CONSTRAINT "source_record_remediationId_fkey" FOREIGN KEY ("remediationId") REFERENCES "remediation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "source_link" ADD CONSTRAINT "source_link_sourceRecordId_fkey" FOREIGN KEY ("sourceRecordId") REFERENCES "source_record"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "source_link" ADD CONSTRAINT "source_link_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "notification"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "source_link" ADD CONSTRAINT "source_link_workOrderTicketId_fkey" FOREIGN KEY ("workOrderTicketId") REFERENCES "work_order_ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "external_source_record_mappings" ADD CONSTRAINT "external_source_record_mappings_integrationId_fkey" FOREIGN KEY ("integrationId") REFERENCES "integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notification_attachment" ADD CONSTRAINT "notification_attachment_sourceId_fkey" FOREIGN KEY ("sourceId") REFERENCES "source_record"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ManagedAssets" ADD CONSTRAINT "_ManagedAssets_A_fkey" FOREIGN KEY ("A") REFERENCES "asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ManagedAssets" ADD CONSTRAINT "_ManagedAssets_B_fkey" FOREIGN KEY ("B") REFERENCES "manages_relationship"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -290,7 +290,6 @@ model Contract {
   vendor   Vendor @relation(fields: [vendorId], references: [id], onDelete: Cascade)
 
   files  ArtifactWrapper[]
-  covers ContractAsset[]
 
   // one-to-one with ManagesRelationship. @unique or Prisma makes this many-to-one.
   managesRelationshipId String?              @unique
@@ -331,22 +330,6 @@ model ManagesRelationship {
   @@index([vendorId])
   @@index([workOrderIntegrationId])
   @@map("manages_relationship")
-}
-
-model ContractAsset {
-  id String @id @default(cuid())
-
-  contractId String
-  contract   Contract @relation(fields: [contractId], references: [id], onDelete: Cascade)
-  assetId    String
-  asset      Asset    @relation(fields: [assetId], references: [id], onDelete: Cascade)
-
-  createdAt DateTime @default(now())
-
-  @@unique([contractId, assetId])
-  @@index([contractId])
-  @@index([assetId])
-  @@map("contract_asset")
 }
 
 model Product {
@@ -472,7 +455,6 @@ model Asset {
   issues               Issue[]
   deviceGroupHistories DeviceGroupHistory[]
   externalMappings     ExternalAssetMapping[]
-  contractAssets       ContractAsset[]
   assetTickets         AssetTicket[]
   notificationMappings NotificationAssetMapping[]
   nodes                Node[]
@@ -1505,10 +1487,8 @@ model SourceRecord {
   // INVARIANT: mappingId set => externalId null
   mappingId        String?
   mapping          ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
-  latestForMapping ExternalSourceRecordMapping? @relation(name: "LatestSourceRecord")
-  // ^opposite side of ExternalSourceRecordMapping.latestSourceRecord.
 
-  contentHash String // dedup: skip the write if it matches the mapping's latest
+  contentHash String // dedup: skip the write if it matches the mapping's newest 
   raw         Json    @default("{}")
   markdown    String? @db.Text
   externalId  String? // TODO VW-448: Consider removing this; used only for email
@@ -1562,8 +1542,6 @@ model ExternalSourceRecordMapping {
   externalId    String // the advisory / notification id on another platform
 
   sourceRecords        SourceRecord[] @relation(name: "MappingSnapshots")
-  latestSourceRecordId String?        @unique
-  latestSourceRecord   SourceRecord?  @relation(name: "LatestSourceRecord", fields: [latestSourceRecordId], references: [id], onDelete: SetNull)
 
   upstreamApi String?
   webUrl      String?
@@ -1574,7 +1552,6 @@ model ExternalSourceRecordMapping {
 
   @@unique([integrationId, externalId])
   @@index([integrationId])
-  @@index([latestSourceRecordId])
   @@map("external_source_record_mappings")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -289,7 +289,7 @@ model Contract {
   vendorId String
   vendor   Vendor @relation(fields: [vendorId], references: [id], onDelete: Cascade)
 
-  files  ArtifactWrapper[]
+  files ArtifactWrapper[]
 
   // one-to-one with ManagesRelationship. @unique or Prisma makes this many-to-one.
   managesRelationshipId String?              @unique
@@ -1014,7 +1014,6 @@ enum SyncStatusEnum {
   Success
 }
 
-
 // stores a cursor in JSON (what do we send to external platforms?)
 // stores if a sync was successful or not
 // only one per integration resource
@@ -1485,8 +1484,8 @@ model SourceRecord {
 
   // null for email / TA4 sources, since those aren't mirrored rows.
   // INVARIANT: mappingId set => externalId null
-  mappingId        String?
-  mapping          ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
+  mappingId String?
+  mapping   ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
 
   contentHash String // dedup: skip the write if it matches the mapping's newest 
   raw         Json    @default("{}")
@@ -1541,7 +1540,7 @@ model ExternalSourceRecordMapping {
   integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
   externalId    String // the advisory / notification id on another platform
 
-  sourceRecords        SourceRecord[] @relation(name: "MappingSnapshots")
+  sourceRecords SourceRecord[] @relation(name: "MappingSnapshots")
 
   upstreamApi String?
   webUrl      String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -251,6 +251,8 @@ model Vendor {
   contracts Contract[]
   contacts  VendorContact[]
 
+  managesRelationships ManagesRelationship[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -290,11 +292,45 @@ model Contract {
   files  ArtifactWrapper[]
   covers ContractAsset[]
 
+  // one-to-one with ManagesRelationship. @unique or Prisma makes this many-to-one.
+  managesRelationshipId String?              @unique
+  managesRelationship   ManagesRelationship? @relation(fields: [managesRelationshipId], references: [id], onDelete: SetNull)
+
+  // TODO: A Contract has a ContractSla in the future
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([vendorId])
   @@map("contract")
+}
+
+// Who in the hospital, or outside of it, is responsible for managing an asset.
+model ManagesRelationship {
+  id               String @id @default(cuid())
+  responsibilities String @db.Text
+
+  departmentId String?
+  department   Department? @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+
+  // one vendor has many ManagesRelationships
+  vendorId String?
+  vendor   Vendor?   @relation(fields: [vendorId], references: [id], onDelete: SetNull)
+  contract Contract? // optional if a vendor is provided. fk lives on Contract
+
+  // where work orders for these assets get filed
+  workOrderIntegrationId String?
+  workOrderIntegration   Integration? @relation(fields: [workOrderIntegrationId], references: [id], onDelete: SetNull)
+
+  assets Asset[] @relation("ManagedAssets")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([departmentId])
+  @@index([vendorId])
+  @@index([workOrderIntegrationId])
+  @@map("manages_relationship")
 }
 
 model ContractAsset {
@@ -349,9 +385,9 @@ model DeviceGroup {
   manufacturer   Manufacturer? @relation(fields: [manufacturerId], references: [id], onDelete: SetNull)
   productId      String?
   product        Product?      @relation(fields: [productId], references: [id], onDelete: SetNull)
-  versionId     String?
-  version       Version?      @relation(fields: [versionId], references: [id], onDelete: SetNull)
-  versionStatus VersionStatus @default(UNKNOWN)
+  versionId      String?
+  version        Version?      @relation(fields: [versionId], references: [id], onDelete: SetNull)
+  versionStatus  VersionStatus @default(UNKNOWN)
 
   cpe        String[] @default([])
   udi        String?
@@ -375,8 +411,8 @@ model DeviceGroupMatching {
   manufacturer   Manufacturer @relation(fields: [manufacturerId], references: [id], onDelete: Cascade)
   productId      String? // null => wildcard (all products of the manufacturer)
   product        Product?     @relation(fields: [productId], references: [id], onDelete: Cascade)
-  versionId String? // exact version when set
-  version   Version? @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  versionId      String? // exact version when set
+  version        Version?     @relation(fields: [versionId], references: [id], onDelete: Cascade)
 
   versionRange String?
 
@@ -418,7 +454,6 @@ model Asset {
   ip             String
   networkSegment String?
   role           String?
-  upstreamApi    String  @map("upstream-api")
 
   hostname     String?
   macAddress   String?
@@ -441,6 +476,8 @@ model Asset {
   assetTickets         AssetTicket[]
   notificationMappings NotificationAssetMapping[]
   nodes                Node[]
+  // who in the hospital, or outside of it, is responsible for managing this asset
+  managedBy            ManagesRelationship[]      @relation("ManagedAssets")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -462,6 +499,11 @@ model ExternalAssetMapping {
   updatedAt     DateTime    @updatedAt
   lastSynced    DateTime?
 
+  // Both optional, both only set by the generic ai/partner platforms
+  // see resource module's .apiUrlFor for other platforms
+  upstreamApi String? // the API endpoint
+  webUrl      String? // where a human looks at it
+
   // Composite unique constraint: one external ID per integration per item
   @@unique([itemId, integrationId], name: "external_asset_mappings_item_integration_key")
   // Critical index for fast lookups: "find item by integration's external ID"
@@ -482,6 +524,9 @@ model ExternalDeviceArtifactMapping {
   updatedAt     DateTime       @updatedAt
   lastSynced    DateTime?
 
+  upstreamApi String?
+  webUrl      String?
+
   @@unique([itemId, integrationId], name: "external_device_artifact_mappings_item_integration_key")
   @@unique([integrationId, externalId], name: "external_device_artifact_mappings_integration_external_key")
   @@index([itemId])
@@ -498,6 +543,9 @@ model ExternalRemediationMapping {
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
   lastSynced    DateTime?
+
+  upstreamApi String?
+  webUrl      String?
 
   @@unique([itemId, integrationId], name: "external_remediation_mappings_item_integration_key")
   @@unique([integrationId, externalId], name: "external_remediation_mappings_integration_external_key")
@@ -516,6 +564,9 @@ model ExternalWorkOrderMapping {
   updatedAt     DateTime        @updatedAt
   lastSynced    DateTime?
 
+  upstreamApi String?
+  webUrl      String?
+
   @@unique([itemId, integrationId], name: "external_work_order_mappings_item_integration_key")
   @@unique([integrationId, externalId], name: "external_work_order_mappings_integration_external_key")
   @@index([itemId])
@@ -532,6 +583,9 @@ model ExternalVulnerabilityMapping {
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
   lastSynced    DateTime?
+
+  upstreamApi String?
+  webUrl      String?
 
   @@unique([itemId, integrationId], name: "external_vulnerability_mappings_item_integration_key")
   @@unique([integrationId, externalId], name: "external_vulnerability_mappings_integration_external_key")
@@ -619,7 +673,6 @@ model DeviceArtifact {
   artifacts     ArtifactWrapper[]
   vulnerability Vulnerability[]
 
-  upstreamApi String? @map("upstream-api")
   description String? @db.Text
   role        String?
 
@@ -668,7 +721,6 @@ model Vulnerability {
   affectedComponents   String[]              @default([])
   deviceGroupMatchings DeviceGroupMatching[] @relation("VulnerabilityMatchings")
   exploitUri           String?               @map("exploit-uri")
-  upstreamApi          String?               @map("upstream-api")
 
   // EPSS (Exploit Prediction Scoring System) fields
   epss        Float? // Probability score between 0.0 and 1.0
@@ -784,8 +836,8 @@ model Note {
   instanceId       String? // weak reference — app validates this id exists in targetModel's table
   answeredQuestion Question?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   deletedAt DateTime?
 
   @@index([targetModel, instanceId])
@@ -838,7 +890,6 @@ model Remediation {
   deviceGroupMatchings DeviceGroupMatching[] @relation("RemediationMatchings")
   description          String?               @db.Text // description of remediation
   narrative            String?               @db.Text // how a remediation can be applied
-  upstreamApi          String?               @map("upstream-api")
 
   vulnerabilityId String?
   vulnerability   Vulnerability? @relation(fields: [vulnerabilityId], references: [id], onDelete: SetNull)
@@ -857,6 +908,8 @@ model Remediation {
   updatedAt DateTime @updatedAt
 
   externalMappings ExternalRemediationMapping[]
+  // raw TA4 submissions that produced this remediation
+  sourceRecords    SourceRecord[]
 
   @@index([vulnerabilityId])
   @@index([userId])
@@ -906,22 +959,20 @@ model Apikey {
   @@map("apikey")
 }
 
+// An instance of a Platform. Pretty much just a way to save settings and auth
+// to the db; everything the platform *does* lives in its own module.
 model Integration {
-  id                 String          @id @default(cuid())
-  name               String
-  platform           String? // The name of the integration platform, e.g "BlueFlow"
-  integrationUri     String          @map("integration-uri")
-  integrationType    IntegrationType
-  // ^PARTNER: Helm, Blueflow. Follows VIPER standard 
-  // AI: uses AI to pull data from any platform
-  // CSAF: parses CSAF security advisories (Vulnerability resource type only)
-  prompt             String?         @db.Text // optional, additional instructions for AI
-  authType           AuthType
-  resourceType       ResourceType
-  authentication     Json? // TODO: this needs to be encrypted
-  syncEvery          Int // e.g 300, sync every 300 seconds
-  syncStatus         SyncStatus[]
-  lastSuccessfulSync DateTime?
+  id       String       @id @default(cuid())
+  name     String
+  platform PlatformEnum
+
+  config      Json   @default("{}") // validated by the platform's configSchema
+  credentials Bytes? // AES-256-GCM, key from CREDENTIAL_ENCRYPTION_KEY.
+  // decrypted plaintext is validated by the platform's credentialSchema
+
+  syncEvery Int? // seconds. null = inherit the platform's defaultSyncEvery.
+  // ^if we're polling, that's how often to poll
+  enabled   Boolean @default(true)
 
   apiKeyConnector ApiKeyConnector?
 
@@ -929,15 +980,20 @@ model Integration {
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  // the user that this integration creates
+  // the shadow user this integration owns; ingested rows are attributed to it
   integrationUserId String @unique
   integrationUser   User   @relation(name: "integration_user", fields: [integrationUserId], references: [id], onDelete: Cascade)
+
+  resourceSyncs IntegrationResourceSync[]
 
   assetMappings          ExternalAssetMapping[]
   deviceArtifactMappings ExternalDeviceArtifactMapping[]
   remediationMappings    ExternalRemediationMapping[]
   vulnerabilityMappings  ExternalVulnerabilityMapping[]
   workOrderMappings      ExternalWorkOrderMapping[]
+  sourceRecordMappings   ExternalSourceRecordMapping[]
+
+  managesRelationships ManagesRelationship[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -948,6 +1004,7 @@ model Integration {
 }
 
 // separate out to preserve between ApiKey rotations
+// TODO VW-435: clean up / delete later...
 model ApiKeyConnector {
   id String @id @default(cuid())
 
@@ -975,15 +1032,34 @@ enum SyncStatusEnum {
   Success
 }
 
-model SyncStatus {
-  id            String         @id @default(cuid())
-  integration   Integration    @relation(fields: [integrationId], references: [id], onDelete: Cascade)
-  integrationId String
-  status        SyncStatusEnum @default(Pending)
-  errorMessage  String?
-  syncedAt      DateTime       @default(now())
 
-  @@map("sync_status")
+// stores a cursor in JSON (what do we send to external platforms?)
+// stores if a sync was successful or not
+// only one per integration resource
+model IntegrationResourceSync {
+  id            String       @id @default(cuid())
+  integrationId String
+  integration   Integration  @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  resource      ResourceType
+
+  cursor              Json? // for pagination — opaque to core, interpreted only by the platform
+  status              SyncStatusEnum @default(Pending)
+  errorMessage        String?
+  lastAttemptAt       DateTime?
+  lastSuccessfulSync  DateTime?
+  consecutiveFailures Int            @default(0) // drives the backoff exponent; reset to 0 on success
+
+  syncEvery Int? // seconds. overrides Integration syncEvery.
+  enabled   Boolean @default(true) // operator toggle: turn off Fleet assets, keep work orders.
+
+  nextSyncAt DateTime? // when this resource is next due. null = due now.
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([integrationId, resource])
+  @@index([integrationId])
+  @@map("integration_resource_sync")
 }
 
 model Webhook {
@@ -1029,13 +1105,14 @@ enum ResourceType {
   DeviceArtifact
   Remediation
   WorkOrder
+  SourceRecord
 }
 
-enum IntegrationType {
-  PARTNER
+// Which platform module handles an Integration. Platforms are represented in code
+enum PlatformEnum {
   AI
-  CSAF
-  REST
+  PARTNER
+  FLEET
 }
 
 // Traffic Light Protocol, governs information sharing
@@ -1136,6 +1213,8 @@ model Department {
   tickets            WorkOrderTicket[]   @relation("WorkOrderTicketDepartments")
   ticketDescriptions TicketDescription[]
 
+  managesRelationships ManagesRelationship[]
+
   @@map("department")
 }
 
@@ -1160,7 +1239,7 @@ model WorkOrderTicket {
   priorityReasonWhy String?  @db.Text
 
   sourceLabel String?
-  sources     NotificationSource[]
+  sourceLinks SourceLink[]
 
   body String? @db.Text
 
@@ -1336,11 +1415,13 @@ enum NotificationType {
   Other
 }
 
-enum NotificationChannel {
-  Email
-  PolledApi
-  Crawl
-  TA4
+// how a record entered the system
+// the platform behind `mappingId` says where it came from.
+enum SourceChannel {
+  Email // inbound mail — mappingId null, externalId is the Resend id
+  // TODO VW-448: Consider eliminating Email (and SourceRecord.externalId)
+  Integration // from a platform — mappingId set
+  TA4 // POSTed to /api/v1/remediations
 }
 
 enum ConfidenceLevel {
@@ -1350,10 +1431,10 @@ enum ConfidenceLevel {
   Rejected // A human marked this match as incorrect
 }
 
-enum NotificationSourceType {
-  // Source: the notification was created as a result of this email
+enum SourceLinkType {
+  // Source: the target was created as a result of this record
   Source
-  // Link: the notification already existed, and was linked to this email
+  // Link: the target already existed and this record was attached to it
   Link
 }
 
@@ -1369,7 +1450,7 @@ model Notification {
   priorityReasonWhy String?  @db.Text
   hospitalImpact    Json     @default("{}") // structured: { byline, impactStatement, careAreas, likelihood } — see hospitalImpactSchema
 
-  sources               NotificationSource[]
+  sourceLinks           SourceLink[]
   reads                 NotificationRead[]
   assets                NotificationAssetMapping[]
   deviceGroupsMatchings NotificationDeviceGroupMapping[]
@@ -1411,36 +1492,96 @@ model MitigationPlan {
   @@map("mitigation_plan")
 }
 
-model NotificationSource {
-  id             String        @id @default(cuid())
-  notificationId String?
-  notification   Notification? @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+// A snapshot of some record at a point in time, that goes on to be a source for
+// a notification or work order. Append-only, deduplicated on contentHash and
+// ordered by observedAt — cheap "version control".
+//
+// A record links to notifications/work roders via SourceLink 
+model SourceRecord {
+  id      String        @id @default(cuid())
+  channel SourceChannel
 
+  // null for email / TA4 sources, since those aren't mirrored rows.
+  // INVARIANT: mappingId set => externalId null
+  mappingId        String?
+  mapping          ExternalSourceRecordMapping? @relation(name: "MappingSnapshots", fields: [mappingId], references: [id], onDelete: Cascade)
+  latestForMapping ExternalSourceRecordMapping? @relation(name: "LatestSourceRecord")
+  // ^opposite side of ExternalSourceRecordMapping.latestSourceRecord.
+
+  contentHash String // dedup: skip the write if it matches the mapping's latest
+  raw         Json    @default("{}")
+  markdown    String? @db.Text
+  externalId  String? // TODO VW-448: Consider removing this; used only for email
+
+  observedAt DateTime @default(now())
+
+  // A SourceRecord can optionally be a TA4 remediation: the raw submission,
+  // pointing at the Remediation it created.
+  remediationId String?
+  remediation   Remediation? @relation(fields: [remediationId], references: [id], onDelete: SetNull)
+
+  links       SourceLink[] // what notifications / work orders this source feeds
+  attachments NotificationAttachment[]
+
+  @@unique([channel, externalId])
+  @@index([mappingId, observedAt])
+  @@index([remediationId])
+  @@map("source_record")
+}
+
+// Links sources to notifications/work orders, with a reason why provided by LLM
+model SourceLink {
+  id             String       @id @default(cuid())
+  sourceRecordId String
+  sourceRecord   SourceRecord @relation(fields: [sourceRecordId], references: [id], onDelete: Cascade)
+
+  // either a notification or a work order
+  notificationId    String?
+  notification      Notification?    @relation(fields: [notificationId], references: [id], onDelete: Cascade)
   workOrderTicketId String?
   workOrderTicket   WorkOrderTicket? @relation(fields: [workOrderTicketId], references: [id], onDelete: Cascade)
 
-  sourceType NotificationSourceType @default(Source)
-  reasonWhy  String?                @db.Text // why was this email linked to this notification?
+  sourceType SourceLinkType @default(Source)
+  reasonWhy  String?        @db.Text
 
-  channel      NotificationChannel
-  externalId   String? // for an email, this is the resend email id
-  referenceUrl String?
-  raw          Json
-  markdown     String?             @db.Text
+  createdAt DateTime @default(now())
 
-  attachments NotificationAttachment[]
-  receivedAt  DateTime                 @default(now())
-
-  @@unique([channel, externalId])
+  @@unique([sourceRecordId, notificationId])
+  @@unique([sourceRecordId, workOrderTicketId])
   @@index([notificationId])
   @@index([workOrderTicketId])
-  @@map("notification_source")
+  @@map("source_link")
+}
+
+// One row per external record (an advisory, a notification on another platform),
+// owning many snapshots of it.
+model ExternalSourceRecordMapping {
+  id            String      @id @default(cuid())
+  integrationId String
+  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  externalId    String // the advisory / notification id on another platform
+
+  sourceRecords        SourceRecord[] @relation(name: "MappingSnapshots")
+  latestSourceRecordId String?        @unique
+  latestSourceRecord   SourceRecord?  @relation(name: "LatestSourceRecord", fields: [latestSourceRecordId], references: [id], onDelete: SetNull)
+
+  upstreamApi String?
+  webUrl      String?
+
+  lastSynced DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@unique([integrationId, externalId])
+  @@index([integrationId])
+  @@index([latestSourceRecordId])
+  @@map("external_source_record_mappings")
 }
 
 model NotificationAttachment {
-  id       String             @id @default(cuid())
+  id       String       @id @default(cuid())
   sourceId String
-  source   NotificationSource @relation(fields: [sourceId], references: [id], onDelete: Cascade)
+  source   SourceRecord @relation(fields: [sourceId], references: [id], onDelete: Cascade)
 
   filename    String?
   contentType String?
@@ -1556,18 +1697,6 @@ model MatchFeedback {
   @@index([targetType, targetId])
   @@index([notificationId])
   @@map("match_feedback")
-}
-
-model IntegrationSession {
-  id        String    @id @default(cuid())
-  host      String    @unique
-  header    String
-  value     String
-  expiresAt DateTime?
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-
-  @@map("integration_session")
 }
 
 // ─── Correction ────────────────────────────────────────────────────────────

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1156,6 +1156,10 @@ async function clearDatabase() {
   await prisma.artifact.deleteMany();
   await prisma.artifactWrapper.deleteMany();
   await prisma.contract.deleteMany();
+  // Both the contract and vendor deletes are SetNull, so the relationship would
+  // otherwise survive here with a null vendorId, out of reach of the
+  // vendor-scoped cleanup in seedVendors().
+  await prisma.managesRelationship.deleteMany();
   await prisma.vendorContact.deleteMany();
   await prisma.vendor.deleteMany();
   await prisma.remediation.deleteMany();

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1149,6 +1149,8 @@ async function clearDatabase() {
   // Delete in order of dependencies (child tables first)
   await prisma.issue.deleteMany();
   await prisma.integrationResourceSync.deleteMany();
+  // Ticket deletion cascades SourceLink but not the records themselves.
+  await prisma.sourceRecord.deleteMany({ where: { links: { none: {} } } });
   await prisma.externalAssetMapping.deleteMany();
   await prisma.externalVulnerabilityMapping.deleteMany();
   await prisma.artifact.deleteMany();
@@ -2246,6 +2248,11 @@ async function seedVendors() {
   // Rebuilt rather than upserted: neither model has a natural unique key, so a
   // re-seed without SEED_CLEAR_DB would otherwise stack duplicates every run.
   await prisma.contract.deleteMany({ where: { vendorId: vendor.id } });
+  // Contract.managesRelationshipId is SetNull, so the delete above orphans the
+  // relationship rather than removing it — clear it explicitly.
+  await prisma.managesRelationship.deleteMany({
+    where: { vendorId: vendor.id },
+  });
   await prisma.vendorContact.deleteMany({ where: { vendorId: vendor.id } });
 
   await prisma.vendorContact.createMany({

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,17 +2,17 @@ import { hashPassword } from "better-auth/crypto";
 import {
   type ArtifactType,
   type AssetStatus,
-  AuthType,
-  IntegrationType,
   NoteStatus,
-  NotificationChannel,
+  PlatformEnum,
   Priority,
   ResourceType,
   Severity,
+  SourceChannel,
   TicketCategory,
   TicketStatus,
 } from "@/generated/prisma";
 import prisma from "@/lib/db";
+import { sourceContentHash } from "@/lib/source-hash";
 
 // Seed user credentials
 const SEED_USER = {
@@ -156,7 +156,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.10",
     cpe: "cpe:2.3:h:gehealthcare:brightspeed_elite_select:-:*:*:*:*:*:*:*",
     role: "CT Scanner",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "CT-BRIGHT-001",
     macAddress: "00:1A:2B:3C:50:10",
@@ -172,7 +171,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.30",
     cpe: "cpe:2.3:h:gehealthcare:logiq_e:r7:*:*:*:*:*:*:*",
     role: "Portable Ultrasound",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "US-LOGIQ-001",
     macAddress: "00:1A:2B:3C:50:30",
@@ -188,7 +186,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.31",
     cpe: "cpe:2.3:h:gehealthcare:logiq_e:r7:*:*:*:*:*:*:*",
     role: "Portable Ultrasound",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "US-LOGIQ-002",
     macAddress: "00:1A:2B:3C:50:31",
@@ -204,7 +201,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.40",
     cpe: "cpe:2.3:h:gehealthcare:optima_xr200amx:-:*:*:*:*:*:*:*",
     role: "X-Ray / DR Node",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "XR-OPTIMA-001",
     macAddress: "00:1A:2B:3C:50:40",
@@ -221,7 +217,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.20",
     cpe: "cpe:2.3:a:gehealthcare:advantage_workstation:4.6:*:*:*:*:*:*:*",
     role: "CT Acquisition Workstation",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "WS-ADVANTAGE-001",
     macAddress: "00:1A:2B:3C:50:20",
@@ -378,7 +373,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.2.10",
     cpe: "cpe:2.3:a:gehealthcare:centricity_pacs_iw:5.0:*:*:*:*:*:*:*",
     role: "PACS Server",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "PACS-VLAN-41",
     hostname: "PACS-CENTRICITY-001",
     macAddress: "00:1A:2B:3C:51:10",
@@ -395,7 +389,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.2.20",
     cpe: "cpe:2.3:a:gehealthcare:centricity_pacs_iw:-:*:*:*:*:*:*:*",
     role: "Radiology Diagnostic Workstation",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "PACS-VLAN-41",
     hostname: "WS-RADIOLOGY-001",
     macAddress: "00:1A:2B:3C:51:20",
@@ -411,7 +404,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.2.21",
     cpe: "cpe:2.3:a:gehealthcare:centricity_pacs_iw:-:*:*:*:*:*:*:*",
     role: "Radiology Diagnostic Workstation",
-    upstreamApi: "https://www.gehealthcare.com/support",
     networkSegment: "PACS-VLAN-41",
     hostname: "WS-RADIOLOGY-002",
     macAddress: "00:1A:2B:3C:51:21",
@@ -429,7 +421,6 @@ const SAMPLE_ASSETS = [
     ip: "10.50.1.10",
     cpe: "cpe:2.3:h:dell:optiplex_790:-:*:*:*:*:*:*:*",
     role: "ED Image Viewer / Workstation",
-    upstreamApi: "https://www.dell.com/support",
     networkSegment: "ED-VLAN-50",
     hostname: "WS-ED-VIEWER-001",
     macAddress: "00:1A:2B:3C:52:10",
@@ -447,7 +438,6 @@ const SAMPLE_ASSETS = [
     ip: "10.70.1.10",
     cpe: "cpe:2.3:h:cisco:asa_5505:-:*:*:*:*:*:*:*",
     role: "Remote Radiology VPN Gateway",
-    upstreamApi: "https://www.cisco.com/c/en/us/support",
     networkSegment: "INFRA-VLAN-70",
     hostname: "VPN-ASA-001",
     macAddress: "00:1A:2B:3C:53:10",
@@ -464,7 +454,6 @@ const SAMPLE_ASSETS = [
     ip: "10.70.1.20",
     cpe: "cpe:2.3:h:cisco:catalyst_2960s-24ts-l:-:*:*:*:*:*:*:*",
     role: "Imaging Network Switch",
-    upstreamApi: "https://www.cisco.com/c/en/us/support",
     networkSegment: "INFRA-VLAN-70",
     hostname: "SW-IMAGING-001",
     macAddress: "00:1A:2B:3C:53:20",
@@ -481,7 +470,6 @@ const SAMPLE_ASSETS = [
     ip: "10.70.1.1",
     cpe: "cpe:2.3:h:cisco:asa_5505:-:*:*:*:*:*:*:*",
     role: "Perimeter Firewall",
-    upstreamApi: "https://www.cisco.com/c/en/us/support",
     networkSegment: "INFRA-VLAN-70",
     hostname: "FW-ASA-001",
     macAddress: "00:1A:2B:3C:53:01",
@@ -498,7 +486,6 @@ const SAMPLE_ASSETS = [
     ip: `10.20.3.${101 + i}`,
     cpe: "cpe:2.3:h:philips:intellivue_mp5:-:*:*:*:*:*:*:*",
     role: "Patient Monitor",
-    upstreamApi: "https://www.philips.com/a-w/about/support.html",
     networkSegment: "WARD-VLAN-20",
     hostname: `MON-MP5-${String(i + 1).padStart(3, "0")}`,
     macAddress: `00:1A:2B:3C:60:${(0x10 + i).toString(16).padStart(2, "0").toUpperCase()}`,
@@ -515,8 +502,6 @@ const SAMPLE_ASSETS = [
     ip: `10.20.4.${101 + i}`,
     cpe: "cpe:2.3:h:baxter:sigma_spectrum:-:*:*:*:*:*:*:*",
     role: "Infusion Pump",
-    upstreamApi:
-      "https://www.baxter.com/healthcare-professionals/service-and-support",
     networkSegment: "WARD-VLAN-20",
     hostname: `PUMP-SIGMA-${String(i + 1).padStart(3, "0")}`,
     macAddress: `00:1A:2B:3C:61:${(0x10 + i).toString(16).padStart(2, "0").toUpperCase()}`,
@@ -533,7 +518,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.60",
     cpe: "cpe:2.3:h:siemens:magnetom_sola:-:*:*:*:*:*:*:*",
     role: "MRI Scanner",
-    upstreamApi: "https://www.siemens-healthineers.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "MR-MAGNETOM-001",
     macAddress: "00:1A:2B:3C:50:60",
@@ -550,7 +534,6 @@ const SAMPLE_ASSETS = [
     ip: "10.40.1.61",
     cpe: "cpe:2.3:h:siemens:somatom_go.top:-:*:*:*:*:*:*:*",
     role: "CT Scanner",
-    upstreamApi: "https://www.siemens-healthineers.com/support",
     networkSegment: "IMAGING-VLAN-40",
     hostname: "CT-SOMATOM-001",
     macAddress: "00:1A:2B:3C:50:61",
@@ -605,8 +588,6 @@ const SAMPLE_VULNERABILITIES = [
       "cpe:2.3:h:gehealthcare:optima_xr200amx:-:*:*:*:*:*:*:*",
     ],
     exploitUri: "https://nvd.nist.gov/vuln/detail/CVE-2020-25175",
-    upstreamApi:
-      "https://www.cisa.gov/news-events/ics-medical-advisories/icsma-20-343-01",
     description:
       "GE Healthcare imaging and ultrasound products may allow specific credentials to be exposed during transport over the network due to insufficiently protected credential transmission (CWE-522/CWE-523). Affects the BrightSpeed Elite Select CT scanner, LOGIQ e R7 portable ultrasound units, and Optima XR200amx X-ray system.",
     narrative:
@@ -650,8 +631,6 @@ const SAMPLE_VULNERABILITIES = [
       "cpe:2.3:h:dell:optiplex_790:-:*:*:*:*:*:*:*",
     ],
     exploitUri: "https://nvd.nist.gov/vuln/detail/CVE-2017-0144",
-    upstreamApi:
-      "https://support.microsoft.com/en-us/topic/ms17-010-security-update-for-windows-smb-server-814d78c1-a11d-e4c8-d52a-f41a41b5d238",
     description:
       "Windows SMBv1 remote code execution vulnerability (MS17-010) allows unauthenticated remote attackers to execute arbitrary code via crafted SMB packets. Exploited by WannaCry and NotPetya ransomware. End-of-life Windows 7 or Windows Server 2008 R2 devices cannot receive the MS17-010 patch through standard Windows Update.",
     narrative:
@@ -689,8 +668,6 @@ const SAMPLE_VULNERABILITIES = [
       "cpe:2.3:a:cisco:adaptive_security_appliance_software:8.2:*:*:*:*:*:*:*",
     ],
     exploitUri: "https://nvd.nist.gov/vuln/detail/CVE-2016-6366",
-    upstreamApi:
-      "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160817-asa-snmp",
     description:
       "Buffer overflow in the SNMP code of Cisco ASA Software versions 8.4 and earlier allows unauthenticated remote attackers to execute arbitrary code or reload the device via crafted SNMPv2c packets. Disclosed by the Shadow Brokers as the EXTRABACON exploit. Both ASA 5505 devices in this network (remote radiology VPN gateway and perimeter firewall) run ASA OS 8.2.",
     narrative:
@@ -727,8 +704,6 @@ const SAMPLE_VULNERABILITIES = [
     },
     cpes: ["cpe:2.3:h:baxter:sigma_spectrum:-:*:*:*:*:*:*:*"],
     exploitUri: "https://nvd.nist.gov/vuln/detail/CVE-2021-12345",
-    upstreamApi:
-      "https://www.baxter.com/healthcare-professionals/service-and-support",
     description:
       "Buffer overflow in the wireless management interface of Baxter Sigma Spectrum infusion pumps running firmware versions prior to 8.x allows an attacker on the same wireless segment to execute arbitrary code or crash the device via crafted management packets. All 23 Sigma Spectrum pumps on WARD-VLAN-20 are running the vulnerable firmware (v1.2.3).",
     narrative:
@@ -767,7 +742,6 @@ const SAMPLE_REMEDIATIONS = [
       "Apply GE Healthcare ICS security controls per CISA advisory ICSMA-20-343-01 and GE Security Bulletin GE-2020-004 to mitigate credential exposure on imaging devices (CVE-2020-25175).",
     narrative:
       "Work with GE Healthcare Biomedical/Clinical Engineering to apply mitigations from GE Security Bulletin GE-2020-004. Immediately isolate all affected GE imaging devices (CT scanner, ultrasound units, X-ray node) to a dedicated DICOM VLAN with strict ACLs permitting only DICOM traffic (port 104/TCP) to and from the PACS server. Disable unnecessary network services on each device via GE service mode. Request firmware update availability from your GE account representative. Deploy IDS/IPS monitoring on the DICOM VLAN to detect anomalous credential-bearing traffic. Post-remediation: verify DICOM connectivity to PACS and confirm the imaging workflow is unaffected.",
-    upstreamApi: "https://www.gehealthcare.com/security",
   },
   // CVE-2017-0144 remediation for CT Acquisition Workstation (Windows 7 / EOL host)
   {
@@ -778,7 +752,6 @@ const SAMPLE_REMEDIATIONS = [
       "Windows 7 and Server 2008 R2 are end-of-life and do not receive patches via standard Windows Update. Apply MS17-010 via Microsoft extended support if contracted, then implement network-level compensating controls to mitigate EternalBlue (CVE-2017-0144) across all five imaging network Windows hosts.",
     narrative:
       "Immediate actions: (1) Disable SMBv1 on all five affected hosts via PowerShell (Set-SmbServerConfiguration -EnableSMB1Protocol $false) and registry (HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters, SMB1=0). (2) Block TCP port 445 inbound at the Cisco Catalyst 2960S switch using ACLs on all imaging and PACS VLANs. (3) Deploy host-based firewall rules to block SMB from non-management hosts. (4) Micro-segment each workstation subnet to minimize lateral movement. Long-term: coordinate with GE Healthcare to plan migration of CT acquisition workstation and PACS server to a supported OS — Advantage Workstation 4.6 and Centricity PACS-IW 5.0 compatibility with newer Windows versions must be confirmed with the manufacturer before upgrading.",
-    upstreamApi: "https://www.microsoft.com/en-us/windows/end-of-support",
   },
   // CVE-2016-6366 remediation for Cisco ASA 5505 (both VPN gateway and firewall)
   {
@@ -789,8 +762,6 @@ const SAMPLE_REMEDIATIONS = [
       "Upgrade Cisco ASA 5505 software from 8.2.x to a patched release (9.1(7.21) or later) per Cisco Security Advisory cisco-sa-20160817-asa-snmp to remediate the EXTRABACON SNMP buffer overflow (CVE-2016-6366). Applies to both the remote radiology VPN gateway and the perimeter firewall.",
     narrative:
       "Both ASA 5505 appliances must be upgraded. Cisco ASA 5505 supports ASA software up to 9.2(x); upgrade to 9.1(7.21)+ or the latest available 9.2.x release. Before upgrading: back up ASA configuration (copy running-config tftp://...), test rollback procedure in a change window. Schedule separate maintenance windows for each device — perimeter firewall first (~30 min downtime), then VPN gateway (coordinate with remote radiology team to minimize after-hours coverage gap). If an immediate upgrade cannot be scheduled: switch from SNMPv2c to SNMPv3 with authentication and encryption, or restrict SNMP community access via ACL to the management VLAN only. Post-upgrade: verify VPN tunnels for remote radiologist access, confirm firewall policy enforcement, and validate DICOM routing.",
-    upstreamApi:
-      "https://www.cisco.com/c/en/us/support/security/asa-5500-series-next-generation-firewalls/series.html",
   },
 ];
 
@@ -869,7 +840,7 @@ type SampleTicket = {
   department: string | string[];
   // When set, the seed creates a linked NotificationSource on this channel
   // (the ticket renders as ingested). Omitted ⇒ manually created.
-  sourceChannel?: NotificationChannel;
+  sourceChannel?: SourceChannel;
   sourceLabel?: string;
   scheduledAt?: Date;
   linkedCveIds?: string[];
@@ -965,7 +936,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
       Administration:
         "Imaging-chain EternalBlue remediation. Compliance-relevant: EOL OS exposure on patient-facing systems. PACS server change requires CMO sign-off (separate child ticket) due to imaging chain blast radius. Expected aggregate downtime across all hosts: under 30 minutes during business hours, plus a single overnight maintenance window for PACS.",
     },
-    sourceChannel: NotificationChannel.PolledApi,
+    sourceChannel: SourceChannel.Integration,
     sourceLabel: "TriMedX RSQ",
     linkedCveIds: ["CVE-2017-0144"],
     linkedAssetIds: [
@@ -986,7 +957,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
         status: TicketStatus.TO_DO,
         category: TicketCategory.CONFIG_CHANGE,
         department: "Radiology",
-        sourceChannel: NotificationChannel.PolledApi,
+        sourceChannel: SourceChannel.Integration,
         sourceLabel: "TriMedX RSQ",
         linkedCveIds: ["CVE-2017-0144"],
         linkedAssetIds: ["rad-ws-001"],
@@ -1002,7 +973,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
         status: TicketStatus.REQUIRES_APPROVAL,
         category: TicketCategory.VULN_REMEDIATION,
         department: "Radiology",
-        sourceChannel: NotificationChannel.Email,
+        sourceChannel: SourceChannel.Email,
         sourceLabel: "security@hospital.example.org",
         scheduledAt: inDays(10),
         linkedCveIds: ["CVE-2017-0144"],
@@ -1060,7 +1031,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
     status: TicketStatus.TO_DO,
     category: TicketCategory.VULN_REMEDIATION,
     department: "Radiology",
-    sourceChannel: NotificationChannel.PolledApi,
+    sourceChannel: SourceChannel.Integration,
     sourceLabel: "TriMedX RSQ",
     linkedCveIds: ["CVE-2020-25175"],
     linkedAssetIds: ["rad-ct-001", "rad-us-001", "rad-us-002", "rad-xr-001"],
@@ -1075,7 +1046,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
         status: TicketStatus.TO_DO,
         category: TicketCategory.CONFIG_CHANGE,
         department: "Radiology",
-        sourceChannel: NotificationChannel.PolledApi,
+        sourceChannel: SourceChannel.Integration,
         sourceLabel: "TriMedX RSQ",
         linkedCveIds: ["CVE-2020-25175"],
         linkedAssetIds: [
@@ -1119,7 +1090,7 @@ const SAMPLE_CHANGE_TICKETS: SampleParentTicket[] = [
         status: TicketStatus.IN_PROGRESS,
         category: TicketCategory.PATCH,
         department: "IT",
-        sourceChannel: NotificationChannel.Email,
+        sourceChannel: SourceChannel.Email,
         sourceLabel: "security@hospital.example.org",
         scheduledAt: inDays(3),
         linkedCveIds: ["CVE-2016-6366"],
@@ -1177,13 +1148,11 @@ async function clearDatabase() {
   await prisma.workflow.deleteMany();
   // Delete in order of dependencies (child tables first)
   await prisma.issue.deleteMany();
-  await prisma.syncStatus.deleteMany();
+  await prisma.integrationResourceSync.deleteMany();
   await prisma.externalAssetMapping.deleteMany();
   await prisma.externalVulnerabilityMapping.deleteMany();
   await prisma.artifact.deleteMany();
   await prisma.artifactWrapper.deleteMany();
-  // ContractAsset references Asset, so it must go before the asset delete below.
-  await prisma.contractAsset.deleteMany();
   await prisma.contract.deleteMany();
   await prisma.vendorContact.deleteMany();
   await prisma.vendor.deleteMany();
@@ -1362,7 +1331,6 @@ async function seedAssets(userId: string) {
           ip: asset.ip,
           networkSegment: asset.networkSegment,
           role: asset.role,
-          upstreamApi: asset.upstreamApi,
           hostname: asset.hostname,
           macAddress: asset.macAddress,
           serialNumber: asset.serialNumber,
@@ -1394,7 +1362,7 @@ async function seedFleetIntegration(userId: string) {
   console.log("\n🌱 Seeding Siemens Healthineers Fleet integration...");
 
   const existing = await prisma.integration.findFirst({
-    where: { integrationUri: { contains: "fleet.siemens-healthineers.com" } },
+    where: { platform: PlatformEnum.FLEET },
   });
 
   // Integrations own a service user — the creator of the tickets they ingest.
@@ -1416,15 +1384,17 @@ async function seedFleetIntegration(userId: string) {
     (await prisma.integration.create({
       data: {
         name: "Siemens Healthineers teamplay Fleet",
-        platform: "teamplay Fleet",
-        integrationUri:
-          "https://fleet.siemens-healthineers.com/rest/v1/activities?tz=-05:00",
-        integrationType: IntegrationType.REST,
-        authType: AuthType.None,
-        resourceType: ResourceType.WorkOrder,
+        platform: PlatformEnum.FLEET,
+        // TODO VW-431 ensure this works with teamplay fleet config
+        // or modify as needed
+        config: {
+          integrationUri:
+            "https://fleet.siemens-healthineers.com/rest/v1/activities?tz=-05:00",
+        },
         syncEvery: 3600,
         userId,
         integrationUserId: integrationUser.id,
+        resourceSyncs: { create: { resource: ResourceType.WorkOrder } },
       },
     }));
 
@@ -1657,7 +1627,6 @@ async function seedRemediations(userId: string) {
         data: {
           description: remediation.description,
           narrative: remediation.narrative,
-          upstreamApi: remediation.upstreamApi,
           vulnerabilityId: vulnerability.id,
           deviceGroupMatchings: matchingId
             ? { connect: { id: matchingId } }
@@ -2171,10 +2140,22 @@ async function createWorkOrderTicket(
       status: ticket.status,
       category: ticket.category,
       sourceLabel: ticket.sourceLabel,
-      // For ingested demo tickets, attach a NotificationSource on the given
-      // channel so the Source column renders the channel icon + label.
-      sources: ticket.sourceChannel
-        ? { create: [{ channel: ticket.sourceChannel, raw: {} }] }
+      // For ingested demo tickets, attach a SourceRecord on the given channel
+      // so the Source column renders the channel icon + label.
+      sourceLinks: ticket.sourceChannel
+        ? {
+            create: [
+              {
+                sourceRecord: {
+                  create: {
+                    channel: ticket.sourceChannel,
+                    raw: {},
+                    contentHash: sourceContentHash({}, null),
+                  },
+                },
+              },
+            ],
+          }
         : undefined,
       departments: {
         connect: orderedDepartments.map((d) => ({ id: d.id })),
@@ -2291,22 +2272,26 @@ async function seedVendors() {
     select: { id: true },
   });
 
-  const contract = await prisma.contract.create({
+  // ContractAsset is gone: a contract reaches its assets through the
+  // ManagesRelationship that answers "who is responsible for this asset?".
+  const managesRelationship = await prisma.managesRelationship.create({
+    data: {
+      responsibilities:
+        "Managed security and maintenance for imaging equipment under contract.",
+      vendorId: vendor.id,
+      assets: { connect: assets.map((asset) => ({ id: asset.id })) },
+    },
+  });
+
+  await prisma.contract.create({
     data: {
       vendorId: vendor.id,
       title: "Imaging Fleet Managed Service Agreement",
       effectiveFrom: new Date("2024-01-01"),
       effectiveTo: new Date("2027-12-31"),
       coverageSummary: `Managed security and maintenance across imaging (${assets.length} assets)`,
+      managesRelationshipId: managesRelationship.id,
     },
-  });
-
-  await prisma.contractAsset.createMany({
-    data: assets.map((asset) => ({
-      contractId: contract.id,
-      assetId: asset.id,
-    })),
-    skipDuplicates: true,
   });
 
   console.log(

--- a/scripts/seed-advisory-environment.ts
+++ b/scripts/seed-advisory-environment.ts
@@ -124,7 +124,6 @@ async function upsertAsset(
   return prisma.asset.create({
     data: {
       ...spec,
-      upstreamApi: "https://example.com/placeholder",
       status: "Active" as AssetStatus,
       deviceGroupId,
       userId,
@@ -222,8 +221,9 @@ async function assetsInScopeOf(matchings: MatchingRow[]) {
 
 async function resetInboxEnvironment() {
   const notifications = await prisma.notification.deleteMany({});
-  const orphanSources = await prisma.notificationSource.deleteMany({
-    where: { notificationId: null, workOrderTicketId: null },
+  // A source is orphaned when nothing links to it any more.
+  const orphanSources = await prisma.sourceRecord.deleteMany({
+    where: { links: { none: {} } },
   });
   const draftTickets = await prisma.workOrderTicket.deleteMany({
     where: { isDraft: true },

--- a/scripts/seed-notifications.ts
+++ b/scripts/seed-notifications.ts
@@ -4,14 +4,15 @@ import {
   ConfidenceLevel,
   IssueStatus,
   NotAffectedJustification,
-  NotificationChannel,
   NotificationType,
   Priority,
   ScopeTargetModel,
   Severity,
+  SourceChannel,
   Tlp,
   VersionStatus,
 } from "@/generated/prisma";
+import { sourceContentHash } from "@/lib/source-hash";
 import prisma from "../src/lib/db";
 
 const SEED_USER = {
@@ -108,7 +109,6 @@ async function seedSyngoPlazaVexScenario(userId: string) {
       return prisma.asset.create({
         data: {
           ...asset,
-          upstreamApi: "https://example.com/placeholder",
           status: "Active" as AssetStatus,
           deviceGroupId: deviceGroup.id,
           userId,
@@ -263,11 +263,14 @@ async function seedSyngoPlazaVexScenario(userId: string) {
     },
   });
 
-  await prisma.notificationSource.create({
+  await prisma.sourceRecord.create({
     data: {
-      notificationId: notification.id,
-      channel: NotificationChannel.Email,
-      sourceType: "Source",
+      channel: SourceChannel.Email,
+      links: {
+        create: { notificationId: notification.id, sourceType: "Source" },
+      },
+      externalId: "seed-ssa-016040",
+      contentHash: sourceContentHash({ emailId: "seed-ssa-016040" }),
       raw: {
         type: "email.received",
         created_at: "2026-02-10T09:00:00.000Z",
@@ -301,7 +304,7 @@ The affected application does not encrypt passwords properly. This could allow a
 
 - CVSS v3.1 Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
 - CWE-261: Weak Encoding for Password`,
-      receivedAt: new Date(),
+      observedAt: new Date(),
     },
   });
 
@@ -621,7 +624,6 @@ async function seedDeserializationScenario(userId: string) {
       await prisma.asset.create({
         data: {
           ...assetFields,
-          upstreamApi: "https://example.com/placeholder",
           status: "Active" as AssetStatus,
           deviceGroupId: deviceGroup.id,
           userId,
@@ -698,11 +700,14 @@ async function seedDeserializationScenario(userId: string) {
     },
   });
 
-  await prisma.notificationSource.create({
+  await prisma.sourceRecord.create({
     data: {
-      notificationId: notification.id,
-      channel: NotificationChannel.Email,
-      sourceType: "Source",
+      channel: SourceChannel.Email,
+      links: {
+        create: { notificationId: notification.id, sourceType: "Source" },
+      },
+      externalId: "seed-ssa-220609",
+      contentHash: sourceContentHash({ emailId: "seed-ssa-220609" }),
       raw: {
         type: "email.received",
         created_at: "2022-06-09T09:00:00.000Z",
@@ -734,7 +739,7 @@ The application deserialises untrusted data without sufficient validations that 
 ## Workarounds and mitigations
 - If possible, block ports 32912/tcp and 32914/tcp on an external firewall.
 - Product-specific fixes are available; contact your local Siemens Healthineers service representative.`,
-      receivedAt: new Date(),
+      observedAt: new Date(),
     },
   });
 

--- a/scripts/seed-notifications.ts
+++ b/scripts/seed-notifications.ts
@@ -263,30 +263,22 @@ async function seedSyngoPlazaVexScenario(userId: string) {
     },
   });
 
-  await prisma.sourceRecord.create({
+  const ssa016040Raw = {
+    type: "email.received",
+    created_at: "2026-02-10T09:00:00.000Z",
     data: {
-      channel: SourceChannel.Email,
-      links: {
-        create: { notificationId: notification.id, sourceType: "Source" },
-      },
-      externalId: "seed-ssa-016040",
-      contentHash: sourceContentHash({ emailId: "seed-ssa-016040" }),
-      raw: {
-        type: "email.received",
-        created_at: "2026-02-10T09:00:00.000Z",
-        data: {
-          email_id: "seed-ssa-016040",
-          created_at: "2026-02-10T09:00:00.000Z",
-          from: "psirt@siemens-healthineers.com",
-          to: ["security@hospital.org"],
-          cc: [],
-          bcc: [],
-          subject:
-            "SSA-016040: Insecure Password Encryption Vulnerability in syngo.plaza VB30E",
-          attachments: [],
-        },
-      },
-      markdown: `# SSA-016040: Insecure Password Encryption Vulnerability in syngo.plaza VB30E
+      email_id: "seed-ssa-016040",
+      created_at: "2026-02-10T09:00:00.000Z",
+      from: "psirt@siemens-healthineers.com",
+      to: ["security@hospital.org"],
+      cc: [],
+      bcc: [],
+      subject:
+        "SSA-016040: Insecure Password Encryption Vulnerability in syngo.plaza VB30E",
+      attachments: [],
+    },
+  };
+  const ssa016040Markdown = `# SSA-016040: Insecure Password Encryption Vulnerability in syngo.plaza VB30E
 
 **Publication Date**: 2026-02-10 · **CVSS v3.1**: 5.3 · **CVSS v4.0**: 6.3
 
@@ -303,7 +295,18 @@ Siemens Healthineers has released a new hot fix (HF07) for syngo.plaza version V
 The affected application does not encrypt passwords properly. This could allow an attacker to recover the original passwords and might gain unauthorized access.
 
 - CVSS v3.1 Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-- CWE-261: Weak Encoding for Password`,
+- CWE-261: Weak Encoding for Password`;
+
+  await prisma.sourceRecord.create({
+    data: {
+      channel: SourceChannel.Email,
+      links: {
+        create: { notificationId: notification.id, sourceType: "Source" },
+      },
+      externalId: "seed-ssa-016040",
+      contentHash: sourceContentHash(ssa016040Raw, ssa016040Markdown),
+      raw: ssa016040Raw,
+      markdown: ssa016040Markdown,
       observedAt: new Date(),
     },
   });
@@ -700,30 +703,22 @@ async function seedDeserializationScenario(userId: string) {
     },
   });
 
-  await prisma.sourceRecord.create({
+  const ssa220609Raw = {
+    type: "email.received",
+    created_at: "2022-06-09T09:00:00.000Z",
     data: {
-      channel: SourceChannel.Email,
-      links: {
-        create: { notificationId: notification.id, sourceType: "Source" },
-      },
-      externalId: "seed-ssa-220609",
-      contentHash: sourceContentHash({ emailId: "seed-ssa-220609" }),
-      raw: {
-        type: "email.received",
-        created_at: "2022-06-09T09:00:00.000Z",
-        data: {
-          email_id: "seed-ssa-220609",
-          created_at: "2022-06-09T09:00:00.000Z",
-          from: "psirt@siemens-healthineers.com",
-          to: ["security@hospital.org"],
-          cc: [],
-          bcc: [],
-          subject:
-            "SSA-220609: Deserialization Vulnerability in Healthcare Products",
-          attachments: [],
-        },
-      },
-      markdown: `# SSA-220609: Deserialization Vulnerability in Healthcare Products
+      email_id: "seed-ssa-220609",
+      created_at: "2022-06-09T09:00:00.000Z",
+      from: "psirt@siemens-healthineers.com",
+      to: ["security@hospital.org"],
+      cc: [],
+      bcc: [],
+      subject:
+        "SSA-220609: Deserialization Vulnerability in Healthcare Products",
+      attachments: [],
+    },
+  };
+  const ssa220609Markdown = `# SSA-220609: Deserialization Vulnerability in Healthcare Products
 
 **Publication Date**: 2022-05-31 · **Last Update**: 2022-06-09 · **CVSS v3.1**: 9.8
 
@@ -738,7 +733,18 @@ The application deserialises untrusted data without sufficient validations that 
 
 ## Workarounds and mitigations
 - If possible, block ports 32912/tcp and 32914/tcp on an external firewall.
-- Product-specific fixes are available; contact your local Siemens Healthineers service representative.`,
+- Product-specific fixes are available; contact your local Siemens Healthineers service representative.`;
+
+  await prisma.sourceRecord.create({
+    data: {
+      channel: SourceChannel.Email,
+      links: {
+        create: { notificationId: notification.id, sourceType: "Source" },
+      },
+      externalId: "seed-ssa-220609",
+      contentHash: sourceContentHash(ssa220609Raw, ssa220609Markdown),
+      raw: ssa220609Raw,
+      markdown: ssa220609Markdown,
       observedAt: new Date(),
     },
   });

--- a/scripts/seed-remediation-metric.ts
+++ b/scripts/seed-remediation-metric.ts
@@ -128,7 +128,7 @@ async function teardownFixture() {
 
   const sources = await prisma.sourceRecord.findMany({
     where: { channel: "TA4", externalId: { in: remediationIds } },
-    select: { links: { select: { notificationId: true } } },
+    select: { id: true, links: { select: { notificationId: true } } },
   });
   const notificationIds = sources
     .flatMap((s) => s.links.map((l) => l.notificationId))
@@ -136,6 +136,11 @@ async function teardownFixture() {
 
   const notifications = await prisma.notification.deleteMany({
     where: { id: { in: notificationIds } },
+  });
+  // Remediation.sourceRecord is SetNull and the links above cascade with their
+  // notification, so these snapshots would otherwise survive every run.
+  const orphanSources = await prisma.sourceRecord.deleteMany({
+    where: { id: { in: sources.map((s) => s.id) }, links: { none: {} } },
   });
   const deleted = await prisma.remediation.deleteMany({
     where: { id: { in: remediationIds } },
@@ -145,7 +150,7 @@ async function teardownFixture() {
   });
 
   console.log(
-    `  teardown: ${notifications.count} notification(s), ${deleted.count} remediation(s), ${vulns.count} vulnerability(s)`,
+    `  teardown: ${notifications.count} notification(s), ${orphanSources.count} source(s), ${deleted.count} remediation(s), ${vulns.count} vulnerability(s)`,
   );
 }
 

--- a/scripts/seed-remediation-metric.ts
+++ b/scripts/seed-remediation-metric.ts
@@ -126,12 +126,12 @@ async function teardownFixture() {
   });
   const remediationIds = remediations.map((r) => r.id);
 
-  const sources = await prisma.notificationSource.findMany({
+  const sources = await prisma.sourceRecord.findMany({
     where: { channel: "TA4", externalId: { in: remediationIds } },
-    select: { notificationId: true },
+    select: { links: { select: { notificationId: true } } },
   });
   const notificationIds = sources
-    .map((s) => s.notificationId)
+    .flatMap((s) => s.links.map((l) => l.notificationId))
     .filter((id): id is string => id !== null);
 
   const notifications = await prisma.notification.deleteMany({

--- a/scripts/test-fleet.ts
+++ b/scripts/test-fleet.ts
@@ -7,8 +7,8 @@ import prisma from "../src/lib/db";
 
 const url =
   "https://fleet.siemens-healthineers.com/rest/v1/security-advisories/active";
-const host = new URL(url).hostname;
 
+// TODO: VW-431, this most certainly needs to be updated as part of this ticket
 async function main() {
   const userName = process.env.FLEET_ADVISORY_USERNAME;
   const password = process.env.FLEET_ADVISORY_PASSWORD;
@@ -42,16 +42,8 @@ async function main() {
   const data = await results.json();
   console.log("data ", data);
 
-  const before = await prisma.integrationSession.findUnique({
-    where: { host },
-  });
-  console.log("before: ", before);
   const res = await FLEET.fetchWithSession(url);
   console.log("status: ", res.status);
-  const after = await prisma.integrationSession.findUnique({
-    where: { host },
-  });
-  console.log("after: ", after);
 }
 
 main()

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -476,7 +476,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset2.networkSegment).toBe(assetPayload2.networkSegment);
     expect(foundAsset2.role).toBe(assetPayload2.role);
-    expect(mapping1.upstreamApi).toBe(assetPayload2.upstreamApi);
+    expect(mapping2.upstreamApi).toBe(assetPayload2.upstreamApi);
     expect(foundAsset2.hostname).toBe(assetPayload2.hostname);
     expect(foundAsset2.macAddress).toBe(assetPayload2.macAddress);
     expect(foundAsset2.serialNumber).toBe(assetPayload2.serialNumber);
@@ -752,7 +752,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset2.networkSegment).toBe(assetPayload2.networkSegment);
     expect(foundAsset2.role).toBe(assetPayload2.role);
-    expect(mapping1.upstreamApi).toBe(assetPayload2.upstreamApi);
+    expect(mapping2.upstreamApi).toBe(assetPayload2.upstreamApi);
     expect(foundAsset2.hostname).toBe(assetPayload2.hostname);
     expect(foundAsset2.macAddress).toBe(assetPayload2.macAddress);
     expect(foundAsset2.serialNumber).toBe(assetPayload2.serialNumber);

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -23,14 +23,12 @@ describe("Assets Endpoint (/assets)", () => {
     ip: "192.168.1.100",
     cpe: generateCPE("asset_v1"),
     role: "Primary Server",
-    upstreamApi: "https://api.hospital-upstream.com/v1",
   };
 
   const payload2 = {
     ip: "192.168.1.101",
     cpe: generateCPE("asset_v2"),
     role: "Primary Server",
-    upstreamApi: "https://api.hospital-upstream.com/v2",
   };
 
   const mockIntegrationPayload = {
@@ -93,10 +91,9 @@ describe("Assets Endpoint (/assets)", () => {
     previous: null,
   };
 
-  it("POST /assets - should create asset with only ip and upstreamApi", async () => {
+  it("POST /assets - should create asset with only ip", async () => {
     const minimalPayload = {
       ip: "10.0.0.1",
-      upstreamApi: "https://api.hospital-upstream.com/v1",
     };
 
     const res = await request(BASE_URL)
@@ -193,7 +190,6 @@ describe("Assets Endpoint (/assets)", () => {
       ip: "192.168.1.105", // Updated field
       cpe: generateCPE("asset_v1"),
       role: "Backup Server",
-      upstreamApi: "https://api.hospital-upstream.com/v1",
     };
 
     const putRes = await request(BASE_URL)
@@ -234,14 +230,12 @@ describe("Assets Endpoint (/assets)", () => {
     expect(bodyFirst.deviceGroup).toHaveProperty("assetsUrl");
     expect(bodyFirst.deviceGroup).toHaveProperty("deviceArtifactsUrl");
     expect(bodyFirst.role).toBe(payload.role);
-    expect(bodyFirst.upstreamApi).toBe(payload.upstreamApi);
 
     const bodySecond = res.body.at(1);
     expect(bodySecond).toHaveProperty("id");
     expect(bodySecond.ip).toBe(payload2.ip);
     expect(bodySecond.deviceGroup.cpe.includes(payload2.cpe)).toBe(true);
     expect(bodySecond.role).toBe(payload2.role);
-    expect(bodySecond.upstreamApi).toBe(payload2.upstreamApi);
 
     // GET first payload from DB
     const firstAssetId = bodyFirst.id;
@@ -257,7 +251,6 @@ describe("Assets Endpoint (/assets)", () => {
     );
     expect(firstDetailRes.body.deviceGroup).toHaveProperty("url");
     expect(firstDetailRes.body.role).toBe(payload.role);
-    expect(firstDetailRes.body.upstreamApi).toBe(payload.upstreamApi);
 
     // GET second payload from DB
     const secondAssetId = bodySecond.id;
@@ -272,7 +265,6 @@ describe("Assets Endpoint (/assets)", () => {
       true,
     );
     expect(secondDetailRes.body.role).toBe(payload2.role);
-    expect(secondDetailRes.body.upstreamApi).toBe(payload2.upstreamApi);
 
     // DELETE the assets
     const deleteFirstAssetRes = await request(BASE_URL)

--- a/src/app/api/v1/__tests__/assets.test.ts
+++ b/src/app/api/v1/__tests__/assets.test.ts
@@ -1,7 +1,12 @@
 import { fail } from "node:assert";
 import request from "supertest";
 import { describe, expect, it, onTestFinished } from "vitest";
-import { AuthType, ResourceType, SyncStatusEnum } from "@/generated/prisma";
+import {
+  AuthType,
+  PlatformEnum,
+  ResourceType,
+  SyncStatusEnum,
+} from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
   AUTH_TOKEN,
@@ -30,11 +35,10 @@ describe("Assets Endpoint (/assets)", () => {
 
   const mockIntegrationPayload = {
     name: "mockIntegration",
-    platform: "mockIntegrationPlatform",
+    platform: PlatformEnum.PARTNER,
     integrationUri: "https://mock-upstream-api.com/",
-    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
-    resourceType: ResourceType.Asset,
+    resource: ResourceType.Asset,
     authentication: {
       token: AUTH_TOKEN,
     },
@@ -443,7 +447,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset1.networkSegment).toBe(assetPayload1.networkSegment);
     expect(foundAsset1.role).toBe(assetPayload1.role);
-    expect(foundAsset1.upstreamApi).toBe(assetPayload1.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(assetPayload1.upstreamApi);
     expect(foundAsset1.hostname).toBe(assetPayload1.hostname);
     expect(foundAsset1.macAddress).toBe(assetPayload1.macAddress);
     expect(foundAsset1.serialNumber).toBe(assetPayload1.serialNumber);
@@ -472,7 +476,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset2.networkSegment).toBe(assetPayload2.networkSegment);
     expect(foundAsset2.role).toBe(assetPayload2.role);
-    expect(foundAsset2.upstreamApi).toBe(assetPayload2.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(assetPayload2.upstreamApi);
     expect(foundAsset2.hostname).toBe(assetPayload2.hostname);
     expect(foundAsset2.macAddress).toBe(assetPayload2.macAddress);
     expect(foundAsset2.serialNumber).toBe(assetPayload2.serialNumber);
@@ -486,14 +490,17 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(mapping1.lastSynced).toStrictEqual(mapping2.lastSynced);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 
   it("update Assets uploadIntegration endpoint int test", async () => {
@@ -578,7 +585,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset1.networkSegment).toBe(assetPayload1.networkSegment);
     expect(foundAsset1.role).toBe(assetPayload1.role);
-    expect(foundAsset1.upstreamApi).toBe(newUpstreamApi); // this field should be updated
+    expect(mapping1.upstreamApi).toBe(newUpstreamApi); // this field should be updated
     expect(foundAsset1.hostname).toBe(assetPayload1.hostname);
     expect(foundAsset1.macAddress).toBe(assetPayload1.macAddress);
     expect(foundAsset1.serialNumber).toBe(assetPayload1.serialNumber);
@@ -613,7 +620,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset2.networkSegment).toBe(assetPayload2.networkSegment);
     expect(foundAsset2.role).toBe(assetPayload2.role);
-    expect(foundAsset2.upstreamApi).toBe(newUpstreamApi); // this field should be updated
+    expect(mapping2.upstreamApi).toBe(newUpstreamApi); // this field should be updated
     expect(foundAsset2.hostname).toBe(assetPayload2.hostname);
     expect(foundAsset2.macAddress).toBe(assetPayload2.macAddress);
     expect(foundAsset2.serialNumber).toBe(assetPayload2.serialNumber);
@@ -621,14 +628,17 @@ describe("Assets Endpoint (/assets)", () => {
     expect(foundAsset2.status).toBe(assetPayload2.status);
     expect(foundAsset2.deviceGroup.cpe.includes(assetPayload2.cpe)).toBe(true);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 
   it("mixed create+update Assets uploadIntegration endpoint int test", async () => {
@@ -713,7 +723,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset1.networkSegment).toBe(assetPayload1.networkSegment);
     expect(foundAsset1.role).toBe(assetPayload1.role);
-    expect(foundAsset1.upstreamApi).toBe(newUpstreamApi); // this field should be updated
+    expect(mapping1.upstreamApi).toBe(newUpstreamApi); // this field should be updated
     expect(foundAsset1.hostname).toBe(assetPayload1.hostname);
     expect(foundAsset1.macAddress).toBe(assetPayload1.macAddress);
     expect(foundAsset1.serialNumber).toBe(assetPayload1.serialNumber);
@@ -742,7 +752,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset2.networkSegment).toBe(assetPayload2.networkSegment);
     expect(foundAsset2.role).toBe(assetPayload2.role);
-    expect(foundAsset2.upstreamApi).toBe(assetPayload2.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(assetPayload2.upstreamApi);
     expect(foundAsset2.hostname).toBe(assetPayload2.hostname);
     expect(foundAsset2.macAddress).toBe(assetPayload2.macAddress);
     expect(foundAsset2.serialNumber).toBe(assetPayload2.serialNumber);
@@ -756,14 +766,17 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(mapping1.lastSynced).toStrictEqual(mapping2.lastSynced);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 
   it("asset with no mapping Assets uploadIntegration endpoint int test", async () => {
@@ -849,7 +862,7 @@ describe("Assets Endpoint (/assets)", () => {
 
     expect(foundAsset1.networkSegment).toBe(updatedAsset.networkSegment);
     expect(foundAsset1.role).toBe(updatedAsset.role);
-    expect(foundAsset1.upstreamApi).toBe(updatedAsset.upstreamApi); // this field should be updated
+    expect(mapping1.upstreamApi).toBe(updatedAsset.upstreamApi); // this field should be updated
     expect(foundAsset1.hostname).toBe(updatedAsset.hostname);
     expect(foundAsset1.macAddress).toBe(updatedAsset.macAddress);
     expect(foundAsset1.serialNumber).toBe(updatedAsset.serialNumber);
@@ -861,14 +874,17 @@ describe("Assets Endpoint (/assets)", () => {
       fail("lastSynced value should not be null");
     }
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping1.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping1.lastSynced);
   });
 
   it("all null unique field should miss Asset uploadIntegration endpoint int test", async () => {
@@ -1015,9 +1031,14 @@ describe("Assets Endpoint (/assets)", () => {
       },
     });
 
+    // The sync matched on serialNumber, so the mapping was created on this pass.
+    const matchedMapping = await prisma.externalAssetMapping.findFirstOrThrow({
+      where: { itemId: foundAsset.id, integrationId: integration.id },
+    });
+
     expect(foundAsset.networkSegment).toBe(matchableAsset.networkSegment);
     expect(foundAsset.role).toBe(matchableAsset.role);
-    expect(foundAsset.upstreamApi).toBe(matchableAsset.upstreamApi); // this should be updated
+    expect(matchedMapping.upstreamApi).toBe(matchableAsset.upstreamApi); // this should be updated
     expect(foundAsset.hostname).toBeNullable();
     expect(foundAsset.macAddress).toBeNullable();
     expect(foundAsset.serialNumber).toBe(matchableAsset.serialNumber);

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -6,6 +6,7 @@ import type { DeviceArtifactResponse } from "@/features/device-artifacts/types";
 import {
   ArtifactType,
   AuthType,
+  PlatformEnum,
   ResourceType,
   SyncStatusEnum,
 } from "@/generated/prisma";
@@ -38,11 +39,10 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
 
   const mockIntegrationPayload = {
     name: "mockDeviceArtifactIntegration",
-    platform: "mockIntegrationPlatform",
+    platform: PlatformEnum.PARTNER,
     integrationUri: "https://mock-deviceArtifact-upstream-api.com/",
-    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
-    resourceType: ResourceType.DeviceArtifact,
+    resource: ResourceType.DeviceArtifact,
     authentication: {
       token: AUTH_TOKEN,
     },
@@ -635,7 +635,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     expect(mapping1.externalId).toBe(daPayload1.vendorId);
 
     expect(foundDeviceArtifact1.description).toBe(daPayload1.description);
-    expect(foundDeviceArtifact1.upstreamApi).toBe(daPayload1.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(daPayload1.upstreamApi);
     expect(
       foundDeviceArtifact1.deviceGroupMatchings.some(
         (m: { product: { canonicalName: string } | null }) =>
@@ -669,7 +669,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     expect(mapping2.externalId).toBe(daPayload2.vendorId);
 
     expect(foundDeviceArtifact2.description).toBe(daPayload2.description);
-    expect(foundDeviceArtifact2.upstreamApi).toBe(daPayload2.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(daPayload2.upstreamApi);
     expect(
       foundDeviceArtifact2.deviceGroupMatchings.some(
         (m: { product: { canonicalName: string } | null }) =>
@@ -685,13 +685,16 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
 
     expect(mapping1.lastSynced).toStrictEqual(mapping2.lastSynced);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 });

--- a/src/app/api/v1/__tests__/deviceArtifacts.test.ts
+++ b/src/app/api/v1/__tests__/deviceArtifacts.test.ts
@@ -669,7 +669,7 @@ describe("DeviceArtifacts Endpoint (/deviceArtifacts)", () => {
     expect(mapping2.externalId).toBe(daPayload2.vendorId);
 
     expect(foundDeviceArtifact2.description).toBe(daPayload2.description);
-    expect(mapping1.upstreamApi).toBe(daPayload2.upstreamApi);
+    expect(mapping2.upstreamApi).toBe(daPayload2.upstreamApi);
     expect(
       foundDeviceArtifact2.deviceGroupMatchings.some(
         (m: { product: { canonicalName: string } | null }) =>

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -6,6 +6,7 @@ import type { RemediationResponse } from "@/features/remediations/types";
 import {
   ArtifactType,
   AuthType,
+  PlatformEnum,
   ResourceType,
   SyncStatusEnum,
 } from "@/generated/prisma";
@@ -48,11 +49,10 @@ describe("Remediations Endpoint (/remediations)", () => {
 
   const mockIntegrationPayload = {
     name: "mockVulnIntegration",
-    platform: "mockIntegrationPlatform",
+    platform: PlatformEnum.PARTNER,
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    integrationType: "PARTNER" as const,
     authType: AuthType.Bearer,
-    resourceType: ResourceType.Remediation,
+    resource: ResourceType.Remediation,
     authentication: {
       token: AUTH_TOKEN,
     },
@@ -299,7 +299,7 @@ describe("Remediations Endpoint (/remediations)", () => {
       // If the analysis job won the race and built a notification anyway, remove
       // it (deleting the notification cascades its source, mappings, mitigation
       // plans, and draft work orders).
-      const src = await prisma.notificationSource
+      const src = await prisma.sourceRecord
         .findUnique({
           where: {
             channel_externalId: {
@@ -307,12 +307,16 @@ describe("Remediations Endpoint (/remediations)", () => {
               externalId: remediationId,
             },
           },
-          select: { notificationId: true },
+          // What a snapshot fed goes through SourceLink now.
+          select: { links: { select: { notificationId: true } } },
         })
         .catch(() => null);
-      if (src?.notificationId) {
+      const notificationId = src?.links.find(
+        (l) => l.notificationId,
+      )?.notificationId;
+      if (notificationId) {
         await prisma.notification
-          .delete({ where: { id: src.notificationId } })
+          .delete({ where: { id: notificationId } })
           .catch(() => {});
       }
       await prisma.remediation
@@ -561,7 +565,7 @@ describe("Remediations Endpoint (/remediations)", () => {
 
     expect(foundRem1.description).toBe(remPayload1.description);
     expect(foundRem1.narrative).toBe(remPayload1.narrative);
-    expect(foundRem1.upstreamApi).toBe(remPayload1.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(remPayload1.upstreamApi);
     expect(foundRem1.artifacts.length).toBe(1);
 
     const remPayload2 = remediationIntegrationPayload.items[1];
@@ -585,7 +589,7 @@ describe("Remediations Endpoint (/remediations)", () => {
 
     expect(foundRem2.description).toBe(remPayload2.description);
     expect(foundRem2.narrative).toBe(remPayload2.narrative);
-    expect(foundRem2.upstreamApi).toBe(remPayload2.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(remPayload2.upstreamApi);
     expect(foundRem2.artifacts.length).toBe(1);
 
     if (!mapping1.lastSynced || !mapping2.lastSynced) {
@@ -594,14 +598,17 @@ describe("Remediations Endpoint (/remediations)", () => {
 
     expect(mapping1.lastSynced).toStrictEqual(mapping2.lastSynced);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 
   it("integration re-sync without cpes preserves existing deviceGroupMatchings", async () => {

--- a/src/app/api/v1/__tests__/remediations.test.ts
+++ b/src/app/api/v1/__tests__/remediations.test.ts
@@ -589,7 +589,7 @@ describe("Remediations Endpoint (/remediations)", () => {
 
     expect(foundRem2.description).toBe(remPayload2.description);
     expect(foundRem2.narrative).toBe(remPayload2.narrative);
-    expect(mapping1.upstreamApi).toBe(remPayload2.upstreamApi);
+    expect(mapping2.upstreamApi).toBe(remPayload2.upstreamApi);
     expect(foundRem2.artifacts.length).toBe(1);
 
     if (!mapping1.lastSynced || !mapping2.lastSynced) {

--- a/src/app/api/v1/__tests__/test-config.ts
+++ b/src/app/api/v1/__tests__/test-config.ts
@@ -62,15 +62,11 @@ export const setupMockIntegration = async (
 
   expect(createdIntegration.name).toBe(mockIntegrationPayload.name);
   expect(createdIntegration.platform).toBe(mockIntegrationPayload.platform);
-  expect(createdIntegration.integrationUri).toBe(
-    mockIntegrationPayload.integrationUri,
-  );
-  expect(createdIntegration.integrationType).toBe(
-    mockIntegrationPayload.integrationType,
-  );
-  expect(createdIntegration.resourceType).toBe(
-    mockIntegrationPayload.resourceType,
-  );
+  // TODO: VW-428 confirm this works
+  expect(createdIntegration.config).toMatchObject({
+    integrationUri: mockIntegrationPayload.integrationUri,
+    resource: mockIntegrationPayload.resource,
+  });
   expect(createdIntegration.syncEvery).toBe(mockIntegrationPayload.syncEvery);
 
   // create an api key for the integration user

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -1,7 +1,12 @@
 import { fail } from "node:assert";
 import request from "supertest";
 import { describe, expect, it, onTestFinished } from "vitest";
-import { AuthType, ResourceType, SyncStatusEnum } from "@/generated/prisma";
+import {
+  AuthType,
+  PlatformEnum,
+  ResourceType,
+  SyncStatusEnum,
+} from "@/generated/prisma";
 import prisma from "@/lib/db";
 import {
   authHeader,
@@ -32,10 +37,9 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
 
   const mockIntegrationPayload = {
     name: "mockVulnIntegration",
-    platform: "mockIntegrationPlatform",
+    platform: PlatformEnum.PARTNER,
     integrationUri: "https://mock-vuln-upstream-api.com/",
-    integrationType: "PARTNER" as const,
-    resourceType: ResourceType.Vulnerability,
+    resource: ResourceType.Vulnerability,
     syncEvery: 300,
     authType: AuthType.None,
   };
@@ -257,7 +261,7 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
     expect(foundVuln1.description).toBe(vulnPayload1.description);
     expect(foundVuln1.narrative).toBe(vulnPayload1.narrative);
     expect(foundVuln1.impact).toBe(vulnPayload1.impact);
-    expect(foundVuln1.upstreamApi).toBe(vulnPayload1.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(vulnPayload1.upstreamApi);
     expect(foundVuln1.exploitUri).toBe(vulnPayload1.exploitUri);
     expect(foundVuln1.sarif).toStrictEqual(vulnPayload1.sarif);
     expect(foundVuln1.deviceGroupMatchings.length).toBe(
@@ -291,7 +295,7 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
     expect(foundVuln2.description).toBe(vulnPayload2.description);
     expect(foundVuln2.narrative).toBe(vulnPayload2.narrative);
     expect(foundVuln2.impact).toBe(vulnPayload2.impact);
-    expect(foundVuln2.upstreamApi).toBe(vulnPayload2.upstreamApi);
+    expect(mapping1.upstreamApi).toBe(vulnPayload2.upstreamApi);
     expect(foundVuln2.exploitUri).toBe(vulnPayload2.exploitUri);
     expect(foundVuln2.sarif).toStrictEqual(vulnPayload2.sarif);
     expect(foundVuln2.deviceGroupMatchings.length).toBe(
@@ -307,13 +311,16 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
 
     expect(mapping1.lastSynced).toStrictEqual(mapping2.lastSynced);
 
-    const foundSync = await prisma.syncStatus.findFirstOrThrow({
-      where: { syncedAt: mapping1.lastSynced },
+    const foundSync = await prisma.integrationResourceSync.findFirstOrThrow({
+      where: {
+        integrationId: createdIntegration.id,
+        resource: mockIntegrationPayload.resource,
+      },
     });
 
     expect(foundSync.integrationId).toBe(createdIntegration.id);
     expect(foundSync.status).toBe(SyncStatusEnum.Success);
     expect(foundSync.errorMessage).toBeNullable();
-    expect(foundSync.syncedAt).toStrictEqual(mapping2.lastSynced);
+    expect(foundSync.lastSuccessfulSync).toStrictEqual(mapping2.lastSynced);
   });
 });

--- a/src/app/api/v1/__tests__/vulnerabilities.test.ts
+++ b/src/app/api/v1/__tests__/vulnerabilities.test.ts
@@ -295,7 +295,7 @@ describe("Vulnerabilities Endpoint (/vulnerabilities)", () => {
     expect(foundVuln2.description).toBe(vulnPayload2.description);
     expect(foundVuln2.narrative).toBe(vulnPayload2.narrative);
     expect(foundVuln2.impact).toBe(vulnPayload2.impact);
-    expect(mapping1.upstreamApi).toBe(vulnPayload2.upstreamApi);
+    expect(mapping2.upstreamApi).toBe(vulnPayload2.upstreamApi);
     expect(foundVuln2.exploitUri).toBe(vulnPayload2.exploitUri);
     expect(foundVuln2.sarif).toStrictEqual(vulnPayload2.sarif);
     expect(foundVuln2.deviceGroupMatchings.length).toBe(

--- a/src/features/assets/types.ts
+++ b/src/features/assets/types.ts
@@ -1,11 +1,10 @@
 import type { inferOutput } from "@trpc/tanstack-react-query";
 import { z } from "zod";
-import { AssetStatus, type Prisma } from "@/generated/prisma";
+import { AssetStatus, PlatformEnum, type Prisma } from "@/generated/prisma";
 import { createPaginatedResponseSchema } from "@/lib/pagination";
 import {
   cpeSchema,
   createIntegrationInputSchema,
-  safeUrlSchema,
   userIncludeSelect,
   userSchema,
 } from "@/lib/schemas";
@@ -38,7 +37,6 @@ export const assetInputSchema = z.object({
   networkSegment: z.string().nullish(),
   cpe: cpeSchema.nullish(),
   role: z.string().min(1).nullish(),
-  upstreamApi: safeUrlSchema,
   hostname: z.string().nullish(),
   macAddress: z.string().nullish(),
   serialNumber: z.string().nullish(),
@@ -65,7 +63,18 @@ export const assetResponseSchema = z.object({
   ip: z.string(),
   deviceGroup: deviceGroupWithUrlsSchema,
   role: z.string().nullable(),
-  upstreamApi: z.string(),
+  externalMappings: z.array(
+    z.object({
+      externalId: z.string(),
+      upstreamApi: z.string().nullable(),
+      webUrl: z.string().nullable(),
+      integration: z.object({
+        id: z.string(),
+        name: z.string(),
+        platform: z.enum(PlatformEnum),
+      }),
+    }),
+  ),
   networkSegment: z.string().nullable(),
   hostname: z.string().nullable(),
   macAddress: z.string().nullable(),
@@ -98,14 +107,27 @@ export type AssetsVulnsInput = z.infer<typeof assetsVulnsInputSchema>;
 export const assetInclude = {
   user: userIncludeSelect,
   deviceGroup: deviceGroupSelect,
+  externalMappings: {
+    select: {
+      externalId: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
+    },
+  },
 };
 
 export const assetDashboardInclude = {
   user: userIncludeSelect,
   deviceGroup: deviceGroupSelect,
   externalMappings: {
-    include: {
-      integration: { select: { id: true, name: true } },
+    select: {
+      id: true,
+      externalId: true,
+      lastSynced: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
     },
   },
   issues: {

--- a/src/features/device-artifacts/types.ts
+++ b/src/features/device-artifacts/types.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
+import { PlatformEnum } from "@/generated/prisma";
 import { createPaginatedResponseSchema } from "@/lib/pagination";
 import {
   cpeSchema,
   createIntegrationInputSchema,
   deviceGroupMatchingResponseSchema,
-  safeUrlSchema,
   userIncludeSelect,
   userSchema,
 } from "@/lib/schemas";
@@ -31,7 +31,6 @@ export const deviceArtifactInputSchema = z.object({
   cpe: cpeSchema,
   role: z.string().min(1, "Role is required"),
   description: z.string().min(1, "Description is required"),
-  upstreamApi: safeUrlSchema.nullish(),
   artifacts: z
     .array(artifactInputSchema)
     .min(1, "at least one artifact is required"),
@@ -44,14 +43,24 @@ export const deviceArtifactUpdateSchema = z.object({
   id: z.string(),
   role: z.string().min(1, "Role is required").optional(),
   description: z.string().optional(),
-  upstreamApi: safeUrlSchema.optional(),
   cpe: cpeSchema.optional(),
 });
 
 export const deviceArtifactResponseSchema = z.object({
   id: z.string(),
   role: z.string(),
-  upstreamApi: z.string().nullable(),
+  externalMappings: z.array(
+    z.object({
+      externalId: z.string(),
+      upstreamApi: z.string().nullable(),
+      webUrl: z.string().nullable(),
+      integration: z.object({
+        id: z.string(),
+        name: z.string(),
+        platform: z.enum(PlatformEnum),
+      }),
+    }),
+  ),
   description: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
@@ -81,4 +90,12 @@ export const deviceArtifactInclude = {
   user: userIncludeSelect,
   deviceGroupMatchings: matchingInclude,
   artifacts: artifactWrapperSelect,
+  externalMappings: {
+    select: {
+      externalId: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
+    },
+  },
 };

--- a/src/features/inbox/agent/mitigation/index.ts
+++ b/src/features/inbox/agent/mitigation/index.ts
@@ -66,7 +66,7 @@ export async function createMitigationPlans(
   inlinedPdfs?: PdfAttachment[],
 ): Promise<MitigationPlansResult & { linkableIds: LinkableIds }> {
   const [source, notification, pdfAttachments, context] = await Promise.all([
-    prisma.notificationSource.findUnique({
+    prisma.sourceRecord.findUnique({
       where: { id: sourceId },
       select: { markdown: true },
     }),

--- a/src/features/inbox/agent/question/index.ts
+++ b/src/features/inbox/agent/question/index.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { buildUserMessage, PdfAttachment } from "@/lib/agent-messages";
+import { buildUserMessage, type PdfAttachment } from "@/lib/agent-messages";
 import prisma from "@/lib/db";
 import { fetchPdfAttachments } from "../../utils";
 import {
@@ -67,9 +67,11 @@ export async function generateFollowUpQuestion(
   );
   if (!context) return null;
 
-  const source = await prisma.notificationSource.findFirst({
-    where: { notificationId: priorQuestions[0].notificationId },
-    orderBy: { receivedAt: "desc" },
+  const source = await prisma.sourceRecord.findFirst({
+    where: {
+      links: { some: { notificationId: priorQuestions[0].notificationId } },
+    },
+    orderBy: { observedAt: "desc" },
   });
 
   const pdfAttachments = source ? await fetchPdfAttachments(source.id) : [];

--- a/src/features/inbox/agent/triage/index.ts
+++ b/src/features/inbox/agent/triage/index.ts
@@ -66,7 +66,7 @@ export async function triageNotification(
   inlinedPdfs?: PdfAttachment[],
 ): Promise<TriageResult> {
   const [source, notification, pdfAttachments, context] = await Promise.all([
-    prisma.notificationSource.findUnique({
+    prisma.sourceRecord.findUnique({
       where: { id: sourceId },
       select: { markdown: true },
     }),

--- a/src/features/inbox/agent/vex/context.ts
+++ b/src/features/inbox/agent/vex/context.ts
@@ -53,7 +53,9 @@ export async function gatherVexContext(
   const notification = await prisma.notification.findUnique({
     where: { id: notificationId },
     include: {
-      sources: { select: { markdown: true, channel: true } },
+      sourceLinks: {
+        select: { sourceRecord: { select: { markdown: true, channel: true } } },
+      },
       vulnerabilities: {
         include: {
           vulnerability: {
@@ -194,7 +196,7 @@ export async function gatherVexContext(
   const cveById = new Map(vulnerabilities.map((v) => [v.id, v.cveId ?? v.id]));
 
   const markdown = renderVexPrompt({
-    sources: notification.sources,
+    sources: notification.sourceLinks.map((l) => l.sourceRecord),
     vulnerabilities,
     remediations,
     candidateGroups,
@@ -396,8 +398,8 @@ export async function gatherVexContextForIssue(
     where: { vulnerabilityId: issue.vulnerabilityId },
   });
 
-  const sources = await prisma.notificationSource.findMany({
-    where: { notificationId },
+  const sources = await prisma.sourceRecord.findMany({
+    where: { links: { some: { notificationId } } },
     select: { markdown: true, channel: true },
   });
 

--- a/src/features/inbox/components/columns.tsx
+++ b/src/features/inbox/components/columns.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";

--- a/src/features/inbox/components/notification-detail.tsx
+++ b/src/features/inbox/components/notification-detail.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import { formatDistanceToNow } from "date-fns";

--- a/src/features/inbox/components/notification-details-tab.tsx
+++ b/src/features/inbox/components/notification-details-tab.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import { format } from "date-fns";

--- a/src/features/integrations/components/columns.tsx
+++ b/src/features/integrations/components/columns.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/features/integrations/components/integrations-layout.tsx
+++ b/src/features/integrations/components/integrations-layout.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/features/integrations/components/integrations.tsx
+++ b/src/features/integrations/components/integrations.tsx
@@ -1,3 +1,4 @@
+// TODO(VW-499): Fix changes after VW-427
 "use client";
 
 import { DialogClose } from "@radix-ui/react-dialog";

--- a/src/features/integrations/hooks/use-integrations.ts
+++ b/src/features/integrations/hooks/use-integrations.ts
@@ -35,11 +35,13 @@ export const useCreateIntegration = () => {
     trpc.integrations.create.mutationOptions({
       onSuccess: (data) => {
         toast.success("Integration created");
-        queryClient.invalidateQueries(
-          trpc.integrations.getMany.queryOptions({
-            resourceType: data.resourceType,
-          }),
-        );
+        for (const sync of data.resourceSyncs) {
+          queryClient.invalidateQueries(
+            trpc.integrations.getMany.queryOptions({
+              resourceType: sync.resource,
+            }),
+          );
+        }
         // Need to recount # of active ApiKey Connectors
         queryClient.invalidateQueries(
           trpc.apiKeyConnectors.getManyTypeCountInternal.queryOptions(),
@@ -65,11 +67,13 @@ export const useUpdateIntegration = () => {
     trpc.integrations.update.mutationOptions({
       onSuccess: (data) => {
         toast.success("Integration updated");
-        queryClient.invalidateQueries(
-          trpc.integrations.getMany.queryOptions({
-            resourceType: data.resourceType,
-          }),
-        );
+        for (const sync of data.resourceSyncs) {
+          queryClient.invalidateQueries(
+            trpc.integrations.getMany.queryOptions({
+              resourceType: sync.resource,
+            }),
+          );
+        }
         return data;
       },
       onError: (error) => {
@@ -91,11 +95,11 @@ export const useRemoveIntegration = () => {
       onSuccess: (data) => {
         toast.success("Integration removed");
         // Invalidate all getMany and getOne queries regardless of params
-        queryClient.invalidateQueries(
-          trpc.integrations.getMany.queryOptions({
-            resourceType: data.resourceType,
-          }),
-        );
+        for (const resource of data.resources) {
+          queryClient.invalidateQueries(
+            trpc.integrations.getMany.queryOptions({ resourceType: resource }),
+          );
+        }
         // Need to recount # of active ApiKey Connectors
         queryClient.invalidateQueries(
           trpc.apiKeyConnectors.getManyTypeCountInternal.queryOptions(),

--- a/src/features/integrations/integration-session-client.ts
+++ b/src/features/integrations/integration-session-client.ts
@@ -1,3 +1,4 @@
+// TODO(VW-431): Move auth to teamplay fleet platform code
 import prisma from "@/lib/db";
 import {
   grabSessionCookie,

--- a/src/features/integrations/teamplay-fleet/activities.test.ts
+++ b/src/features/integrations/teamplay-fleet/activities.test.ts
@@ -87,8 +87,8 @@ describe("mapFleetActivities", () => {
     expect(items[0].body).toContain("US_1064669350");
   });
 
-  it("attaches a PolledApi source keyed by ticketKey, preserving the raw record", () => {
-    expect(items[0].source.channel).toBe("PolledApi");
+  it("attaches an Integration source keyed by ticketKey, preserving the raw record", () => {
+    expect(items[0].source.channel).toBe("Integration");
     expect(items[0].source.externalId).toBe("US_400501937577");
     expect(items[0].source.raw.ticketKey).toBe("US_400501937577");
     // markdown mirrors the ticket body so the source view has detail.

--- a/src/features/integrations/teamplay-fleet/activities.ts
+++ b/src/features/integrations/teamplay-fleet/activities.ts
@@ -1,4 +1,4 @@
-// TODO: VW-433 
+// TODO: VW-433
 
 import { z } from "zod";
 import {

--- a/src/features/integrations/teamplay-fleet/activities.ts
+++ b/src/features/integrations/teamplay-fleet/activities.ts
@@ -1,6 +1,8 @@
+// TODO: VW-433 
+
 import { z } from "zod";
 import {
-  NotificationChannel,
+  SourceChannel,
   TicketCategory,
   TicketStatus,
 } from "@/generated/prisma";
@@ -35,9 +37,8 @@ export interface FleetWorkOrderItem {
   sourceLabel: string;
   body: string;
   source: {
-    channel: NotificationChannel;
+    channel: SourceChannel;
     externalId: string;
-    referenceUrl: string | null;
     markdown: string;
     raw: FleetActivity;
   };
@@ -123,12 +124,9 @@ export function mapFleetActivities(
       scheduledAt: toIso(a.plannedStart ?? a.dueDate, offset),
       sourceLabel: "Siemens Healthineers Fleet",
       body,
-      // Polled from a REST API → PolledApi channel. Drives the source badge and
-      // Suggested-tab membership; `raw` keeps the original activity.
       source: {
-        channel: NotificationChannel.PolledApi,
+        channel: SourceChannel.Integration,
         externalId: a.ticketKey,
-        referenceUrl: null,
         markdown: body,
         raw: a,
       },

--- a/src/features/integrations/teamplay-fleet/tracking.ts
+++ b/src/features/integrations/teamplay-fleet/tracking.ts
@@ -1,3 +1,5 @@
+// TODO: VW-432
+
 /**
  * Outbound client for Siemens Healthineers teamplay Fleet.
  *
@@ -28,7 +30,7 @@ import "server-only";
 import { z } from "zod";
 import {
   type Asset,
-  type Integration,
+  PlatformEnum,
   ResourceType,
   type TicketCategory,
 } from "@/generated/prisma";
@@ -54,9 +56,10 @@ export { FLEET_HOST, FLEET_SOURCE_LABEL };
  * integration rows (activities → WorkOrder, equipment → Asset), and an asset is
  * "Siemens-managed" if it's mapped through ANY of them.
  */
-export function getFleetIntegrations(): Promise<Integration[]> {
+export function getFleetIntegrations() {
   return prisma.integration.findMany({
-    where: { integrationUri: { contains: FLEET_HOST, mode: "insensitive" } },
+    where: { platform: PlatformEnum.FLEET },
+    include: { resourceSyncs: { select: { resource: true } } },
     orderBy: { createdAt: "asc" },
   });
 }
@@ -68,10 +71,10 @@ export function getFleetIntegrations(): Promise<Integration[]> {
  * fallback to another resourceType: attaching the mapping to, say, the Asset
  * (equipment-sync) integration would break that dedup contract.
  */
-export async function getFleetWorkOrderIntegration(): Promise<Integration> {
+export async function getFleetWorkOrderIntegration() {
   const integrations = await getFleetIntegrations();
-  const integration = integrations.find(
-    (i) => i.resourceType === ResourceType.WorkOrder,
+  const integration = integrations.find((i) =>
+    i.resourceSyncs.some((s) => s.resource === ResourceType.WorkOrder),
   );
 
   if (!integration) {

--- a/src/features/remediations/components/remediations.tsx
+++ b/src/features/remediations/components/remediations.tsx
@@ -1,3 +1,4 @@
+// TODO: VW-449
 "use client";
 
 import { formatDistanceToNow } from "date-fns";

--- a/src/features/remediations/types.ts
+++ b/src/features/remediations/types.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
-import type { Prisma } from "@/generated/prisma";
+import { PlatformEnum, type Prisma } from "@/generated/prisma";
 import { createPaginatedResponseSchema } from "@/lib/pagination";
 import {
   alohaResponseSchema,
   cpeSchema,
   createIntegrationInputSchema,
   deviceGroupMatchingResponseSchema,
-  safeUrlSchema,
   userIncludeSelect,
   userSchema,
 } from "@/lib/schemas";
@@ -36,7 +35,6 @@ export const remediationInputSchema = z.object({
   vulnerabilityId: z.string().nullish(),
   description: z.string().nullish(),
   narrative: z.string().nullish(),
-  upstreamApi: safeUrlSchema.nullish(),
   artifacts: z
     .array(artifactInputSchema)
     .min(1, "at least one artifact is required"),
@@ -52,7 +50,6 @@ export const remediationUpdateSchema = z.object({
   vulnerabilityId: z.string().nullish(),
   description: z.string().nullish(),
   narrative: z.string().nullish(),
-  upstreamApi: safeUrlSchema.nullish(),
   artifacts: z.array(artifactInputSchema).optional(),
 });
 
@@ -64,7 +61,18 @@ export const vulnerabilitySchema = z.object({
 export const remediationResponseSchema = z.object({
   id: z.string(),
   deviceGroupMatchings: z.array(deviceGroupMatchingResponseSchema),
-  upstreamApi: z.string().nullish(),
+  externalMappings: z.array(
+    z.object({
+      externalId: z.string(),
+      upstreamApi: z.string().nullable(),
+      webUrl: z.string().nullable(),
+      integration: z.object({
+        id: z.string(),
+        name: z.string(),
+        platform: z.enum(PlatformEnum),
+      }),
+    }),
+  ),
   description: z.string().nullish(),
   narrative: z.string().nullish(),
   vulnerability: vulnerabilitySchema.nullish(),
@@ -103,6 +111,14 @@ export const remediationInclude = {
   deviceGroupMatchings: matchingInclude,
   vulnerability: remediationVulnerabilitySelect,
   artifacts: artifactWrapperSelect,
+  externalMappings: {
+    select: {
+      externalId: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
+    },
+  },
 };
 
 export const remediationCardInclude = {

--- a/src/features/vendors/server/routers.ts
+++ b/src/features/vendors/server/routers.ts
@@ -19,8 +19,9 @@ export const vendorsRouter = createTRPCRouter({
           ...vendor,
           // Contracts under one vendor may overlap, so the same asset can appear twice.
           assetCount: new Set(
-            contracts.flatMap((contract) =>
-              contract.covers.map((c) => c.assetId),
+            contracts.flatMap(
+              (contract) =>
+                contract.managesRelationship?.assets.map((a) => a.id) ?? [],
             ),
           ).size,
         }),

--- a/src/features/vendors/types.ts
+++ b/src/features/vendors/types.ts
@@ -8,7 +8,12 @@ export const vendorListSelect = {
   canonicalDisplayName: true,
   overview: true,
   partnerSince: true,
-  contracts: { select: { covers: { select: { assetId: true } } } },
+  // a contract reaches its assets through the ManagesRelationship it belongs to
+  contracts: {
+    select: {
+      managesRelationship: { select: { assets: { select: { id: true } } } },
+    },
+  },
 } satisfies Prisma.VendorSelect;
 
 export type VendorListRow = Prisma.VendorGetPayload<{

--- a/src/features/vulnerabilities/types.ts
+++ b/src/features/vulnerabilities/types.ts
@@ -1,6 +1,11 @@
 import type { inferOutput } from "@trpc/tanstack-react-query";
 import { z } from "zod";
-import { Priority, type Prisma, Severity } from "@/generated/prisma";
+import {
+  PlatformEnum,
+  Priority,
+  type Prisma,
+  Severity,
+} from "@/generated/prisma";
 import {
   createPaginatedResponseSchema,
   paginationInputSchema,
@@ -47,7 +52,6 @@ export const vulnerabilityInputSchema = z.object({
   cvssVector: z.string().min(1).nullish(),
   affectedComponents: z.array(z.string().min(1)).optional(),
   exploitUri: safeUrlSchema.nullish(),
-  upstreamApi: safeUrlSchema.nullish(),
   deviceArtifactId: z.string().min(1).nullish(),
 });
 
@@ -66,7 +70,18 @@ export const vulnerabilityResponseSchema = z.object({
   sarif: z.any(), // JSON data - Prisma JsonValue type
   deviceGroupMatchings: z.array(deviceGroupMatchingResponseSchema),
   exploitUri: z.string().nullable(),
-  upstreamApi: z.string().nullable(),
+  externalMappings: z.array(
+    z.object({
+      externalId: z.string(),
+      upstreamApi: z.string().nullable(),
+      webUrl: z.string().nullable(),
+      integration: z.object({
+        id: z.string(),
+        name: z.string(),
+        platform: z.enum(PlatformEnum),
+      }),
+    }),
+  ),
   description: z.string().nullable(),
   narrative: z.string().nullable(),
   impact: z.string().nullable(),
@@ -110,11 +125,27 @@ export const vulnerabilitiesByPriorityInputSchema =
 export const vulnerabilityInclude = {
   user: userIncludeSelect,
   deviceGroupMatchings: deviceGroupMatchingInclude,
+  externalMappings: {
+    select: {
+      externalId: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
+    },
+  },
 };
 
 export const vulnerabilityByPriorityInclude = {
   user: userIncludeSelect,
   deviceGroupMatchings: deviceGroupMatchingInclude,
+  externalMappings: {
+    select: {
+      externalId: true,
+      upstreamApi: true,
+      webUrl: true,
+      integration: { select: { id: true, name: true, platform: true } },
+    },
+  },
   issues: {
     include: {
       asset: {

--- a/src/inngest/functions/reevaluate-issue-on-answer.ts
+++ b/src/inngest/functions/reevaluate-issue-on-answer.ts
@@ -43,9 +43,11 @@ export const reevaluateIssueOnAnswer = inngest.createFunction(
 
     if (updatedIssue.status !== "UNDER_INVESTIGATION") {
       await step.run("retriage-notification", async () => {
-        const source = await prisma.notificationSource.findFirst({
-          where: { notificationId: question.notificationId },
-          orderBy: { receivedAt: "desc" },
+        const source = await prisma.sourceRecord.findFirst({
+          where: {
+            links: { some: { notificationId: question.notificationId } },
+          },
+          orderBy: { observedAt: "desc" },
         });
         if (!source) return;
         const result = await triageNotification(

--- a/src/lib/source-hash.ts
+++ b/src/lib/source-hash.ts
@@ -1,6 +1,31 @@
 import { createHash } from "node:crypto";
 
 /**
+ * Rebuild plain objects with their keys in sorted order so `JSON.stringify`
+ * produces the same bytes regardless of insertion order. Raw payloads come off
+ * the wire (email webhooks, partner submissions), where key order is whatever
+ * the sender serialized — without this, a replay of an identical payload can
+ * hash differently and defeat the dedup below.
+ *
+ * Arrays keep their order: element position is meaningful, key order is not.
+ */
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  // Dates, null, and class instances serialize via their own toJSON/valueOf.
+  if (value === null || typeof value !== "object") return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+
+  return Object.fromEntries(
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [
+        key,
+        canonicalize((value as Record<string, unknown>)[key]),
+      ]),
+  );
+};
+
+/**
  * Content hash for `SourceRecord.contentHash`.
  *
  * SourceRecords are append-only and deduplicate on this value: if a freshly
@@ -15,7 +40,7 @@ export const sourceContentHash = (
   markdown?: string | null,
 ): string =>
   createHash("sha256")
-    .update(JSON.stringify(raw ?? {}))
+    .update(JSON.stringify(canonicalize(raw ?? {})))
     .update("\0")
     .update(markdown ?? "")
     .digest("hex");

--- a/src/lib/source-hash.ts
+++ b/src/lib/source-hash.ts
@@ -1,0 +1,21 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Content hash for `SourceRecord.contentHash`.
+ *
+ * SourceRecords are append-only and deduplicate on this value: if a freshly
+ * fetched snapshot hashes to the same thing as the mapping's newest one, skip
+ * the write. The column is NOT NULL, so every create site needs this.
+ *
+ * The NUL separator keeps `{raw: {a: 1}, markdown: null}` from colliding with a
+ * raw payload whose serialization happens to end in the markdown text.
+ */
+export const sourceContentHash = (
+  raw: unknown,
+  markdown?: string | null,
+): string =>
+  createHash("sha256")
+    .update(JSON.stringify(raw ?? {}))
+    .update("\0")
+    .update(markdown ?? "")
+    .digest("hex");


### PR DESCRIPTION
* adds agent documentation (will remove later)
* modifications to prisma schema
* a few TODO comments on where to go next
* fixed some low-hanging type errors, that I thought were reasonable to bundle in this PR


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned integrations around configurable platforms and resource-specific synchronization.
  * Added external mapping details, including external IDs, source URLs, integration metadata, and sync timestamps.
  * Added unified source records and links for notifications, work orders, and remediations.
  * Added asset management relationships connecting vendors, departments, contracts, and managed assets.
  * Added consistent source-content hashing for ingested records.
* **Breaking Changes**
  * Integration and asset-related API responses now use external mappings instead of top-level upstream API fields.
  * Legacy notification-source and contract-asset structures were replaced.
* **Documentation**
  * Added integration redesign specifications, implementation guidance, and current integration behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->