### PR TITLE
[VW-452] Adding notification endpoints to query platform data file

### DIFF
--- a/src/features/agents/chat/graph.ts
+++ b/src/features/agents/chat/graph.ts
@@ -21,8 +21,8 @@ Be concise, accurate, and prioritize patient safety in your recommendations.
 - ask_user_questions: ask the user 1–4 clarifying questions with suggested answers.
   The agent turn ends here until the user replies.
 - query_platform_data: read-only lookup of assets, vulnerabilities, remediations,
-  and device groups on demand. You are NOT given the inventory up front — call
-  this to fetch the specific records you need.
+  device groups, clinical workflows, and inbox notifications on demand. You are NOT
+  given the inventory up front — call this to fetch the specific records you need.
 - list_fleet_managed_assets: list the assets Siemens Healthineers services.
 - propose_fleet_work_order: propose a work order on Siemens Healthineers'
   teamplay Fleet platform. Your turn ends here until the user accepts or dismisses.

--- a/src/features/agents/recommendations/graph.ts
+++ b/src/features/agents/recommendations/graph.ts
@@ -131,8 +131,9 @@ ask_user_questions call (up to 4 questions) rather than asking them one at a tim
 <tools>
 - ask_user_questions: ask the user 1–4 clarifying questions with suggested answers.
   The agent turn ends here until the user replies.
-- query_platform_data: read-only lookup of assets, vulnerabilities, remediations, and
-  device groups on demand (see data_access). Use it to retrieve the records you reason over.
+- query_platform_data: read-only lookup of assets, vulnerabilities, remediations, device
+  groups, clinical workflows, and inbox notifications on demand (see data_access). Use it
+  to retrieve the records you reason over.
 - list_fleet_managed_assets: list the assets Siemens Healthineers services, with the
   full asset ids propose_fleet_work_order requires.
 - propose_fleet_work_order: propose a work order on Siemens Healthineers' teamplay

