### PR TITLE
[VW-442] Run the question agent on TA4 remediations

### DIFF
--- a/src/inngest/functions/analyze-remediation.ts
+++ b/src/inngest/functions/analyze-remediation.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { persistMitigationPlans } from "@/features/inbox/agent/mitigation/persist";
+import { generateQuestionForNotification } from "@/features/inbox/agent/question";
 import { triageNotification } from "@/features/inbox/agent/triage";
 import { sortNotificationVulnerabilities } from "@/features/inbox/agent/vex";
 import { Prisma } from "@/generated/prisma";
@@ -130,12 +131,18 @@ export const analyzeRemediation = inngest.createFunction(
       persistMitigationPlans(sourceId, notificationId),
     );
 
+    const questionSummary = await step.run("generate-questions", async () => {
+      if (!vexSummary) return { questionSkipped: true as const };
+      return generateQuestionForNotification(sourceId, notificationId);
+    });
+
     return {
       remediationId,
       notificationId,
       sourceId,
       vexSummary,
       mitigationSummary,
+      questionSummary,
     };
   },
 );


### PR DESCRIPTION
[VW-442](https://northeastern-patch.atlassian.net/browse/VW-442)

## Summary

The question agent now runs on TA4 remediations, so `analyzeRemediation` is `VEX → triage → mitigation → question`.

- New `generate-questions` step in `analyze-remediation.ts`, running last after `create-mitigation-plans` and guarded on VEX having run.

## Testing

**End-to-end, local dev stack.** Seeded `CVE-2099-0371` (1 device-group matching, 1 baseline issue, 3 assets) → `POST /api/v1/remediations` with its `vulnerabilityId` → watched the Inngest run.

| What was tested | Result |
|---|---|
| All five steps run, in order | ✅ `prepare-notification → sort-vulnerabilities → triage-notification → create-mitigation-plans → generate-questions` |
| Triage and mitigation still work | ✅ notification came back `High`, 2 mitigation plans |
| VEX resolves everything → no questions | ✅ `questionSummary: null`, nothing written |
| VEX leaves an issue unresolved → question | ✅ 1 `PENDING` question, audience `VENDOR`, 5 suggested answers |
| Remediation with no `vulnerabilityId` | ✅ `{ skipped: "no-vulnerability" }`, never reaches the new step |
| Same `remediationId` sent twice | ✅ notification reused, no duplicate question |
| Renders on the Questions tab | ✅ returned by `questions.getManyByNotificationId` |

The question it drafted: *"What is the installed firmware version on the hospital's Infuse Station IQ units?"*


[VW-442]: https://northeastern-patch.atlassian.net/browse/VW-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remediation analysis now generates notification questions after creating mitigation plans when a VEX summary is available.
  * The generated question summary is included in the analysis response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->