### PR TITLE
[VW-450] Added asset filter and status bar

### DIFF
--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -927,6 +927,42 @@ describe("TicketDetailContent — view mode", () => {
     expect(screen.getByText("Infusion Pump")).toBeInTheDocument();
   });
 
+  it("shows a progress indicator reflecting how many linked assets are Done", async () => {
+    const user = userEvent.setup();
+    renderDetail({
+      assets: [
+        sampleAssetTicket({}, { id: "child-1" }),
+        sampleAssetTicket({}, { id: "child-2", status: "DONE" }),
+      ],
+    });
+    await user.click(screen.getByRole("tab", { name: /assets/i }));
+    expect(screen.getByText("50% resolved")).toBeInTheDocument();
+    expect(screen.getByText(/1 of 2 done/i)).toBeInTheDocument();
+  });
+
+  it("sorts asset rows with active statuses before Done", async () => {
+    const user = userEvent.setup();
+    renderDetail({
+      assets: [
+        sampleAssetTicket(
+          { id: "asset-done", hostname: "host-done" },
+          { id: "child-done", status: "DONE" },
+        ),
+        sampleAssetTicket(
+          { id: "asset-todo", hostname: "host-todo" },
+          { id: "child-todo", status: "TO_DO" },
+        ),
+      ],
+    });
+    await user.click(screen.getByRole("tab", { name: /assets/i }));
+
+    const rows = screen.getAllByRole("row").slice(1); // drop header row
+    const firstRowText = rows[0].textContent ?? "";
+    const secondRowText = rows[1].textContent ?? "";
+    expect(firstRowText).toContain("host-todo");
+    expect(secondRowText).toContain("host-done");
+  });
+
   it("renders the author's department badge next to their name in comments", () => {
     renderDetail({
       comments: [

--- a/src/features/tracking/components/ticket-detail.test.tsx
+++ b/src/features/tracking/components/ticket-detail.test.tsx
@@ -927,42 +927,6 @@ describe("TicketDetailContent — view mode", () => {
     expect(screen.getByText("Infusion Pump")).toBeInTheDocument();
   });
 
-  it("shows a progress indicator reflecting how many linked assets are Done", async () => {
-    const user = userEvent.setup();
-    renderDetail({
-      assets: [
-        sampleAssetTicket({}, { id: "child-1" }),
-        sampleAssetTicket({}, { id: "child-2", status: "DONE" }),
-      ],
-    });
-    await user.click(screen.getByRole("tab", { name: /assets/i }));
-    expect(screen.getByText("50% resolved")).toBeInTheDocument();
-    expect(screen.getByText(/1 of 2 done/i)).toBeInTheDocument();
-  });
-
-  it("sorts asset rows with active statuses before Done", async () => {
-    const user = userEvent.setup();
-    renderDetail({
-      assets: [
-        sampleAssetTicket(
-          { id: "asset-done", hostname: "host-done" },
-          { id: "child-done", status: "DONE" },
-        ),
-        sampleAssetTicket(
-          { id: "asset-todo", hostname: "host-todo" },
-          { id: "child-todo", status: "TO_DO" },
-        ),
-      ],
-    });
-    await user.click(screen.getByRole("tab", { name: /assets/i }));
-
-    const rows = screen.getAllByRole("row").slice(1); // drop header row
-    const firstRowText = rows[0].textContent ?? "";
-    const secondRowText = rows[1].textContent ?? "";
-    expect(firstRowText).toContain("host-todo");
-    expect(secondRowText).toContain("host-done");
-  });
-
   it("renders the author's department badge next to their name in comments", () => {
     renderDetail({
       comments: [

--- a/src/features/tracking/components/ticket-detail/edit-form.tsx
+++ b/src/features/tracking/components/ticket-detail/edit-form.tsx
@@ -29,7 +29,7 @@ import {
 } from "../../hooks/use-tracking";
 import type { TicketDetail } from "../../types";
 import { DepartmentMultiSelect } from "./department-multi-select";
-import { categoryLabels, statusLabels } from "./shared";
+import { categoryLabels, TicketStatusSelectTrigger } from "./shared";
 
 const UNASSIGNED = "__unassigned__";
 
@@ -287,16 +287,11 @@ export const TicketEditForm = ({
                 setForm((f) => ({ ...f, status: v as TicketStatus }))
               }
             >
-              <SelectTrigger id="ticket-status">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {(Object.keys(statusLabels) as TicketStatus[]).map((s) => (
-                  <SelectItem key={s} value={s}>
-                    {statusLabels[s]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
+              <TicketStatusSelectTrigger
+                status={form.status}
+                id="ticket-status"
+                colored
+              />
             </Select>
           </div>
         </div>

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -19,9 +19,15 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getChipClass } from "@/features/tag-colors/palette";
 import { useUpdateTicket } from "@/features/tracking/hooks/use-tracking";
 import type { TicketStatus } from "@/generated/prisma";
-import { type DetailAssetTicket, formatLocation, statusLabels } from "./shared";
+import {
+  type DetailAssetTicket,
+  formatLocation,
+  statusHue,
+  statusLabels,
+} from "./shared";
 
 const AssetTicketStatusSelect = ({
   parentTicketId,
@@ -44,7 +50,11 @@ const AssetTicketStatusSelect = ({
       }
       disabled={update.isPending}
     >
-      <SelectTrigger size="sm" aria-label="Ticket status">
+      <SelectTrigger
+        size="sm"
+        aria-label="Ticket status"
+        className={getChipClass(statusHue[status])}
+      >
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets-table.tsx
@@ -4,13 +4,7 @@ import { XIcon } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ClampedCell } from "@/components/ui/clamped-cell";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Select } from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -19,14 +13,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getChipClass } from "@/features/tag-colors/palette";
 import { useUpdateTicket } from "@/features/tracking/hooks/use-tracking";
 import type { TicketStatus } from "@/generated/prisma";
 import {
   type DetailAssetTicket,
   formatLocation,
-  statusHue,
-  statusLabels,
+  TicketStatusSelectTrigger,
 } from "./shared";
 
 const AssetTicketStatusSelect = ({
@@ -50,20 +42,7 @@ const AssetTicketStatusSelect = ({
       }
       disabled={update.isPending}
     >
-      <SelectTrigger
-        size="sm"
-        aria-label="Ticket status"
-        className={getChipClass(statusHue[status])}
-      >
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {(Object.keys(statusLabels) as TicketStatus[]).map((s) => (
-          <SelectItem key={s} value={s}>
-            {statusLabels[s]}
-          </SelectItem>
-        ))}
-      </SelectContent>
+      <TicketStatusSelectTrigger status={status} size="sm" colored />
     </Select>
   );
 };

--- a/src/features/tracking/components/ticket-detail/linked-assets.tsx
+++ b/src/features/tracking/components/ticket-detail/linked-assets.tsx
@@ -17,13 +17,68 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { getSwatchClass } from "@/features/tag-colors/palette";
+import { TicketStatus } from "@/generated/prisma";
+import { cn } from "@/lib/utils";
 import {
   useAttachAsset,
   useAttachableAssets,
   useDetachAsset,
 } from "../../hooks/use-tracking";
 import { LinkedAssetsTable } from "./linked-assets-table";
-import type { DetailAssetTicket } from "./shared";
+import {
+  countAssetTicketsByStatus,
+  type DetailAssetTicket,
+  sortAssetTicketsByStatus,
+  statusHue,
+  statusLabels,
+} from "./shared";
+
+const AssetProgressStrip = ({
+  assetTickets,
+}: {
+  assetTickets: DetailAssetTicket[];
+}) => {
+  const total = assetTickets.length;
+  if (total === 0) return null;
+  const counts = countAssetTicketsByStatus(assetTickets);
+  const done = counts.find((c) => c.status === TicketStatus.DONE)?.count ?? 0;
+  const pctResolved = Math.round((done / total) * 100);
+
+  return (
+    <div className="border-b px-5 py-4">
+      <p className="text-sm">
+        <span className="font-semibold">{pctResolved}% resolved</span>
+        <span className="text-muted-foreground">
+          {" "}
+          — {done} of {total} done
+        </span>
+      </p>
+      <div className="mt-2 flex h-2 w-full overflow-hidden rounded-full bg-muted">
+        {counts.map(({ status, count }) => (
+          <div
+            key={status}
+            className={getSwatchClass(statusHue[status])}
+            style={{ width: `${(count / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {counts.map(({ status, count }) => (
+          <span key={status} className="inline-flex items-center gap-1.5">
+            <span
+              className={cn(
+                "size-2 rounded-full",
+                getSwatchClass(statusHue[status]),
+              )}
+            />
+            {count} {statusLabels[status]}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const AttachAssetPopover = ({ ticketId }: { ticketId: string }) => {
   const [open, setOpen] = useState(false);
@@ -92,6 +147,7 @@ export const LinkedAssetsTabContent = ({
   assetTickets: DetailAssetTicket[];
 }) => {
   const detach = useDetachAsset(ticketId);
+  const sortedAssetTickets = sortAssetTicketsByStatus(assetTickets);
 
   return (
     <Card className="gap-0 py-0">
@@ -102,11 +158,12 @@ export const LinkedAssetsTabContent = ({
         </h2>
         <AttachAssetPopover ticketId={ticketId} />
       </div>
+      <AssetProgressStrip assetTickets={sortedAssetTickets} />
       <div className="p-2">
         {assetTickets.length > 0 ? (
           <LinkedAssetsTable
             parentTicketId={ticketId}
-            assetTickets={assetTickets}
+            assetTickets={sortedAssetTickets}
             onDetach={(assetId) => detach.mutate({ ticketId, assetId })}
             detachPending={detach.isPending}
           />

--- a/src/features/tracking/components/ticket-detail/shared.test.ts
+++ b/src/features/tracking/components/ticket-detail/shared.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { TicketStatus } from "@/generated/prisma";
+import {
+  countAssetTicketsByStatus,
+  type DetailAssetTicket,
+  sortAssetTicketsByStatus,
+} from "./shared";
+
+const assetTicket = (status: TicketStatus, id: string) =>
+  ({ ticket: { id, status }, asset: { id } }) as unknown as DetailAssetTicket;
+
+describe("sortAssetTicketsByStatus", () => {
+  it("orders To Do, then In Progress, then Requires Approval, then Done, regardless of input order", () => {
+    const input = [
+      assetTicket(TicketStatus.DONE, "1"),
+      assetTicket(TicketStatus.IN_PROGRESS, "2"),
+      assetTicket(TicketStatus.TO_DO, "3"),
+      assetTicket(TicketStatus.REQUIRES_APPROVAL, "4"),
+    ];
+    expect(sortAssetTicketsByStatus(input).map((a) => a.ticket.id)).toEqual([
+      "3",
+      "2",
+      "4",
+      "1",
+    ]);
+  });
+
+  it("keeps ties in their original relative order (stable sort)", () => {
+    const input = [
+      assetTicket(TicketStatus.DONE, "1"),
+      assetTicket(TicketStatus.TO_DO, "2"),
+      assetTicket(TicketStatus.DONE, "3"),
+    ];
+    expect(sortAssetTicketsByStatus(input).map((a) => a.ticket.id)).toEqual([
+      "2",
+      "1",
+      "3",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      assetTicket(TicketStatus.DONE, "1"),
+      assetTicket(TicketStatus.TO_DO, "2"),
+    ];
+    const copy = [...input];
+    sortAssetTicketsByStatus(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe("countAssetTicketsByStatus", () => {
+  it("counts per status, in canonical order, omitting zero-count statuses", () => {
+    const input = [
+      assetTicket(TicketStatus.DONE, "1"),
+      assetTicket(TicketStatus.TO_DO, "2"),
+      assetTicket(TicketStatus.TO_DO, "3"),
+    ];
+    expect(countAssetTicketsByStatus(input)).toEqual([
+      { status: TicketStatus.TO_DO, count: 2 },
+      { status: TicketStatus.DONE, count: 1 },
+    ]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(countAssetTicketsByStatus([])).toEqual([]);
+  });
+});

--- a/src/features/tracking/components/ticket-detail/shared.test.ts
+++ b/src/features/tracking/components/ticket-detail/shared.test.ts
@@ -61,8 +61,4 @@ describe("countAssetTicketsByStatus", () => {
       { status: TicketStatus.DONE, count: 1 },
     ]);
   });
-
-  it("returns an empty array for an empty input", () => {
-    expect(countAssetTicketsByStatus([])).toEqual([]);
-  });
 });

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -91,7 +91,7 @@ export const DepartmentChips = ({
 
 export type DetailAssetTicket = TicketDetail["assets"][number];
 
-export const statusOrder = Object.keys(statusLabels) as TicketStatus[];
+const statusOrder = Object.keys(statusLabels) as TicketStatus[];
 
 // To Do → In Progress → Requires Approval → Done (doesn't mutate the input).
 export const sortAssetTicketsByStatus = (

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -91,6 +91,28 @@ export const DepartmentChips = ({
 
 export type DetailAssetTicket = TicketDetail["assets"][number];
 
+export const statusOrder = Object.keys(statusLabels) as TicketStatus[];
+
+// To Do → In Progress → Requires Approval → Done (doesn't mutate the input).
+export const sortAssetTicketsByStatus = (
+  assetTickets: DetailAssetTicket[],
+): DetailAssetTicket[] =>
+  [...assetTickets].sort(
+    (a, b) =>
+      statusOrder.indexOf(a.ticket.status) -
+      statusOrder.indexOf(b.ticket.status),
+  );
+
+export const countAssetTicketsByStatus = (
+  assetTickets: DetailAssetTicket[],
+): { status: TicketStatus; count: number }[] =>
+  statusOrder
+    .map((status) => ({
+      status,
+      count: assetTickets.filter((a) => a.ticket.status === status).length,
+    }))
+    .filter((c) => c.count > 0);
+
 export const formatLocation = (location: unknown): string => {
   if (!location || typeof location !== "object") return "—";
   const loc = location as Record<string, unknown>;

--- a/src/features/tracking/components/ticket-detail/shared.tsx
+++ b/src/features/tracking/components/ticket-detail/shared.tsx
@@ -2,6 +2,12 @@
 
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
+import {
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useCategoryColor } from "@/features/tag-colors/context";
 import { getChipClass } from "@/features/tag-colors/palette";
 import type { TicketCategory, TicketStatus } from "@/generated/prisma";
@@ -21,6 +27,8 @@ export const statusHue: Record<TicketStatus, string> = {
   REQUIRES_APPROVAL: "yellow",
   DONE: "green",
 };
+
+const statusOrder = Object.keys(statusLabels) as TicketStatus[];
 
 export const categoryLabels: Record<TicketCategory, string> = {
   PATCH: "Patch",
@@ -65,6 +73,41 @@ export const StatusChip = ({
   </Badge>
 );
 
+// Trigger + option list for a ticket-status Select. Callers still own the
+// <Select value={...} onValueChange={...}> wrapper — this only standardizes
+// the trigger's coloring/labeling and the option list, since edit-form.tsx
+// (labeled via id) and linked-assets-table.tsx (labeled via aria-label,
+// no visible <Label>) need different labeling but the same options/colors.
+export const TicketStatusSelectTrigger = ({
+  status,
+  id,
+  size,
+  colored = false,
+}: {
+  status: TicketStatus;
+  id?: string;
+  size?: "sm" | "default";
+  colored?: boolean;
+}) => (
+  <>
+    <SelectTrigger
+      id={id}
+      size={size}
+      aria-label={id ? undefined : "Ticket status"}
+      className={colored ? getChipClass(statusHue[status]) : undefined}
+    >
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent>
+      {statusOrder.map((s) => (
+        <SelectItem key={s} value={s}>
+          {statusLabels[s]}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </>
+);
+
 export const DepartmentChips = ({
   departments,
 }: {
@@ -90,8 +133,6 @@ export const DepartmentChips = ({
 };
 
 export type DetailAssetTicket = TicketDetail["assets"][number];
-
-const statusOrder = Object.keys(statusLabels) as TicketStatus[];
 
 // To Do → In Progress → Requires Approval → Done (doesn't mutate the input).
 export const sortAssetTicketsByStatus = (


### PR DESCRIPTION
https://northeastern-patch.atlassian.net/browse/VW-450
## Summary
- Added a progress indicator to the work order Assets tab: "% resolved" callout,
- Asset rows now sort by status by default — To Do → In Progress → Requires Approval → Done, so completed rows sink to the bottom

## Screenshots
<img width="1170" height="952" alt="image" src="https://github.com/user-attachments/assets/47727619-17ca-4ee6-8ced-d0710c28703e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a progress summary for linked assets, including resolution percentage, completion counts, and status distribution.
  * Linked assets are now grouped and sorted by status for easier review.
  * Standardized status selectors across ticket editing and linked-asset views.

* **Bug Fixes**
  * Improved status ordering and consistency while preserving the original asset list during sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->