--- a/src/features/agents/tools/query-platform-tool.test.ts
+++ b/src/features/agents/tools/query-platform-tool.test.ts
@@ -1,0 +1,349 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAgentCaller } from "@/trpc/agent-caller";
+import {
+  addNavigationLinks,
+  capPageSize,
+  PLATFORM_CATALOG,
+  PLATFORM_QUERY_PROCEDURES,
+} from "./query-platform-tool";
+
+/** Every catalog bullet starts `- <router>.<procedure> — …`. */
+const CATALOG_LINE = /^- ([a-zA-Z]+\.[a-zA-Z]+) —/gm;
+
+function documentedProcedures(): string[] {
+  return [...PLATFORM_CATALOG.matchAll(CATALOG_LINE)].map((m) => m[1]);
+}
+
+describe("PLATFORM_CATALOG stays in sync with PLATFORM_QUERY_PROCEDURES", () => {
+  // The allowlist is what the model *can* call; the catalog is what it is *told*
+  // it can call. They are maintained by hand in the same file, so they drift
+  // silently: an undocumented procedure is unreachable in practice, and a
+  // documented one that isn't allowlisted makes the model retry a call that
+  // can never succeed.
+  // Array equality covers all three ways these drift: an allowlisted procedure
+  // with no catalog entry, a catalog entry for something not allowlisted, and a
+  // duplicate bullet. It also pins the catalog to the enum's order.
+  it("documents exactly the allowlisted procedures, in order", () => {
+    expect(documentedProcedures()).toEqual([...PLATFORM_QUERY_PROCEDURES]);
+  });
+
+  // A typo in a dot-path, or a procedure later renamed in its router, is
+  // invisible until an agent calls it and gets back "Unknown procedure".
+  // Resolve each path the same way the tool does, so drift fails here instead.
+  it("resolves every allowlisted procedure on the tRPC caller", () => {
+    const caller = createAgentCaller("test-user") as unknown as Record<
+      string,
+      unknown
+    >;
+
+    const unresolved = PLATFORM_QUERY_PROCEDURES.filter((procedure) => {
+      const resolved = procedure
+        .split(".")
+        .reduce<unknown>(
+          (obj, key) => (obj as Record<string, unknown> | undefined)?.[key],
+          caller,
+        );
+      return typeof resolved !== "function";
+    });
+
+    expect(unresolved).toEqual([]);
+  });
+});
+
+describe("capPageSize", () => {
+  // notifications.getMany fans out one deviceGroup.findMany per matching per
+  // row. At pageSize 100 with ~18 matchings an advisory that is ~1800
+  // concurrent queries against a pool of ~17, which throws P2024 and starves
+  // the UI. The catalog says the same thing, but prose does not bind a model.
+  it("clamps an over-large notifications page", () => {
+    expect(capPageSize("notifications.getMany", { pageSize: 100 })).toEqual({
+      pageSize: 10,
+    });
+  });
+
+  it("keeps the rest of the input intact", () => {
+    expect(
+      capPageSize("notifications.getMany", {
+        pageSize: 50,
+        search: "siemens",
+        priority: ["Critical"],
+      }),
+    ).toEqual({ pageSize: 10, search: "siemens", priority: ["Critical"] });
+  });
+
+  it("leaves a request at or under the cap alone", () => {
+    const input = { pageSize: 10, page: 3 };
+
+    expect(capPageSize("notifications.getMany", input)).toBe(input);
+  });
+
+  it("leaves uncapped procedures alone", () => {
+    const input = { pageSize: 100 };
+
+    expect(capPageSize("assets.getMany", input)).toBe(input);
+  });
+
+  it("passes through input with no pageSize, and undefined", () => {
+    const input = { search: "pump" };
+
+    expect(capPageSize("notifications.getMany", input)).toBe(input);
+    expect(capPageSize("notifications.getMany", undefined)).toBeUndefined();
+  });
+});
+
+describe("the tool applies the cap, not just the helper", () => {
+  afterEach(() => {
+    vi.doUnmock("@/trpc/agent-caller");
+    vi.resetModules();
+  });
+
+  // Testing capPageSize alone leaves the wiring untested: deleting the call in
+  // makeQueryPlatformDataTool keeps every other test green. Mock the caller and
+  // assert what tRPC actually receives.
+  it("clamps the input that reaches tRPC", async () => {
+    vi.resetModules();
+    const getMany = vi.fn().mockResolvedValue({ items: [], totalCount: 0 });
+    vi.doMock("@/trpc/agent-caller", () => ({
+      createAgentCaller: () => ({ notifications: { getMany } }),
+    }));
+
+    const { makeQueryPlatformDataTool } = await import("./query-platform-tool");
+    await makeQueryPlatformDataTool("user_1").invoke({
+      procedure: "notifications.getMany",
+      input: { pageSize: 100, search: "siemens" },
+    });
+
+    expect(getMany).toHaveBeenCalledWith({ pageSize: 10, search: "siemens" });
+  });
+});
+
+describe("addNavigationLinks — notifications", () => {
+  // hospitalImpact is the discriminator: it exists only on Notification.
+  const notification = () => ({
+    id: "notif_1",
+    title: "Vendor advisory",
+    hospitalImpact: { byline: "Two ICU pumps affected" },
+  });
+
+  it("points a notification at its detail call", () => {
+    const result = addNavigationLinks(notification()) as {
+      _links: { detail: { procedure: string; input: { id: string } } };
+    };
+
+    expect(result._links.detail).toEqual({
+      procedure: "notifications.getOne",
+      input: { id: "notif_1" },
+    });
+  });
+
+  it("links notifications nested in a paginated list", () => {
+    const page = { items: [notification()], meta: { page: 1 } };
+
+    const result = addNavigationLinks(page) as {
+      items: { _links: { detail: { input: { id: string } } } }[];
+    };
+
+    expect(result.items[0]._links.detail.input.id).toBe("notif_1");
+  });
+
+  it("does not point the detail result back at itself", () => {
+    // affectedAssets is only on the getOne payload. A "detail" link there is a
+    // call that returns what the model already holds.
+    const detail = { ...notification(), affectedAssets: { AFFECTED: [] } };
+
+    const result = addNavigationLinks(detail) as { _links?: unknown };
+
+    expect(result._links).toBeUndefined();
+  });
+
+  it("leaves objects without hospitalImpact alone", () => {
+    const remediation = { id: "rem_1", description: "Apply firmware M.02.07" };
+
+    const result = addNavigationLinks(remediation) as {
+      _links?: unknown;
+    };
+
+    expect(result._links).toBeUndefined();
+  });
+
+  it("does not clobber links added by another transform", () => {
+    // An asset carries _links.workflows; a notification-shaped object should
+    // only ever add to that map, never replace it.
+    const hybrid = {
+      id: "a_1",
+      utilization: { "0": 10 },
+      hospitalImpact: {},
+    };
+
+    const result = addNavigationLinks(hybrid) as {
+      _links: Record<string, unknown>;
+    };
+
+    expect(Object.keys(result._links).sort()).toEqual([
+      "detail",
+      "utilization",
+      "workflows",
+    ]);
+  });
+});
+
+describe("addNavigationLinks — source payload stripping", () => {
+  // NotificationSource.raw is the whole inbound email event, tens of KB per row.
+  // The notification's own title and summary carry what the model reads, and on
+  // the detail call the source keeps its markdown.
+  const source = () => ({
+    id: "src_1",
+    channel: "Email",
+    raw: { from: "vendor@example.com", html: "<html>…40KB…</html>" },
+    markdown: "Vendor advisory body",
+    receivedAt: "2026-08-13T00:00:00.000Z",
+  });
+
+  it("drops raw but keeps the fields the model reads", () => {
+    const result = addNavigationLinks(source()) as Record<string, unknown>;
+
+    expect(result).not.toHaveProperty("raw");
+    expect(result.markdown).toBe("Vendor advisory body");
+    expect(result.channel).toBe("Email");
+    expect(result.id).toBe("src_1");
+  });
+
+  it("strips raw from sources nested under a notification", () => {
+    const notification = {
+      id: "notif_1",
+      hospitalImpact: {},
+      sources: [source(), source()],
+    };
+
+    const result = addNavigationLinks(notification) as {
+      sources: Record<string, unknown>[];
+    };
+
+    for (const s of result.sources) {
+      expect(s).not.toHaveProperty("raw");
+    }
+  });
+
+  it("strips raw from work order ticket sources too", () => {
+    // WorkOrderTicket.sources is the same NotificationSource shape under a
+    // different parent, which is why this keys off the source, not the parent.
+    const ticket = { id: "wot_1", summary: "Patch pumps", sources: [source()] };
+
+    const result = addNavigationLinks(ticket) as {
+      sources: Record<string, unknown>[];
+    };
+
+    expect(result.sources[0]).not.toHaveProperty("raw");
+  });
+
+  it("leaves a `raw` field alone when the object is not a source", () => {
+    const notASource = { id: "x_1", raw: "keep me" };
+
+    const result = addNavigationLinks(notASource) as { raw?: string };
+
+    expect(result.raw).toBe("keep me");
+  });
+});
+
+describe("addNavigationLinks — canonical record trimming", () => {
+  // The same record repeats once per row that references it, so a vendor
+  // advisory with 18 matchings sends the identical manufacturer 18 times. The
+  // transform is shape-blind, so one fixture carrying every noise key covers
+  // Manufacturer, Product, Version, and Vendor. `versScheme` lives on Version.
+  const manufacturer = () => ({
+    id: "mfr_1",
+    canonicalName: "siemens healthineers",
+    canonicalDisplayName: "Siemens Healthineers",
+    hasCpe: true,
+    nameMappings: [],
+    versScheme: null,
+    createdAt: "2026-08-13T14:23:04.179Z",
+    updatedAt: "2026-08-13T14:23:04.179Z",
+  });
+
+  it("drops every noise key and keeps the id and both names", () => {
+    const result = addNavigationLinks(manufacturer()) as Record<
+      string,
+      unknown
+    >;
+
+    for (const key of [
+      "hasCpe",
+      "nameMappings",
+      "versScheme",
+      "createdAt",
+      "updatedAt",
+    ]) {
+      expect(result).not.toHaveProperty(key);
+    }
+    // The catalog tells the model to find a device group by these names.
+    expect(result.id).toBe("mfr_1");
+    expect(result.canonicalName).toBe("siemens healthineers");
+    expect(result.canonicalDisplayName).toBe("Siemens Healthineers");
+  });
+
+  it("trims records nested inside a notification's matchings", () => {
+    const notification = {
+      id: "notif_1",
+      hospitalImpact: {},
+      deviceGroupsMatchings: [
+        { deviceGroupMatching: { manufacturer: manufacturer() } },
+        { deviceGroupMatching: { manufacturer: manufacturer() } },
+      ],
+    };
+
+    const result = addNavigationLinks(notification) as {
+      deviceGroupsMatchings: {
+        deviceGroupMatching: { manufacturer: Record<string, unknown> };
+      }[];
+    };
+
+    for (const m of result.deviceGroupsMatchings) {
+      expect(m.deviceGroupMatching.manufacturer).not.toHaveProperty("hasCpe");
+      expect(m.deviceGroupMatching.manufacturer.canonicalDisplayName).toBe(
+        "Siemens Healthineers",
+      );
+    }
+  });
+
+  it("leaves an object that is not a canonical record alone", () => {
+    // An asset also has createdAt, but it is not a lookup record.
+    const asset = { id: "a_1", hostname: "icu-01", createdAt: "2026-01-01" };
+
+    const result = addNavigationLinks(asset) as Record<string, unknown>;
+
+    expect(result.createdAt).toBe("2026-01-01");
+  });
+});
+
+describe("addNavigationLinks — existing behaviour is preserved", () => {
+  it("still linkifies assets", () => {
+    const asset = { id: "a_1", hostname: "icu-01", utilization: { "0": 10 } };
+
+    const result = addNavigationLinks(asset) as {
+      utilization?: unknown;
+      _links: Record<string, { procedure: string }>;
+    };
+
+    expect(result.utilization).toBeUndefined();
+    expect(result._links.workflows.procedure).toBe("workflows.getManyByAsset");
+    expect(result._links.utilization.procedure).toBe("assets.getUtilization");
+  });
+
+  it("still linkifies device groups and strips their href keys", () => {
+    const deviceGroup = {
+      id: "dg_1",
+      assetsUrl: "https://example.test/dg/1/assets",
+      vulnerabilitiesUrl: "https://example.test/dg/1/vulns",
+    };
+
+    const result = addNavigationLinks(deviceGroup) as {
+      assetsUrl?: string;
+      _links: Record<string, { procedure: string }>;
+    };
+
+    expect(result.assetsUrl).toBeUndefined();
+    expect(result._links.assets.procedure).toBe("assets.getManyByDeviceGroup");
+  });
+});

--- a/src/features/agents/tools/query-platform-tool.test.ts
+++ b/src/features/agents/tools/query-platform-tool.test.ts
@@ -4,6 +4,7 @@ import { createAgentCaller } from "@/trpc/agent-caller";
 import {
   addNavigationLinks,
   capPageSize,
+  makeQueryPlatformDataTool,
   PLATFORM_CATALOG,
   PLATFORM_QUERY_PROCEDURES,
 } from "./query-platform-tool";
@@ -13,6 +14,24 @@ const CATALOG_LINE = /^- ([a-zA-Z]+\.[a-zA-Z]+) —/gm;
 
 function documentedProcedures(): string[] {
   return [...PLATFORM_CATALOG.matchAll(CATALOG_LINE)].map((m) => m[1]);
+}
+
+/**
+ * How each router prefix is named in prose. The tool description and both agent
+ * `<tools>` blocks summarise the same domains in words, so a new prefix here is
+ * a reminder that those sentences need updating too.
+ */
+const DOMAIN_PHRASES: Record<string, string> = {
+  assets: "assets",
+  vulnerabilities: "vulnerabilities",
+  remediations: "remediations",
+  deviceGroups: "device groups",
+  workflows: "clinical workflows",
+  notifications: "notifications",
+};
+
+function allowlistedPrefixes(): string[] {
+  return [...new Set(PLATFORM_QUERY_PROCEDURES.map((p) => p.split(".")[0]))];
 }
 
 describe("PLATFORM_CATALOG stays in sync with PLATFORM_QUERY_PROCEDURES", () => {
@@ -26,6 +45,40 @@ describe("PLATFORM_CATALOG stays in sync with PLATFORM_QUERY_PROCEDURES", () => 
   // duplicate bullet. It also pins the catalog to the enum's order.
   it("documents exactly the allowlisted procedures, in order", () => {
     expect(documentedProcedures()).toEqual([...PLATFORM_QUERY_PROCEDURES]);
+  });
+
+  // The description opens with a prose list of domains before it pastes the
+  // catalog. That sentence went stale once already: it named four domains while
+  // the catalog listed sixteen procedures, and an agent that trusts the summary
+  // will refuse a request the tool would have served. Assert against the
+  // preamble only — testing the whole string passes via the pasted catalog.
+  it("names every allowlisted domain in the tool description preamble", () => {
+    const description =
+      makeQueryPlatformDataTool("test-user").description ?? "";
+    const preamble = description.split(PLATFORM_CATALOG)[0];
+
+    const missing = allowlistedPrefixes().filter((prefix) => {
+      const phrase = DOMAIN_PHRASES[prefix];
+      // An unmapped prefix is a new domain. Fail, so DOMAIN_PHRASES and the
+      // prose summaries get updated together.
+      return phrase === undefined || !preamble.includes(phrase);
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  // A matching id sent as deviceGroupId returns an empty page rather than an
+  // error, so the model reports "no assets affected" against a real count. The
+  // catalog is the only thing standing between the agent and that answer today.
+  //
+  // Anchored on the two emphasised phrases, which appear once each and only in
+  // that paragraph. Bare identifiers do not work: `deviceGroupId` appears three
+  // times in the catalog and `deviceGroups.getMany` twice, both via ordinary
+  // procedure bullets, so asserting them passes even with the warning deleted.
+  // Rewording this guidance will fail here, which is the intent.
+  it("keeps the warning that matching ids are not device group ids", () => {
+    expect(PLATFORM_CATALOG).toContain("matching RULES");
+    expect(PLATFORM_CATALOG).toContain("NOT device group ids");
   });
 
   // A typo in a dot-path, or a procedure later renamed in its router, is

--- a/src/features/agents/tools/query-platform-tool.ts
+++ b/src/features/agents/tools/query-platform-tool.ts
@@ -26,6 +26,8 @@ export const PLATFORM_QUERY_PROCEDURES = [
   "deviceGroups.getOne",
   "workflows.getManyByAsset",
   "workflows.getManyForLlm",
+  "notifications.getMany",
+  "notifications.getOne",
 ] as const;
 
 /** Condensed, prompt-injectable catalog of the allowlisted read procedures. */
@@ -44,8 +46,23 @@ export const PLATFORM_CATALOG = `Available read-only procedures for query_platfo
 - deviceGroups.getOne — one device group by id. input: { id }
 - workflows.getManyByAsset — clinical workflows that use an asset. input: { id } (asset id)
 - workflows.getManyForLlm — list/search all clinical workflows. input: { search?, page?, pageSize? }
+- notifications.getMany — list/search inbox notifications. input: { search?, page?, pageSize?, priority?, type? } — priority and type are optional arrays; omit them for everything. priority values: Critical, High, Monitor, Defer, Unsorted. type values: Advisory, Recall, UpdateAvailable, Other. pageSize is capped at 10 here and a larger request is clamped, so read totalCount and step through with page.
+- notifications.getOne — one notification by id, with the affected-asset counts per matching rule and the ids of the vulnerabilities it references. input: { id }
 
 'Workflows' represent how devices are used in clinical contexts/for patient care.
+
+'Notifications' are the hospital's inbox: vendor advisories, recalls, and update
+announcements that arrive from vendors and feeds. Each carries a triaged priority and
+the matching rules it was matched to.
+
+A notification's "deviceGroupsMatchings" and "affectedAssets" entries are matching RULES
+(manufacturer/product/version), not device groups. They give asset COUNTS per triage
+bucket, not asset records, and their ids are NOT device group ids — never send one as a
+deviceGroupId, because that returns an empty page instead of an error and reads as "no
+assets affected". To get the assets themselves, find the device group with
+deviceGroups.getMany, and search on the matching's manufacturer/product/version names.
+Then follow that device group's "_links.assets". A notification's "vulnerabilities"
+array holds vulnerabilityId values; send one to vulnerabilities.getOne for the CVE.
 
 Assets, vulnerabilities, and remediations each include a "notes" array of resolved,
 entity-specific notes ({ id, text }) — device/vuln/remediation caveats a human recorded
@@ -79,6 +96,7 @@ function linkifyDeviceGroup(dg: Record<string, any>): void {
   for (const key of DEVICE_GROUP_URL_KEYS) delete dg[key];
   if (typeof id !== "string") return;
   dg._links = {
+    ...(dg._links ?? {}),
     assets: {
       procedure: "assets.getManyByDeviceGroup",
       input: { deviceGroupId: id },
@@ -137,10 +155,57 @@ function linkifyWorkflow(workflow: Record<string, any>): void {
 }
 
 /**
- * Deep-walk a tRPC result and turn every device group's HATEOAS URLs into tRPC
- * "_links" navigation hints
+ * Manufacturer, Product, Version, and Vendor are canonical reference records.
+ * Their audit columns and internal flags never change an answer, and the same
+ * record repeats once per row that references it. One vendor advisory carries
+ * 18 device group matchings, so the identical manufacturer arrives 18 times.
+ *
+ * Keep the id and the names. The catalog tells the model to find a device group
+ * by searching these names, so they are load-bearing.
+ *
+ * Every key below is a scalar or a string array, so the order against the child
+ * walk does not matter.
  */
-function addNavigationLinks(value: unknown): unknown {
+const CANONICAL_NOISE_KEYS = [
+  "hasCpe",
+  "nameMappings",
+  "versScheme",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+// biome-ignore lint/suspicious/noExplicitAny: walking arbitrary tRPC result JSON
+function trimCanonicalRecord(record: Record<string, any>): void {
+  for (const key of CANONICAL_NOISE_KEYS) delete record[key];
+}
+
+/**
+ * Notifications are the hospital's inbox items. getMany returns list rows without
+ * the affected-asset breakdown, so point the model at the detail call.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: walking arbitrary tRPC result JSON
+function linkifyNotification(notification: Record<string, any>): void {
+  const id = notification.id;
+  if (typeof id !== "string") return;
+  notification._links = {
+    ...(notification._links ?? {}),
+    detail: {
+      procedure: "notifications.getOne",
+      input: { id },
+    },
+  };
+}
+
+/**
+ * Deep-walk a tRPC result and turn every device group's HATEOAS URLs into tRPC
+ * "_links" navigation hints. Also drops payloads too expensive to put in context.
+ *
+ * Entities are matched by shape, not by the procedure that produced them, so a
+ * nested entity is linkified too (e.g. the device group inside an asset result).
+ *
+ * Exported for tests; the tool itself is the only production caller.
+ */
+export function addNavigationLinks(value: unknown): unknown {
   if (Array.isArray(value)) {
     for (const item of value) addNavigationLinks(item);
     return value;
@@ -148,10 +213,16 @@ function addNavigationLinks(value: unknown): unknown {
   if (value !== null && typeof value === "object") {
     // biome-ignore lint/suspicious/noExplicitAny: walking arbitrary tRPC result JSON
     const obj = value as Record<string, any>;
+    if ("raw" in obj && "channel" in obj) delete obj.raw;
     for (const key of Object.keys(obj)) addNavigationLinks(obj[key]);
+    if ("canonicalName" in obj && "canonicalDisplayName" in obj)
+      trimCanonicalRecord(obj);
     if ("assetsUrl" in obj || "vulnerabilitiesUrl" in obj)
       linkifyDeviceGroup(obj);
     if ("utilization" in obj) linkifyAsset(obj);
+    // hospitalImpact exists only on Notification
+    if ("hospitalImpact" in obj && !("affectedAssets" in obj))
+      linkifyNotification(obj);
     if (
       typeof obj.id === "string" &&
       Array.isArray(obj.nodes) &&
@@ -161,6 +232,43 @@ function addNavigationLinks(value: unknown): unknown {
     return obj;
   }
   return value;
+}
+
+type PlatformProcedure = (typeof PLATFORM_QUERY_PROCEDURES)[number];
+
+/**
+ * Hard page-size limits for procedures whose cost grows faster than their row
+ * count. `paginationInputSchema` accepts up to 100, and prose in the catalog is
+ * advisory — the model can ignore it and often will.
+ *
+ * notifications.getMany runs one deviceGroup.findMany per matching per row, with
+ * no batching. A vendor advisory carries ~18 matchings, so a page of 100 is
+ * ~1800 concurrent queries against a Prisma pool of roughly 17. The overflow
+ * throws P2024, which reaches the model as "an unexpected error occurred", and
+ * the pool is starved for the live UI while it happens.
+ *
+ * Capped here rather than in `paginationInputSchema`, because the routers are
+ * shared with the UI and this limit is about the agent caller only.
+ */
+const PAGE_SIZE_CAPS: Partial<Record<PlatformProcedure, number>> = {
+  "notifications.getMany": 10,
+};
+
+/**
+ * Clamp an over-large page request. The response still carries `totalCount` and
+ * `hasNextPage`, so the model can see that more rows exist and page for them.
+ *
+ * Exported for tests.
+ */
+export function capPageSize(
+  procedure: PlatformProcedure,
+  input: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const cap = PAGE_SIZE_CAPS[procedure];
+  if (cap === undefined) return input;
+  const requested = input?.pageSize;
+  if (typeof requested !== "number" || requested <= cap) return input;
+  return { ...input, pageSize: cap };
 }
 
 /**
@@ -178,8 +286,8 @@ export function makeQueryPlatformDataTool(userId: string) {
         if (typeof fn !== "function") {
           return `Unknown procedure: ${procedure}`;
         }
-        const result = await fn(input ?? {});
-        return JSON.stringify(addNavigationLinks(result), null, 2);
+        const result = await fn(capPageSize(procedure, input) ?? {});
+        return JSON.stringify(addNavigationLinks(result));
       } catch (error) {
         const message =
           error instanceof TRPCError
@@ -190,7 +298,7 @@ export function makeQueryPlatformDataTool(userId: string) {
     },
     {
       name: "query_platform_data",
-      description: `Read-only lookup of Viper platform data (assets, vulnerabilities, remediations, device groups, clinical workflows) on demand. Never invent data (ids, CVSS scores, versions, hostnames); if you need a value, look it up here. Returned objects may carry a "_links" map of follow-up calls — call this tool again with a link's procedure and input to navigate (e.g. from an asset's device group to all its assets or vulnerabilities).
+      description: `Read-only lookup of Viper platform data (assets, vulnerabilities, remediations, device groups, clinical workflows, inbox notifications) on demand. Never invent data (ids, CVSS scores, versions, hostnames); if you need a value, look it up here. Returned objects may carry a "_links" map of follow-up calls — call this tool again with a link's procedure and input to navigate (e.g. from an asset's device group to all its assets or vulnerabilities).
 
 ${PLATFORM_CATALOG}`,
       schema: z.object({


### PR DESCRIPTION
Adding notification endpoints to `query_platform_data` which allows for us to `Ask VIPER` for the contents of our Inbox! This will also be leveraged later to build the daily VIPER debrief

<img width="1412" height="1262" alt="image" src="https://github.com/user-attachments/assets/67d299f2-3596-44df-9bfc-6c5115dfe80a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying clinical workflows and inbox notifications.
  * Added navigation links to notification details in query results.
  * Improved result matching and streamlined JSON responses.
  * Added safeguards to limit notification query page sizes.

* **Bug Fixes**
  * Preserved existing asset and device-group result transformations and links.
  * Improved consistency between available query options and platform capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->